### PR TITLE
tell the pear installer that xdebug is a zend ext

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -194,7 +194,7 @@ Tue, May 08, 2012 - xdebug 2.2.0
   </required>
  </dependencies>
  <providesextension>xdebug</providesextension>
- <extsrcrelease />
+ <zendextsrcrelease />
  <changelog>
   <release>
    <version>


### PR DESCRIPTION
this will cause the pear installer to suggest
You should add 'zend_extension=xdebug.so" to php.ini
instead of the current
You should add 'extension=xdebug.so" to php.ini
