### PR TITLE
fix endless recursive calls of xdebug_error_cb

### DIFF
--- a/xdebug.c
+++ b/xdebug.c
@@ -912,7 +912,7 @@ PHP_RINIT_FUNCTION(xdebug)
 	 * Xdebug's error handler to keep soap fault from fucking up. */
 	if (XG(default_enable) && zend_hash_find(Z_ARRVAL_P(PG(http_globals)[TRACK_VARS_SERVER]), "HTTP_SOAPACTION", 16, (void**)&dummy) == FAILURE) {
 		/* If zend_error_cb has been changed by another ext, register it as external cb */
-		if (zend_error_cb != xdebug_old_error_cb) {
+		if (zend_error_cb != xdebug_new_error_cb) {
 			xdebug_external_error_cb = zend_error_cb;
 		}
 		zend_error_cb = xdebug_new_error_cb;


### PR DESCRIPTION
Reproducible with SOAP ext and (not sure if that matters) PHP 5.5.
The first execution of this code used to set zend_error_cb to
xdebug_error_cb.
The second execution of it set also xdebug_external_error_cb to
xdebug_error_cb, which resulted in xdebug_error_cb calling itself
till PHP crashed.
