### PR TITLE
Fixed: Implicit declarations of some functions.

### DIFF
--- a/usefulstuff.h
+++ b/usefulstuff.h
@@ -61,6 +61,8 @@ char *xdebug_path_to_url(const char *fileurl TSRMLS_DC);
 char *xdebug_path_from_url(const char *fileurl TSRMLS_DC);
 FILE *xdebug_fopen(char *fname, char *mode, char *extension, char **new_fname);
 int xdebug_format_output_filename(char **filename, char *format, char *script_name);
+void xdebug_open_log(TSRMLS_D);
+void xdebug_close_log(TSRMLS_D);
 
 #define XDEBUG_CRC32(crc, ch)	 (crc = (crc >> 8) ^ xdebug_crc32tab[(crc ^ (ch)) & 0xff])
 

--- a/xdebug_var.h
+++ b/xdebug_var.h
@@ -65,6 +65,7 @@ char* xdebug_get_zval_value_xml(char *name, zval *val);
 char* xdebug_get_zval_value_fancy(char *name, zval *val, int *len, int debug_zval, xdebug_var_export_options *options TSRMLS_DC);
 
 int xdebug_attach_static_vars(xdebug_xml_node *node, xdebug_var_export_options *options, zend_class_entry *ce TSRMLS_DC);
+void xdebug_attach_uninitialized_var(xdebug_xml_node *node, char *name);
 void xdebug_attach_static_var_with_contents(zval **zv XDEBUG_ZEND_HASH_APPLY_TSRMLS_DC, int num_args, va_list args, zend_hash_key *hash_key);
 xdebug_xml_node* xdebug_get_zval_value_xml_node(char *name, zval *val, xdebug_var_export_options *options);
 #define xdebug_get_zval_value_xml_node(name, val, options) xdebug_get_zval_value_xml_node_ex(name, val, XDEBUG_VAR_TYPE_NORMAL, options)


### PR DESCRIPTION
Avoid warnings like: "implicit declaration of function '...'"

Those are reported by GCC with: _-Wall_
