### PR TITLE
Test for issue 625 should fail prior to 622fbf8

### DIFF
--- a/tests/bug00625.phpt
+++ b/tests/bug00625.phpt
@@ -4,12 +4,16 @@ Test for bug #625: xdebug_get_headers() resets header list
 xdebug.default_enable=1
 --FILE--
 <?php
-header( 'Location: bar');
-header( 'HTTP/1.0 404 Not Found' );
+header('Content-type: text/plain');
+var_dump( xdebug_get_headers( ) );
 var_dump( xdebug_get_headers( ) );
 ?>
 --EXPECTF--
 array(1) {
   [0] =>
-  string(13) "Location: bar"
+  string(24) "Content-type: text/plain"
+}
+array(1) {
+  [0] =>
+  string(24) "Content-type: text/plain"
 }


### PR DESCRIPTION
I provided the original patch for issue 625 (http://bugs.xdebug.org/print_bug_page.php?bug_id=625) some years ago. The bug is related to headers being reset on subsequent calls to `xdebug_get_headers()`. The test should set a header and call `xdebug_get_headers()` multiple times to ensure headers are not reset.
