### PR TITLE
Fix for #747

### DIFF
--- a/xdebug.c
+++ b/xdebug.c
@@ -1359,7 +1359,7 @@ static int check_soap_call(function_stack_entry *fse)
 	if (fse->function.class && 
 		(
 			(strstr(fse->function.class, "SoapClient") != NULL) ||
-			(strstr(fse->function.class, "SoapClient") != NULL)
+			(strstr(fse->function.class, "SoapServer") != NULL)
 		) &&
 		(zend_hash_find(&module_registry, "soap", 5, (void**) &tmp_mod_entry) == SUCCESS)
 	) {


### PR DESCRIPTION
Due to a copy/paste bug, the fix for #609 only fixes the error overloading for SoapClient. This commit fixes the error for SoapServer too.
