### PR TITLE
Use whatever CFLAGS PHP had (usually -O2).

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -5,10 +5,6 @@ PHP_ARG_ENABLE(xdebug, whether to enable eXtended debugging support,
 [  --enable-xdebug         Enable Xdebug support])
 
 if test "$PHP_XDEBUG" != "no"; then
-dnl We need to set optimization to 0 because my GCC otherwise optimizes too
-dnl much out.
-  CFLAGS=`echo $CFLAGS | sed 's/O2/O0/'`
-  
   AC_DEFINE(HAVE_XDEBUG,1,[ ])
 
 dnl Check for new current_execute_data field in zend_executor_globals


### PR DESCRIPTION
Derick said that this is probably no longer an issue. And it's a huge performance booster!

I ran tests on my mac (OSX 10.6.8, php-5.3.6, i686-apple-darwin10-gcc-4.2.1, XCode 3.2.6). One extra failed, but I don't suspect it's related.

Test for bug #538: Error in watches and call stack parameter with string containing '\\'. [tests/bug00538-2.phpt]

(tests/bug00538.phpt failed on both master and this branch)
