### PR TITLE
Coverage line array

### DIFF
--- a/xdebug_code_coverage.h
+++ b/xdebug_code_coverage.h
@@ -24,14 +24,15 @@
 #include "xdebug_mm.h"
 
 typedef struct xdebug_coverage_line {
-	int lineno;
-	int count;
-	int executable;
+	unsigned int hit:1;
+	unsigned int count:1;
+	unsigned int executable:2;
 } xdebug_coverage_line;
 
 typedef struct xdebug_coverage_file {
 	char        *name;
-	xdebug_hash *lines;
+	int          lines_slots;
+	xdebug_coverage_line *lines;
 } xdebug_coverage_file;
 
 /* Needed for code coverage as Zend doesn't always add EXT_STMT when expected */
@@ -41,7 +42,6 @@ typedef struct xdebug_coverage_file {
 	zend_set_user_opcode_handler(oc, xdebug_##f##_handler);
 
 
-void xdebug_coverage_line_dtor(void *data);
 void xdebug_coverage_file_dtor(void *data);
 
 int xdebug_common_override_handler(ZEND_OPCODE_HANDLER_ARGS);


### PR DESCRIPTION
So this is a rather more involved patch which may be starting to go a little "too far" in the name of performance. :) It supersedes use_lineno_index because it obliterates the coverage line hashes entirely.

Instead of storing the line coverage data in a hash, just store it in an array. The data members themselves easily fit into struct bitfields, so each line should only require one byte of storage. Given the overhead of the hash, LL structs, the old line structs, and malloc header overhead, I suspect that it's a memory saver on average, too; at least, assuming people don't write 100k lines of comment before 1 line of code at the end! Definitely easier on memory fragmentation.

I've run the numbers, and this patch squeezes an extra 4% improvement over just -O2 and cache_filename when running phpunit with HTML coverage enabled (relative to master at cd16e8de280f).

I updated the numbers in the spreadsheet from my initial email to include this newest result:
https://spreadsheets.google.com/spreadsheet/pub?hl=en_US&hl=en_US&key=0AlxHwOOM4sEudG12YUNJZGVKV25oVFA2Vy02TUZYMnc&output=html

Let me know what you think. :) Thanks!
