### PR TITLE
Added compatibility with other extensions modifying zend_error_cb

### DIFF
--- a/php_xdebug.h
+++ b/php_xdebug.h
@@ -90,6 +90,8 @@ ZEND_MODULE_POST_ZEND_DEACTIVATE_D(xdebug);
 int xdebug_is_output_tty();
 #endif
 
+extern ZEND_API void (*xdebug_external_error_cb)(int type, const char *error_filename, const uint error_lineno, const char *format, va_list args) ZEND_ATTRIBUTE_PTR_FORMAT(printf, 4, 0);
+
 /* call stack functions */
 PHP_FUNCTION(xdebug_get_stack_depth);
 PHP_FUNCTION(xdebug_get_function_stack);

--- a/xdebug_stack.c
+++ b/xdebug_stack.c
@@ -544,10 +544,13 @@ void xdebug_error_cb(int type, const char *error_filename, const uint error_line
 	xdebug_brk_info *extra_brk_info = NULL;
 	error_handling_t  error_handling;
 	zend_class_entry *exception_class;
+	va_list args_copy;
 
 	TSRMLS_FETCH();
 
+	va_copy(args_copy, args);
 	buffer_len = vspprintf(&buffer, PG(log_errors_max_len), format, args);
+	va_end(args_copy);
 
 	error_type_str = xdebug_error_type(type);
 
@@ -748,6 +751,10 @@ void xdebug_error_cb(int type, const char *error_filename, const uint error_line
 	}
 
 	efree(buffer);
+
+	if (xdebug_external_error_cb) {
+		xdebug_external_error_cb(type, error_filename, error_lineno, format, args_copy);
+	}
 }
 
 /* {{{ proto array xdebug_print_function_stack([string message])


### PR DESCRIPTION
Since Xdebug doesn't call the previously defined error callback but replaces it, find a way to make it coexist with other extensions that replaces the error callback at RINIT, like APM.
