### PR TITLE
Profile output dir configurable

### DIFF
--- a/usefulstuff.c
+++ b/usefulstuff.c
@@ -688,3 +688,31 @@ void xdebug_close_log(TSRMLS_D)
 		XG(remote_log_file) = NULL;
 	}
 }
+
+
+int xdebug_recursive_mkdir( const char *path )
+{
+	if ( ( access( path , F_OK ) == 0 ) )
+		return 0;
+
+	char *copy, *p;
+	p = copy = strdup(path);
+	mode_t mode = S_IRWXU|S_IRWXG|S_IROTH|S_IXOTH;
+
+	do {
+		p = strchr (p + 1, '/');
+		if (p)
+			*p = '\0';
+		if (access (copy, F_OK) == -1) {
+			if ( mkdir ( copy, mode ) == -1) {
+					return -1;
+			}
+		}
+
+		if (p)
+			*p = '/';
+	} while (p);
+
+	return 0;
+}
+

--- a/xdebug_profiler.c
+++ b/xdebug_profiler.c
@@ -58,7 +58,7 @@ void xdebug_profile_call_entry_dtor(void *dummy, void *elem)
 
 int xdebug_profiler_init(char *script_name TSRMLS_DC)
 {
-	char *filename = NULL, *fname = NULL;
+	char *filename = NULL, *fname = NULL, *profileDir = NULL;
 	
 	if (!strlen(XG(profiler_output_name)) ||
 		xdebug_format_output_filename(&fname, XG(profiler_output_name), script_name) <= 0
@@ -73,9 +73,11 @@ int xdebug_profiler_init(char *script_name TSRMLS_DC)
 		/* Invalid or empty xdebug.profiler_output_dir */
 		return FAILURE;
 	}
-	
+	//create all path
+	xdebug_recursive_mkdir( profileDir );
 	filename = xdebug_sprintf("%s/%s", profileDir , fname);
 	xdfree(fname);
+	xdfree(profileDir);
 		
 	if (XG(profiler_append)) {
 		XG(profile_file) = xdebug_fopen(filename, "a", NULL, &XG(profile_filename));


### PR DESCRIPTION
Hi,

I added posibility to configure "profiler_output_dir". During preparing, I utilized "xdebug_format_output_filename" function, so in directory configuration can be used same specifiers as there. I also added "xdebug_recursive_mkdir" function that create full path if not exists.

I tested that solution on lastest ubuntu, it need to be tested on Windows.

I will try to prepare unit test but I'm not expert in that.

If you aproved this solution it can be apllied to other dir configuration.
