### PR TITLE
Log a php error when cannot open remote_log

### DIFF
--- a/usefulstuff.c
+++ b/usefulstuff.c
@@ -680,6 +680,8 @@ void xdebug_open_log(TSRMLS_D)
 		fprintf(XG(remote_log_file), "Log opened at %s\n", timestr);
 		fflush(XG(remote_log_file));
 		xdfree(timestr);
+	} else {
+		php_log_err(xdebug_sprintf("PHP: XDebug could not open log file at %s", XG(remote_log)) TSRMLS_CC);
 	}
 }
 


### PR DESCRIPTION
log a php error if xdebug can't write to the log file.
