### PR TITLE
xdebug_env_config() now requires TSRMLS_FETCH

### DIFF
--- a/xdebug.c
+++ b/xdebug.c
@@ -357,13 +357,15 @@ void xdebug_env_key()
 
 void xdebug_env_config()
 {
-	char       *config = getenv("XDEBUG_CONFIG");
+	char       *config = NULL;
 	xdebug_arg *parts;
 	int			i;
+	TSRMLS_FETCH();
 	/*
 		XDEBUG_CONFIG format:
 		XDEBUG_CONFIG=var=val var=val
 	*/
+	config = getenv("XDEBUG_CONFIG");
 	xdebug_env_key();
 	if (!config) {
 		return;


### PR DESCRIPTION
this is due to change 02b828f (bug 662), which introduced XG macro to xdebug_env_config(): c.f. http://bugs.xdebug.org/view.php?id=662
