### PR TITLE
Fixed bug #985: The current Git head does not compile anymore for Windows

### DIFF
--- a/php_xdebug.h
+++ b/php_xdebug.h
@@ -90,7 +90,7 @@ ZEND_MODULE_POST_ZEND_DEACTIVATE_D(xdebug);
 int xdebug_is_output_tty();
 #endif
 
-extern ZEND_API void (*xdebug_external_error_cb)(int type, const char *error_filename, const uint error_lineno, const char *format, va_list args) ZEND_ATTRIBUTE_PTR_FORMAT(printf, 4, 0);
+void (*xdebug_external_error_cb)(int type, const char *error_filename, const uint error_lineno, const char *format, va_list args);
 
 /* call stack functions */
 PHP_FUNCTION(xdebug_get_stack_depth);

--- a/xdebug.c
+++ b/xdebug.c
@@ -85,7 +85,6 @@ void xdebug_execute_internal(zend_execute_data *current_execute_data, struct _ze
 /* error callback replacement functions */
 void (*xdebug_old_error_cb)(int type, const char *error_filename, const uint error_lineno, const char *format, va_list args);
 void (*xdebug_new_error_cb)(int type, const char *error_filename, const uint error_lineno, const char *format, va_list args);
-ZEND_API void (*xdebug_external_error_cb)(int type, const char *error_filename, const uint error_lineno, const char *format, va_list args);
 void xdebug_error_cb(int type, const char *error_filename, const uint error_lineno, const char *format, va_list args);
 
 static int xdebug_header_handler(sapi_header_struct *h XG_SAPI_HEADER_OP_DC, sapi_headers_struct *s TSRMLS_DC);


### PR DESCRIPTION
Tentatively fixes: http://bugs.xdebug.org/view.php?id=985 (untested)
