### PR TITLE
Cache the previous filename's entry. (code coverage)

### DIFF
--- a/php_xdebug.h
+++ b/php_xdebug.h
@@ -32,6 +32,7 @@
 #include "xdebug_handlers.h"
 #include "xdebug_hash.h"
 #include "xdebug_llist.h"
+#include "xdebug_code_coverage.h"
 
 #if PHP_VERSION_ID >= 50399
 # define OUTPUTBUFFERING 0
@@ -207,6 +208,8 @@ ZEND_BEGIN_MODULE_GLOBALS(xdebug)
 	zend_bool     code_coverage_dead_code_analysis;
 	unsigned int  function_count;
 	int           reserved_offset;
+	char                 *previous_filename;
+	xdebug_coverage_file *previous_file;
 
 	/* used for collection errors */
 	zend_bool     do_collect_errors;

--- a/xdebug.c
+++ b/xdebug.c
@@ -313,6 +313,8 @@ static void php_xdebug_init_globals (zend_xdebug_globals *xg TSRMLS_DC)
 	xg->do_trace             = 0;
 	xg->trace_file           = NULL;
 	xg->coverage_enable      = 0;
+	xg->previous_filename    = "";
+	xg->previous_file        = NULL;
 	xg->do_code_coverage     = 0;
 	xg->breakpoint_count     = 0;
 	xg->ide_key              = NULL;

--- a/xdebug_code_coverage.c
+++ b/xdebug_code_coverage.c
@@ -272,10 +272,6 @@ XDEBUG_OPCODE_OVERRIDE_ASSIGN(assign_bw_xor,"^=",0)
 XDEBUG_OPCODE_OVERRIDE_ASSIGN(assign_dim,"=",1)
 XDEBUG_OPCODE_OVERRIDE_ASSIGN(assign_obj,"=",1)
 
-/* File hash entry cache; faster than doing a hash lookup most of the time */
-static char* previous_filename = "";
-static void* previous_file = NULL;
-
 void xdebug_count_line(char *filename, int lineno, int executable, int deadcode TSRMLS_DC)
 {
 	xdebug_coverage_file *file;
@@ -284,8 +280,8 @@ void xdebug_count_line(char *filename, int lineno, int executable, int deadcode 
 
 	sline = xdebug_sprintf("%d", lineno);
 
-	if (strcmp(previous_filename, filename) == 0) {
-		file = previous_file;
+	if (strcmp(XG(previous_filename), filename) == 0) {
+		file = XG(previous_file);
 	} else {
 		/* Check if the file already exists in the hash */
 		if (!xdebug_hash_find(XG(code_coverage), filename, strlen(filename), (void *) &file)) {
@@ -297,8 +293,8 @@ void xdebug_count_line(char *filename, int lineno, int executable, int deadcode 
 		
 			xdebug_hash_add(XG(code_coverage), filename, strlen(filename), file);
 		}
-		previous_filename = file->name;
-		previous_file = file;
+		XG(previous_filename) = file->name;
+		XG(previous_file) = file;
 	}
 
 	/* Check if the line already exists in the hash */
@@ -591,8 +587,8 @@ PHP_FUNCTION(xdebug_stop_code_coverage)
 	}
 	if (XG(do_code_coverage)) {
 		if (cleanup) {
-			previous_filename = "";
-			previous_file = NULL;
+			XG(previous_filename) = "";
+			XG(previous_file) = NULL;
 			xdebug_hash_destroy(XG(code_coverage));
 			XG(code_coverage) = xdebug_hash_alloc(32, xdebug_coverage_file_dtor);
 		}


### PR DESCRIPTION
Doing strcmp is a lot faster than hashing and going through the table. And don't forget to reset the cache entry when coverage is disabled!
