### PR TITLE
Fixed warnings when compiling with -Wall against PHP 5.4

### DIFF
--- a/usefulstuff.c
+++ b/usefulstuff.c
@@ -542,8 +542,9 @@ int xdebug_format_output_filename(char **filename, char *format, char *script_na
 			switch (*format)
 			{
 				case 'c': /* crc32 of the current working directory */
-					VCWD_GETCWD(cwd, 127);
-					xdebug_str_add(&fname, xdebug_sprintf("%lu", xdebug_crc32(cwd, strlen(cwd))), 1);
+					if (VCWD_GETCWD(cwd, 127)) {
+						xdebug_str_add(&fname, xdebug_sprintf("%lu", xdebug_crc32(cwd, strlen(cwd))), 1);
+					}
 					break;
 
 				case 'p': /* pid */
@@ -601,7 +602,7 @@ int xdebug_format_output_filename(char **filename, char *format, char *script_na
 				case 'R': { /* $_SERVER['REQUEST_URI'] */
 					zval **data;
 					char *char_ptr, *strval;
-					int retval;
+					int retval = FAILURE;
 
 					if (PG(http_globals)[TRACK_VARS_SERVER]) {
 						switch (*format) {

--- a/xdebug_code_coverage.c
+++ b/xdebug_code_coverage.c
@@ -61,7 +61,7 @@ int xdebug_common_override_handler(ZEND_OPCODE_HANDLER_ARGS)
 		cur_opcode = *EG(opline_ptr);
 		lineno = cur_opcode->lineno;
 
-		file = op_array->filename;
+		file = (char *)op_array->filename;
 
 		xdebug_count_line(file, lineno, 0, 0 TSRMLS_CC);
 	}
@@ -221,7 +221,7 @@ static int xdebug_common_assign_dim_handler(char *op, int do_cc, ZEND_OPCODE_HAN
 
 	cur_opcode = *EG(opline_ptr);
 	next_opcode = cur_opcode + 1;
-	file = op_array->filename;
+	file = (char *) op_array->filename;
 	lineno = cur_opcode->lineno;
 
 	if (do_cc && XG(do_code_coverage)) {
@@ -550,7 +550,7 @@ static int prefill_from_function_table(zend_op_array *opa XDEBUG_ZEND_HASH_APPLY
 	new_filename = va_arg(args, char*);
 	if (opa->type == ZEND_USER_FUNCTION) {
 		if (opa->reserved[XG(reserved_offset)] != (void*) 1 /* && opa->filename && strcmp(opa->filename, new_filename) == 0)*/) {
-			prefill_from_oparray(opa->filename, opa TSRMLS_CC);
+			prefill_from_oparray((char *) opa->filename, opa TSRMLS_CC);
 		}
 	}
 
@@ -578,7 +578,7 @@ static int prefill_from_class_table(zend_class_entry **class_entry XDEBUG_ZEND_H
 void xdebug_prefill_code_coverage(zend_op_array *op_array TSRMLS_DC)
 {
 	if (op_array->reserved[XG(reserved_offset)] != (void*) 1) {
-		prefill_from_oparray(op_array->filename, op_array TSRMLS_CC);
+		prefill_from_oparray((char *) op_array->filename, op_array TSRMLS_CC);
 	}
 
 	zend_hash_apply_with_arguments(CG(function_table)  XDEBUG_ZEND_HASH_APPLY_TSRMLS_CC, (apply_func_args_t) prefill_from_function_table, 1, op_array->filename);

--- a/xdebug_handler_dbgp.c
+++ b/xdebug_handler_dbgp.c
@@ -302,7 +302,7 @@ inline static char *fetch_classname_from_zval(zval *z, int *length, zend_class_e
 
 	tmp_ce = zend_get_class_entry(z TSRMLS_CC);
 	if (Z_OBJ_HT_P(z)->get_class_name == NULL ||
-		Z_OBJ_HT_P(z)->get_class_name(z, &name, &name_len, 0 TSRMLS_CC) != SUCCESS) {
+		Z_OBJ_HT_P(z)->get_class_name(z, (const char **) &name, &name_len, 0 TSRMLS_CC) != SUCCESS) {
 
 		if (!tmp_ce) {
 			return NULL;
@@ -833,7 +833,7 @@ static xdebug_xml_node* return_stackframe(int nr TSRMLS_DC)
 		}
 		xdebug_xml_add_attribute_ex(tmp, "lineno",   xdebug_sprintf("%lu", fse_prev->lineno TSRMLS_CC), 0, 1);
 	} else {
-		tmp_filename = zend_get_executed_filename(TSRMLS_C);
+		tmp_filename = (char *) zend_get_executed_filename(TSRMLS_C);
 		tmp_lineno = zend_get_executed_lineno(TSRMLS_C);
 		if (check_evaled_code(fse, &tmp_filename, &tmp_lineno, 0 TSRMLS_CC)) {
 			xdebug_xml_add_attribute_ex(tmp, "type", xdstrdup("eval"), 0, 1);

--- a/xdebug_stack.c
+++ b/xdebug_stack.c
@@ -273,7 +273,7 @@ void xdebug_append_error_description(xdebug_str *str, int html, const char *erro
 #endif
 
 	if (html) {
-		escaped = php_escape_html_entities(buffer, strlen(buffer), &newlen, 0, 0, NULL TSRMLS_CC);
+		escaped = php_escape_html_entities((unsigned char *) buffer, strlen(buffer), &newlen, 0, 0, NULL TSRMLS_CC);
 	} else {
 		escaped = estrdup(buffer);
 	}
@@ -661,7 +661,7 @@ void xdebug_error_cb(int type, const char *error_filename, const uint error_line
 	if (XG(remote_enabled) && XG(breakpoints_allowed)) {
 		if (xdebug_hash_find(XG(context).exception_breakpoints, error_type_str, strlen(error_type_str), (void *) &extra_brk_info)) {
 			if (xdebug_handle_hit_value(extra_brk_info)) {
-				if (!XG(context).handler->remote_breakpoint(&(XG(context)), XG(stack), error_filename, error_lineno, XDEBUG_BREAK, error_type_str, buffer)) {
+				if (!XG(context).handler->remote_breakpoint(&(XG(context)), XG(stack), (char *) error_filename, error_lineno, XDEBUG_BREAK, error_type_str, buffer)) {
 					XG(remote_enabled) = 0;
 				}
 			}
@@ -927,8 +927,8 @@ function_stack_entry *xdebug_add_stack_frame(zend_execute_data *zdata, zend_op_a
 	zend_op              *cur_opcode;
 	zval                **param;
 	int                   i = 0;
-	char                 *aggr_key;
-	int                   aggr_key_len;
+	char                 *aggr_key = NULL;
+	int                   aggr_key_len = 0;
 
 	tmp = xdmalloc (sizeof (function_stack_entry));
 	tmp->var           = NULL;

--- a/xdebug_superglobals.c
+++ b/xdebug_superglobals.c
@@ -97,7 +97,7 @@ static int dump_hash_elem_va(void *pDest XDEBUG_ZEND_HASH_APPLY_TSRMLS_DC, int n
 	if (hash_key->nKeyLength == 0) {
 		dump_hash_elem(*((zval **) pDest), name, hash_key->h, NULL, html, str TSRMLS_CC);
 	} else {
-		dump_hash_elem(*((zval **) pDest), name, 0, hash_key->arKey, html, str TSRMLS_CC);
+		dump_hash_elem(*((zval **) pDest), name, 0, (char *) hash_key->arKey, html, str TSRMLS_CC);
 	}
 
 	return SUCCESS;

--- a/xdebug_var.h
+++ b/xdebug_var.h
@@ -72,7 +72,7 @@ char* xdebug_get_zval_value_text_ansi(zval *val, int mode, int debug_zval, xdebu
 char* xdebug_get_zval_value_xml(char *name, zval *val);
 char* xdebug_get_zval_value_fancy(char *name, zval *val, int *len, int debug_zval, xdebug_var_export_options *options TSRMLS_DC);
 
-int xdebug_attach_static_vars(xdebug_xml_node *node, xdebug_var_export_options *options, zend_class_entry *ce TSRMLS_DC);
+void xdebug_attach_static_vars(xdebug_xml_node *node, xdebug_var_export_options *options, zend_class_entry *ce TSRMLS_DC);
 void xdebug_attach_uninitialized_var(xdebug_xml_node *node, char *name);
 void xdebug_attach_static_var_with_contents(zval **zv XDEBUG_ZEND_HASH_APPLY_TSRMLS_DC, int num_args, va_list args, zend_hash_key *hash_key);
 #define xdebug_get_zval_value_xml_node(name, val, options) xdebug_get_zval_value_xml_node_ex(name, val, XDEBUG_VAR_TYPE_NORMAL, options)


### PR DESCRIPTION
GCC errors before patch:
https://gist.github.com/fb815dce0bfa8c07efa9

after patch:
https://gist.github.com/401d2f1b5eb16c55c1ff
