### PR TITLE
print error to STDERR only if sapi is cli or cgi

### DIFF
--- a/xdebug_stack.c
+++ b/xdebug_stack.c
@@ -527,7 +527,9 @@ void xdebug_do_jit(TSRMLS_D)
 static void php_output_error(const char *error TSRMLS_DC)
 {
 #ifdef PHP_DISPLAY_ERRORS_STDERR
-	if (PG(display_errors) == PHP_DISPLAY_ERRORS_STDERR) {
+	if ((!strcmp(sapi_module.name, "cli") || !strcmp(sapi_module.name, "cgi")) &&
+		PG(display_errors) == PHP_DISPLAY_ERRORS_STDERR
+	) {
 		fputs(error, stderr);
 		fflush(stderr);
 		return;


### PR DESCRIPTION
remake a pull request against the xdebug_2_2 branch.

---

Hi.

PHP is error output to STDERR only if sapi is cli or cgi.

But, xdebug do output to STDERR, independent of sapi, if display_errors is stderr.

As with PHP should check sapi.

[PHP main.c php_error_cb()](https://github.com/php/php-src/blob/master/main/main.c#L1078)
