### PR TITLE
Fixes for var_export functions

### DIFF
--- a/xdebug_var.c
+++ b/xdebug_var.c
@@ -661,12 +661,12 @@ void xdebug_var_export_ansi(zval **struc, xdebug_str *str, int level, int debug_
 				xdebug_str_add(str, tmp_str, 0);
 			} else if (options->max_data == 0 || Z_STRLEN_PP(struc) <= options->max_data) {
 				xdebug_str_add(str, xdebug_sprintf("%sstring%s(%s%ld%s) '%s%s%s'", ANSI_COLOR_BOLD, ANSI_COLOR_BOLD_OFF, 
-				               ANSI_COLOR_LONG, Z_STRLEN_PP(struc), ANSI_COLOR_RESET,
-				               ANSI_COLOR_STRING, tmp_str, ANSI_COLOR_RESET), 1);
+							ANSI_COLOR_LONG, Z_STRLEN_PP(struc), ANSI_COLOR_RESET,
+							ANSI_COLOR_STRING, tmp_str, ANSI_COLOR_RESET), 1);
 			} else {
-				xdebug_str_addl(str, xdebug_sprintf("%sstring%s(%s%ld%s) '%s%s%s", ANSI_COLOR_BOLD, ANSI_COLOR_BOLD_OFF, 
-				                ANSI_COLOR_LONG, Z_STRLEN_PP(struc), ANSI_COLOR_RESET,
-				                ANSI_COLOR_STRING, tmp_str, ANSI_COLOR_RESET), options->max_data, 1);
+				xdebug_str_add(str, xdebug_sprintf("%sstring%s(%s%ld%s) '%s", ANSI_COLOR_BOLD, ANSI_COLOR_BOLD_OFF, 
+							ANSI_COLOR_LONG, Z_STRLEN_PP(struc), ANSI_COLOR_RESET, ANSI_COLOR_STRING), 1);
+				xdebug_str_addl(str, tmp_str, options->max_data, 0);
 				xdebug_str_add(str, xdebug_sprintf("...%s'", ANSI_COLOR_RESET), 1);
 			}
 			efree(tmp_str);


### PR DESCRIPTION
Hi,
These two commits should fix both #735 and #733. Not looked into #734 yet - I think in that case it just uses PHP's own var_dump functions?
