### PR TITLE
xdebug is a zend extension

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -147,7 +147,7 @@ Xdebug also provides:
   </required>
  </dependencies>
  <providesextension>xdebug</providesextension>
- <extsrcrelease />
+ <zendextsrcrelease />
  <changelog>
   <release>
    <version>


### PR DESCRIPTION
this will cause the pear installer to suggest
You should add 'zend_extension=xdebug.so" to php.ini
instead of the current
You should add 'extension=xdebug.so" to php.ini
