### PR TITLE
Implemented issue #998: Added support for IPv6

### DIFF
--- a/.travis.scripts/compile.sh
+++ b/.travis.scripts/compile.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-export CFLAGS="-Wall -Wextra -Wdeclaration-after-statement -Wmissing-field-initializers -Wshadow -Wno-unused-parameter -ggdb3"
+export CFLAGS="-Wall -Wextra -Wdeclaration-after-statement -Wmissing-field-initializers -Wshadow -Wno-unused-parameter -ggdb3 -DDEBUGGER_FAIL_SILENTLY"
 phpize
 ./configure
 make all install

--- a/config.m4
+++ b/config.m4
@@ -20,7 +20,6 @@ if test "$PHP_XDEBUG" != "no"; then
   CPPFLAGS="$INCLUDES $CPPFLAGS"
 
   AC_CHECK_FUNCS(gettimeofday)
-  AC_CHECK_HEADERS([sys/select.h])
 
   PHP_CHECK_LIBRARY(m, cos, [ PHP_ADD_LIBRARY(m,, XDEBUG_SHARED_LIBADD) ])
 

--- a/debugclient/.gitignore
+++ b/debugclient/.gitignore
@@ -23,3 +23,7 @@
 /Debug
 /Release
 /depcomp
+/debugclient.opensdf
+/debugclient.sdf
+/debugclient.v12.suo
+/debugclient.vcxproj.user

--- a/debugclient/debugclient.sln
+++ b/debugclient/debugclient.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2013
+VisualStudioVersion = 12.0.31101.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "debugclient", "debugclient.vcxproj", "{B14560EF-7CD9-49B4-AD67-7EC1962EFBD2}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Win32 = Debug|Win32
+		Release|Win32 = Release|Win32
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{B14560EF-7CD9-49B4-AD67-7EC1962EFBD2}.Debug|Win32.ActiveCfg = Debug|Win32
+		{B14560EF-7CD9-49B4-AD67-7EC1962EFBD2}.Debug|Win32.Build.0 = Debug|Win32
+		{B14560EF-7CD9-49B4-AD67-7EC1962EFBD2}.Release|Win32.ActiveCfg = Release|Win32
+		{B14560EF-7CD9-49B4-AD67-7EC1962EFBD2}.Release|Win32.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/debugclient/debugclient.vcxproj
+++ b/debugclient/debugclient.vcxproj
@@ -1,0 +1,134 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <SccProjectName />
+    <SccLocalPath />
+    <ProjectGuid>{B14560EF-7CD9-49B4-AD67-7EC1962EFBD2}</ProjectGuid>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v120</PlatformToolset>
+    <UseOfMfc>false</UseOfMfc>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v120</PlatformToolset>
+    <UseOfMfc>false</UseOfMfc>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(VCTargetsPath)Microsoft.Cpp.UpgradeFromVC60.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(VCTargetsPath)Microsoft.Cpp.UpgradeFromVC60.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <OutDir>.\Debug\</OutDir>
+    <IntDir>.\Debug\</IntDir>
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <OutDir>.\Release\</OutDir>
+    <IntDir>.\Release\</IntDir>
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <InlineFunctionExpansion>Default</InlineFunctionExpansion>
+      <FunctionLevelLinking>false</FunctionLevelLinking>
+      <Optimization>Disabled</Optimization>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <WarningLevel>Level3</WarningLevel>
+      <MinimalRebuild>true</MinimalRebuild>
+      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AssemblerListingLocation>.\Debug\</AssemblerListingLocation>
+      <PrecompiledHeaderOutputFile>.\Debug\debugclient.pch</PrecompiledHeaderOutputFile>
+      <ObjectFileName>.\Debug\</ObjectFileName>
+      <ProgramDataBaseFileName>.\Debug\</ProgramDataBaseFileName>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+    </ClCompile>
+    <Midl>
+      <TypeLibraryName>.\Debug\debugclient.tlb</TypeLibraryName>
+    </Midl>
+    <ResourceCompile>
+      <Culture>0x0409</Culture>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ResourceCompile>
+    <Bscmake>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <OutputFile>.\Debug\debugclient.bsc</OutputFile>
+    </Bscmake>
+    <Link>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+      <OutputFile>.\Debug\debugclient.exe</OutputFile>
+      <AdditionalDependencies>odbc32.lib;odbccp32.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <InlineFunctionExpansion>Default</InlineFunctionExpansion>
+      <StringPooling>true</StringPooling>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <Optimization>MaxSpeed</Optimization>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <WarningLevel>Level3</WarningLevel>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AssemblerListingLocation>.\Release\</AssemblerListingLocation>
+      <PrecompiledHeaderOutputFile>.\Release\debugclient.pch</PrecompiledHeaderOutputFile>
+      <ObjectFileName>.\Release\</ObjectFileName>
+      <ProgramDataBaseFileName>.\Release\</ProgramDataBaseFileName>
+    </ClCompile>
+    <Midl>
+      <TypeLibraryName>.\Release\debugclient.tlb</TypeLibraryName>
+    </Midl>
+    <ResourceCompile>
+      <Culture>0x0409</Culture>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ResourceCompile>
+    <Bscmake>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <OutputFile>.\Release\debugclient.bsc</OutputFile>
+    </Bscmake>
+    <Link>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <SubSystem>Console</SubSystem>
+      <OutputFile>.\Release\debugclient.exe</OutputFile>
+      <AdditionalDependencies>odbc32.lib;odbccp32.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="getopt.c" />
+    <ClCompile Include="main.c" />
+    <ClCompile Include="usefulstuff.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="getopt.h" />
+    <ClInclude Include="usefulstuff.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/debugclient/debugclient.vcxproj.filters
+++ b/debugclient/debugclient.vcxproj.filters
@@ -1,0 +1,32 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{af32d68d-0885-4c92-9023-b92d7d8b494e}</UniqueIdentifier>
+      <Extensions>cpp;c;cxx;rc;def;r;odl;idl;hpj;bat</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{d61cd144-2fbc-42a7-8fb6-56ba2d1e2f45}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="main.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="usefulstuff.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="getopt.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="usefulstuff.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="getopt.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/debugclient/getopt.c
+++ b/debugclient/getopt.c
@@ -1,0 +1,250 @@
+/*****************************************************************************
+* getopt.c - competent and free getopt library.
+* $Header: /cvsroot/freegetopt/freegetopt/getopt.c,v 1.2 2003/10/26 03:10:20 vindaci Exp $
+*
+* Copyright (c)2002-2003 Mark K. Kim
+* All rights reserved.
+* 
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*
+*   * Redistributions in binary form must reproduce the above copyright
+*     notice, this list of conditions and the following disclaimer in
+*     the documentation and/or other materials provided with the
+*     distribution.
+*
+*   * Neither the original author of this software nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+* FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+* COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+* BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+* OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+* AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+* THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+* DAMAGE.
+*/
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "getopt.h"
+
+
+static const char* ID = "$Id: getopt.c,v 1.2 2003/10/26 03:10:20 vindaci Exp $";
+
+
+char* optarg = NULL;
+int optind = 0;
+int opterr = 1;
+int optopt = '?';
+
+
+static char** prev_argv = NULL;        /* Keep a copy of argv and argc to */
+static int prev_argc = 0;              /*    tell if getopt params change */
+static int argv_index = 0;             /* Option we're checking */
+static int argv_index2 = 0;            /* Option argument we're checking */
+static int opt_offset = 0;             /* Index into compounded "-option" */
+static int dashdash = 0;               /* True if "--" option reached */
+static int nonopt = 0;                 /* How many nonopts we've found */
+
+static void increment_index()
+{
+	/* Move onto the next option */
+	if(argv_index < argv_index2)
+	{
+		while(prev_argv[++argv_index] && prev_argv[argv_index][0] != '-'
+				&& argv_index < argv_index2+1);
+	}
+	else argv_index++;
+	opt_offset = 1;
+}
+
+
+/*
+* Permutes argv[] so that the argument currently being processed is moved
+* to the end.
+*/
+static int permute_argv_once()
+{
+	/* Movability check */
+	if(argv_index + nonopt >= prev_argc) return 1;
+	/* Move the current option to the end, bring the others to front */
+	else
+	{
+		char* tmp = prev_argv[argv_index];
+
+		/* Move the data */
+		memmove(&prev_argv[argv_index], &prev_argv[argv_index+1],
+				sizeof(char**) * (prev_argc - argv_index - 1));
+		prev_argv[prev_argc - 1] = tmp;
+
+		nonopt++;
+		return 0;
+	}
+}
+
+
+int getopt(int argc, char** argv, char* optstr)
+{
+	int c = 0;
+
+	/* If we have new argv, reinitialize */
+	if(prev_argv != argv || prev_argc != argc)
+	{
+		/* Initialize variables */
+		prev_argv = argv;
+		prev_argc = argc;
+		argv_index = 1;
+		argv_index2 = 1;
+		opt_offset = 1;
+		dashdash = 0;
+		nonopt = 0;
+	}
+
+	/* Jump point in case we want to ignore the current argv_index */
+	getopt_top:
+
+	/* Misc. initializations */
+	optarg = NULL;
+
+	/* Dash-dash check */
+	if(argv[argv_index] && !strcmp(argv[argv_index], "--"))
+	{
+		dashdash = 1;
+		increment_index();
+	}
+
+	/* If we're at the end of argv, that's it. */
+	if(argv[argv_index] == NULL)
+	{
+		c = -1;
+	}
+	/* Are we looking at a string? Single dash is also a string */
+	else if(dashdash || argv[argv_index][0] != '-' || !strcmp(argv[argv_index], "-"))
+	{
+		/* If we want a string... */
+		if(optstr[0] == '-')
+		{
+			c = 1;
+			optarg = argv[argv_index];
+			increment_index();
+		}
+		/* If we really don't want it (we're in POSIX mode), we're done */
+		else if(optstr[0] == '+' || getenv("POSIXLY_CORRECT"))
+		{
+			c = -1;
+
+			/* Everything else is a non-opt argument */
+			nonopt = argc - argv_index;
+		}
+		/* If we mildly don't want it, then move it back */
+		else
+		{
+			if(!permute_argv_once()) goto getopt_top;
+			else c = -1;
+		}
+	}
+	/* Otherwise we're looking at an option */
+	else
+	{
+		char* opt_ptr = NULL;
+
+		/* Grab the option */
+		c = argv[argv_index][opt_offset++];
+
+		/* Is the option in the optstr? */
+		if(optstr[0] == '-') opt_ptr = strchr(optstr+1, c);
+		else opt_ptr = strchr(optstr, c);
+		/* Invalid argument */
+		if(!opt_ptr)
+		{
+			if(opterr)
+			{
+				fprintf(stderr, "%s: invalid option -- %c\n", argv[0], c);
+			}
+
+			optopt = c;
+			c = '?';
+
+			/* Move onto the next option */
+			increment_index();
+		}
+		/* Option takes argument */
+		else if(opt_ptr[1] == ':')
+		{
+			/* ie, -oARGUMENT, -xxxoARGUMENT, etc. */
+			if(argv[argv_index][opt_offset] != '\0')
+			{
+				optarg = &argv[argv_index][opt_offset];
+				increment_index();
+			}
+			/* ie, -o ARGUMENT (only if it's a required argument) */
+			else if(opt_ptr[2] != ':')
+			{
+				/* One of those "you're not expected to understand this" moment */
+				if(argv_index2 < argv_index) argv_index2 = argv_index;
+				while(argv[++argv_index2] && argv[argv_index2][0] == '-');
+				optarg = argv[argv_index2];
+
+				/* Don't cross into the non-option argument list */
+				if(argv_index2 + nonopt >= prev_argc) optarg = NULL;
+
+				/* Move onto the next option */
+				increment_index();
+			}
+			else
+			{
+				/* Move onto the next option */
+				increment_index();
+			}
+
+			/* In case we got no argument for an option with required argument */
+			if(optarg == NULL && opt_ptr[2] != ':')
+			{
+				optopt = c;
+				c = '?';
+
+				if(opterr)
+				{
+					fprintf(stderr,"%s: option requires an argument -- %c\n",
+							argv[0], optopt);
+				}
+			}
+		}
+		/* Option does not take argument */
+		else
+		{
+			/* Next argv_index */
+			if(argv[argv_index][opt_offset] == '\0')
+			{
+				increment_index();
+			}
+		}
+	}
+
+	/* Calculate optind */
+	if(c == -1)
+	{
+		optind = argc - nonopt;
+	}
+	else
+	{
+		optind = argv_index;
+	}
+
+	return c;
+}
+
+
+/* vim:ts=3
+*/

--- a/debugclient/getopt.h
+++ b/debugclient/getopt.h
@@ -1,0 +1,63 @@
+/*****************************************************************************
+* getopt.h - competent and free getopt library.
+* $Header: /cvsroot/freegetopt/freegetopt/getopt.h,v 1.2 2003/10/26 03:10:20 vindaci Exp $
+*
+* Copyright (c)2002-2003 Mark K. Kim
+* All rights reserved.
+* 
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*
+*   * Redistributions in binary form must reproduce the above copyright
+*     notice, this list of conditions and the following disclaimer in
+*     the documentation and/or other materials provided with the
+*     distribution.
+*
+*   * Neither the original author of this software nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+* FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+* COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+* BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+* OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+* AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+* THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+* DAMAGE.
+*/
+#ifndef GETOPT_H_
+#define GETOPT_H_
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+extern char* optarg;
+extern int optind;
+extern int opterr;
+extern int optopt;
+
+int getopt(int argc, char** argv, char* optstr);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* GETOPT_H_ */
+
+
+/* vim:ts=3
+*/

--- a/debugclient/main.c
+++ b/debugclient/main.c
@@ -7,27 +7,32 @@
    | This source file is subject to version 1.0 of the Xdebug license,    |
    | that is bundled with this package in the file LICENSE, and is        |
    | available at through the world-wide-web at                           |
-   | http://xdebug.derickrethans.nl/license.php                           |
+   | https://xdebug.org/license.php                                       |
    | If you did not receive a copy of the Xdebug license and are unable   |
    | to obtain it through the world-wide-web, please send a note to       |
    | xdebug@derickrethans.nl so we can mail you a copy immediately.       |
    +----------------------------------------------------------------------+
    | Authors:  Derick Rethans <derick@xdebug.org>                         |
    |           Marco Canini <m.canini@libero.it>                          |
+   |           Thomas Vanhaniemi <thomas.vanhaniemi@arcada.fi>            |
    +----------------------------------------------------------------------+
  */
 
 #include <stdio.h>
 #include <sys/types.h>
 #ifndef WIN32
-#include "config.h"
+#ifdef HAVE_CONFIG_H 
+# include "config.h"
+#endif
 #include <unistd.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <netdb.h>
 #include <sys/un.h>
 #else
+#include "getopt.h"
 #include <winsock2.h>
+#include <Ws2ipdef.h>
 #define socklen_t int
 #endif
 #include <stdlib.h>
@@ -51,8 +56,12 @@
 #define MSG_NOSIGNAL 0
 #endif
 
-#define DEBUGCLIENT_VERSION "0.10.0"
+#define DEBUGCLIENT_VERSION "0.11.0"
 #define DEFAULT_PORT        9000
+
+#define IPV4                4
+#define IPV6                6
+#define DEFAULT_IP          IPV4
 
 #ifdef HAVE_LIBEDIT
 
@@ -123,22 +132,21 @@ void handle_sigterm(int i)
 
 int main(int argc, char *argv[])
 {
-	int                 port = DEFAULT_PORT; /* Port number to listen for connections */
-	int                 ssocket = 0;         /* Socket file descriptor */
-	int                 debug_once = 1;      /* Whether to allow more than one debug session (1 = no) */
-	struct sockaddr_in  server_in;
-	struct sockaddr_in  client_in;
-	socklen_t           client_in_len;
-	int                 fd;                  /* Filedescriptor for userinput */
-	fd_buf              cxt = { NULL, 0 };
-	struct in_addr     *iaddr;
-	char               *buffer;              /* Buffer with data from the server */
-	char               *cmd;                 /* Command to send to the server */
-	char               *prev_cmd = NULL;     /* Last send command to the server */
-	int                 length;              /* Length of read buffer */
-#ifndef WIN32
-	int                 opt;                 /* Current option during parameter parsing */
-#endif
+	int                      port = DEFAULT_PORT;    /* Port number to listen for connections */
+	int                      ssocket = 0;            /* Socket file descriptor */
+	int                      debug_once = 1;         /* Whether to allow more than one debug session (1 = no) */
+	struct sockaddr_storage  server_in;
+	socklen_t                server_in_len;
+	struct sockaddr_storage  client_in;
+	socklen_t                client_in_len;
+	int                      fd;                     /* Filedescriptor for userinput */
+	fd_buf                   cxt = { NULL, 0 };
+	char                    *buffer;                 /* Buffer with data from the server */
+	char                    *cmd;                    /* Command to send to the server */
+	char                    *prev_cmd = NULL;        /* Last send command to the server */
+	int                      length;                 /* Length of read buffer */
+	int                      ipversion = DEFAULT_IP; /* 1 = IPv4, 2 = IPv6 */
+	int                      opt;                    /* Current option during parameter parsing */
 
 #ifdef HAVE_LIBEDIT
 	int num = 0;
@@ -161,15 +169,14 @@ int main(int argc, char *argv[])
 
 	/* Display copyright notice and version number */
 	printf("Xdebug Simple DBGp client (%s)\n", DEBUGCLIENT_VERSION);
-	printf("Copyright 2002-2007 by Derick Rethans.\n");
+	printf("Copyright 2002-2016 by Derick Rethans.\n");
 #ifdef HAVE_LIBEDIT
 	printf("- libedit support: enabled\n");
 #endif
 
-#ifndef WIN32
 	/* Option handling */
 	while (1) {
-		opt = getopt(argc, argv, "hp:v1");
+		opt = getopt(argc, argv, "hp:v146");
 
 		if (opt == -1) {
 			break;
@@ -178,11 +185,14 @@ int main(int argc, char *argv[])
 		switch (opt) {
 			case 'h':
 				printf("\nUsage:\n");
-				printf("\tdebugclient [-h] [-p port] [-v]\n");
+				printf("\tdebugclient [-h] [-p port] [-v] [-1] [-4] [-6]\n");
 				printf("\t-h\tShow this help\n");
 				printf("\t-p\tSpecify the port to listen on (default = 9000)\n");
 				printf("\t-v\tShow version number and exit\n");
 				printf("\t-1\tDebug once and then exit\n");
+				printf("\t-4\tListen on IPv4 (default)\n");
+				printf("\t-6\tListen on IPv6\n");
+				printf("\n");
 				exit(0);
 				break;
 			case 'v':
@@ -190,35 +200,64 @@ int main(int argc, char *argv[])
 				break;
 			case 'p':
 				port = atoi(optarg);
-				printf("Listening on TCP port %d.\n", port);
 				break;
 			case '1':
 				debug_once = 0;
 				break;
+			case '4':
+				ipversion = IPV4;
+				break;
+			case '6':
+				ipversion = IPV6;
+				break;
 		}
 	}
-#endif
 
 	/* Main loop that listens for connections from the debug client and that
 	 * does all the communications handling. */
 	do {
-		ssocket = socket(AF_INET, SOCK_STREAM, 0);
+		memset(&server_in, 0, sizeof(server_in));
+		memset(&client_in, 0, sizeof(client_in));
+
+		if (ipversion == IPV4) {
+			printf("\nCreating a socket for IPv4.\n");
+			ssocket = socket(AF_INET, SOCK_STREAM, 0);
+
+			((struct sockaddr_in *)&server_in)->sin_family = AF_INET;
+			((struct sockaddr_in *)&server_in)->sin_addr.s_addr = htonl(INADDR_ANY);
+			((struct sockaddr_in *)&server_in)->sin_port = htons((unsigned short int) port);
+
+			server_in_len = sizeof(struct sockaddr_in);
+			client_in_len = sizeof(struct sockaddr_in);
+		} else {
+			printf("\nCreating a socket for IPv6.\n");
+			ssocket = socket(AF_INET6, SOCK_STREAM, 0);
+
+			((struct sockaddr_in6 *)&server_in)->sin6_family = AF_INET6;
+			((struct sockaddr_in6 *)&server_in)->sin6_addr = in6addr_any;
+			((struct sockaddr_in6 *)&server_in)->sin6_port = htons((unsigned short int) port);
+
+			server_in_len = sizeof(struct sockaddr_in6);
+			client_in_len = sizeof(struct sockaddr_in6);
+		}
+
 		if (ssocket < 0) {
 			fprintf(stderr, "socket: couldn't create socket\n");
 			exit(-1);
 		}
 
-		memset(&server_in, 0, sizeof(struct sockaddr));
-		server_in.sin_family      = AF_INET;
-		server_in.sin_addr.s_addr = htonl(INADDR_ANY);
-		server_in.sin_port        = htons((unsigned short int) port);
-
-		memset(&client_in, 0, sizeof(client_in));
-		client_in_len = sizeof(client_in);
+		/* Set the socket to not accept IPv4 over IPv6 when using IPv6 */
+		if (ipversion == IPV6) {
+			int opt = 1;
+			if (setsockopt(ssocket, IPPROTO_IPV6, IPV6_V6ONLY, &opt, sizeof(opt)) < 0) {
+				fprintf(stderr, "socket: couldn't set the IPV6_V6ONLY to true\n");
+				exit(-4);
+			}
+		}
 
 		/* Loop until we can bind to the listening socket. */
-		while (bind(ssocket, (struct sockaddr *) &server_in, sizeof(struct sockaddr_in)) < 0) {
-			fprintf(stderr, "bind: couldn't bind AF_INET socket?\n");
+		while (bind(ssocket, (struct sockaddr *) &server_in, server_in_len) < 0) {
+			fprintf(stderr, "bind: couldn't bind AF_INET%s socket on port %d?\n", ipversion == IPV4 ? "" : "6", port);
 			sleep(5);
 		}
 
@@ -226,7 +265,7 @@ int main(int argc, char *argv[])
 			fprintf(stderr, "listen: listen call failed\n");
 			exit(-2);
 		}
-		printf("\nWaiting for debug server to connect.\n");
+		printf("\nWaiting for debug server to connect on port %d.\n", port);
 
 #ifdef WIN32
 		fd = accept(ssocket, (struct sockaddr *) &client_in, NULL);
@@ -242,8 +281,6 @@ int main(int argc, char *argv[])
 		}
 #endif
 		close(ssocket);
-
-		iaddr = &client_in.sin_addr;
 
 		printf("Connect\n");
 

--- a/tests/bug00998-ipv4.phpt
+++ b/tests/bug00998-ipv4.phpt
@@ -1,0 +1,10 @@
+--TEST--
+Test for bug #998: Test that Xdebug connects back on IPv4
+--FILE--
+<?php
+require 'dbgp/dbgpclient.php';
+dbgpRun("", array(), null, XDEBUG_DBGP_IPV4);
+?>
+--EXPECTF--
+<?xml version="1.0" encoding="iso-8859-1"?>
+<init xmlns="urn:debugger_protocol_v1" xmlns:xdebug="http://xdebug.org/dbgp/xdebug" fileuri="file:///tmp/xdebug-dbgp-test.php" language="PHP" xdebug:language_version="" protocol_version="1.0" appid="" idekey=""><engine version=""><![CDATA[Xdebug]]></engine><author><![CDATA[Derick Rethans]]></author><url><![CDATA[http://xdebug.org]]></url><copyright><![CDATA[Copyright (c) 2002-%d by Derick Rethans]]></copyright></init>

--- a/tests/bug00998-ipv4_localhost.phpt
+++ b/tests/bug00998-ipv4_localhost.phpt
@@ -1,0 +1,10 @@
+--TEST--
+Test for bug #998: Test that Xdebug connects back on IPv4 with localhost as the remote host
+--FILE--
+<?php
+require 'dbgp/dbgpclient.php';
+dbgpRun("", array(), array("xdebug.remote_host" => "localhost"), XDEBUG_DBGP_IPV4);
+?>
+--EXPECTF--
+<?xml version="1.0" encoding="iso-8859-1"?>
+<init xmlns="urn:debugger_protocol_v1" xmlns:xdebug="http://xdebug.org/dbgp/xdebug" fileuri="file:///tmp/xdebug-dbgp-test.php" language="PHP" xdebug:language_version="" protocol_version="1.0" appid="" idekey=""><engine version=""><![CDATA[Xdebug]]></engine><author><![CDATA[Derick Rethans]]></author><url><![CDATA[http://xdebug.org]]></url><copyright><![CDATA[Copyright (c) 2002-%d by Derick Rethans]]></copyright></init>

--- a/tests/bug00998-ipv6.phpt
+++ b/tests/bug00998-ipv6.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Test for bug #998: Test that Xdebug connects back on IPv6
+--SKIPIF--
+<?php
+require 'dbgp/dbgpclient.php';
+if (!DebugClientIPv6::isSupported()) echo "skip IPv6 support is not configured.\n";
+?>
+--FILE--
+<?php
+require 'dbgp/dbgpclient.php';
+dbgpRun("", array(), null, XDEBUG_DBGP_IPV6);
+?>
+--EXPECTF--
+<?xml version="1.0" encoding="iso-8859-1"?>
+<init xmlns="urn:debugger_protocol_v1" xmlns:xdebug="http://xdebug.org/dbgp/xdebug" fileuri="file:///tmp/xdebug-dbgp-test.php" language="PHP" xdebug:language_version="" protocol_version="1.0" appid="" idekey=""><engine version=""><![CDATA[Xdebug]]></engine><author><![CDATA[Derick Rethans]]></author><url><![CDATA[http://xdebug.org]]></url><copyright><![CDATA[Copyright (c) 2002-%d by Derick Rethans]]></copyright></init>

--- a/tests/bug00998-ipv6_localhost.phpt
+++ b/tests/bug00998-ipv6_localhost.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Test for bug #998: Test that Xdebug connects back on IPv6 with localhost as the remote host
+--SKIPIF--
+<?php
+require 'dbgp/dbgpclient.php';
+if (!DebugClientIPv6::isSupported()) echo "skip IPv6 support is not configured.\n";
+?>
+--FILE--
+<?php
+require 'dbgp/dbgpclient.php';
+dbgpRun("", array(), array("xdebug.remote_host" => "localhost"), XDEBUG_DBGP_IPV6);
+?>
+--EXPECTF--
+<?xml version="1.0" encoding="iso-8859-1"?>
+<init xmlns="urn:debugger_protocol_v1" xmlns:xdebug="http://xdebug.org/dbgp/xdebug" fileuri="file:///tmp/xdebug-dbgp-test.php" language="PHP" xdebug:language_version="" protocol_version="1.0" appid="" idekey=""><engine version=""><![CDATA[Xdebug]]></engine><author><![CDATA[Derick Rethans]]></author><url><![CDATA[http://xdebug.org]]></url><copyright><![CDATA[Copyright (c) 2002-%d by Derick Rethans]]></copyright></init>

--- a/xdebug_com.c
+++ b/xdebug_com.c
@@ -13,6 +13,7 @@
    | xdebug@derickrethans.nl so we can mail you a copy immediately.       |
    +----------------------------------------------------------------------+
    | Authors:  Derick Rethans <derick@xdebug.org>                         |
+   |           Thomas Vanhaniemi <thomas.vanhaniemi@arcada.fi>            |
    +----------------------------------------------------------------------+
  */
 #include "php_xdebug.h"
@@ -21,169 +22,242 @@
 #include <errno.h>
 #include <stdio.h>
 #include <fcntl.h>
-#if HAVE_SYS_SELECT_H
-# include <sys/select.h>
-#endif
 #ifndef PHP_WIN32
-#include <unistd.h>
-#endif
-
-#ifdef PHP_WIN32
+# include <sys/poll.h>
+# include <unistd.h>
+# include <sys/socket.h>
+# include <netinet/tcp.h>
+# include <netdb.h>
+#else
 # include <process.h>
 # include <direct.h>
 # include "win32/time.h"
-#define PATH_MAX MAX_PATH
-#else
-# include <sys/socket.h>
-# include <netinet/in.h>
-# include <netinet/tcp.h>
-# include <arpa/inet.h>
-# include <netdb.h>
+# undef UNICODE
+# include <winsock2.h>
+# include <ws2tcpip.h>
+# include <mstcpip.h>
+# pragma comment (lib, "Ws2_32.lib")
+# define PATH_MAX MAX_PATH
+# define poll WSAPoll
 #endif
 
 #include "xdebug_com.h"
 
-#ifdef PHP_WIN32
-int inet_aton(const char *cp, struct in_addr *inp)
-{
-	inp->s_addr = inet_addr(cp);
-	if (inp->s_addr == INADDR_NONE) {
-		return 0;
-	}
-	return 1;
-}
-#endif
-
-/*
- * Converts a host name to an IP address.  */
-static int lookup_hostname(const char *addr, struct in_addr *in)
-{
-	struct hostent *host_info;
-
-	if (!inet_aton(addr, in)) {
-		host_info = gethostbyname(addr);
-		if (host_info == 0) {
-			/* Error: unknown host */
-			return -1;
-		}
-		*in = *((struct in_addr *) host_info->h_addr);
-	}
-	return 0;
-}
-/* }}} */
-
 int xdebug_create_socket(const char *hostname, int dport)
 {
-	struct sockaddr    sa;
-	struct sockaddr_in address;
-	int                sockfd;
-	int                status;
-	struct timeval     timeout;
-	int                actually_connected;
-	socklen_t          size = sizeof(sa);
+	struct addrinfo            hints;
+	struct addrinfo            *remote;
+	struct addrinfo            *ptr;
+	int                        status;
+	int                        sockfd;
+	int                        sockerror;
+	char                       sport[10];
+	int                        timeout = 200;
+	int                        actually_connected;
+	struct sockaddr_in6        sa;
+	socklen_t                  size = sizeof(sa);
+	struct pollfd              ufds[1];
 #if WIN32|WINNT
-	WORD               wVersionRequested;
-	WSADATA            wsaData;
-	char               optval = 1;
-	const char         yes = 1;
-	u_long             no = 0;
+	WORD                       wVersionRequested;
+	WSADATA                    wsaData;
+	char                       optval = 1;
+	const char                 yes = 1;
+	u_long                     no = 0;
 
 	wVersionRequested = MAKEWORD(2, 2);
 	WSAStartup(wVersionRequested, &wsaData);
 #else
-	long               optval = 1;
+	long                       optval = 1;
 #endif
-	memset(&address, 0, sizeof(address));
-	lookup_hostname(hostname, &address.sin_addr);
-	address.sin_family = AF_INET;
-	address.sin_port = htons((unsigned short)dport);
+	
+	/* Make a string of the port number that can be used with getaddrinfo */
+	sprintf(sport, "%d", dport);
 
-	sockfd = socket(address.sin_family, SOCK_STREAM, 0);
-	if (sockfd == SOCK_ERR) {
+	/* Create hints for getaddrinfo saying that we want IPv4 and IPv6 TCP stream sockets */
+	memset(&hints, 0, sizeof(hints));
+	hints.ai_family = AF_UNSPEC;
+	hints.ai_socktype = SOCK_STREAM;
+	hints.ai_protocol = IPPROTO_TCP;
+	hints.ai_flags = AI_PASSIVE;
+
+	/* Call getaddrinfo and return SOCK_ERR if the call fails for some reason */
+	if ((status = getaddrinfo(hostname, sport, &hints, &remote)) != 0) {
 #ifndef DEBUGGER_FAIL_SILENTLY
-#if WIN32|WINNT
-		printf("create_debugger_socket(\"%s\", %d) socket: %d\n",
+# if WIN32|WINNT
+		printf("xdebug_create_socket(\"%s\", %d) getaddrinfo: %d\n",
 					hostname, dport, WSAGetLastError());
-#else
-		printf("create_debugger_socket(\"%s\", %d) socket: %s\n",
+# else
+		printf("xdebug_create_socket(\"%s\", %d) getaddrinfo: %s\n",
 					hostname, dport, strerror(errno));
+# endif
 #endif
-#endif
-		return -1;
+		return SOCK_ERR;
 	}
 
-	/* Put socket in non-blocking mode so we can use select for timeouts */
-	timeout.tv_sec = 0;
-	timeout.tv_usec = 200000;
+	/* Go through every returned IP address */
+	for (ptr = remote; ptr != NULL; ptr = ptr->ai_next) {
+		/* Try to create the socket. If the creation fails continue on with the
+		 * next IP address in the list */
+		if ((sockfd = socket(ptr->ai_family, ptr->ai_socktype, ptr->ai_protocol)) == SOCK_ERR) {
+#ifndef DEBUGGER_FAIL_SILENTLY
+# if WIN32|WINNT
+			printf("xdebug_create_socket(\"%s\", %d) socket: %d\n",
+						hostname, dport, WSAGetLastError());
+# else
+			printf("xdebug_create_socket(\"%s\", %d) socket: %s\n",
+						hostname, dport, strerror(errno));
+# endif
+#endif
+			continue;
+		}
 
+		/* Put socket in non-blocking mode so we can use poll for timeouts */
 #ifdef WIN32
-	ioctlsocket(sockfd, FIONBIO, (u_long*)&yes);
+		ioctlsocket(sockfd, FIONBIO, (u_long*)&yes);
 #else
-	fcntl(sockfd, F_SETFL, O_NONBLOCK);
+		fcntl(sockfd, F_SETFL, O_NONBLOCK);
 #endif
 
-	/* connect */
-	status = connect(sockfd, (struct sockaddr*)&address, sizeof(address));
-	if (status < 0) {
+		/* Try to connect to the newly created socket */
+		/* Worth noting is that the port is set in the getaddrinfo call before */
+		status = connect(sockfd, ptr->ai_addr, ptr->ai_addrlen);
+		
+		/* Determine if we got a connection. If no connection could be made
+		 * we close the socket and continue with the next IP address in the list */
+		if (status < 0) {
 #ifdef WIN32
-		errno = WSAGetLastError();
-		if (errno != WSAEINPROGRESS && errno != WSAEWOULDBLOCK) {
-			close(sockfd);
-			return -1;
-		}
+			errno = WSAGetLastError();
+			if (errno != WSAEINPROGRESS && errno != WSAEWOULDBLOCK) {
+# ifndef DEBUGGER_FAIL_SILENTLY
+				printf("xdebug_create_socket(\"%s\", %d) connect: %d\n",
+						   hostname, dport, errno);
+# endif
 #else
-		if (errno == EACCES) {
-			close(sockfd);
-			return -3;
-		}
-		if (errno != EINPROGRESS) {
-			close(sockfd);
-			return -1;
-		}
+			if (errno == EACCES) {
+# ifndef DEBUGGER_FAIL_SILENTLY
+				printf("xdebug_create_socket(\"%s\", %d) connect: %s\n",
+						   hostname, dport, strerror(errno));
+# endif
+				SCLOSE(sockfd);
+				sockfd = SOCK_ACCESS_ERR;
+				
+				continue;
+			}
+			if (errno != EINPROGRESS) {
+# ifndef DEBUGGER_FAIL_SILENTLY
+				printf("xdebug_create_socket(\"%s\", %d) connect: %s\n",
+						   hostname, dport, strerror(errno));
+# endif
 #endif
-
-		while (1) {
-			fd_set rset, wset, eset;
-
-			FD_ZERO(&rset);
-			FD_SET(sockfd, &rset);
-			FD_ZERO(&wset);
-			FD_SET(sockfd, &wset);
-			FD_ZERO(&eset);
-			FD_SET(sockfd, &eset);
-
-			if (select(sockfd+1, &rset, &wset, &eset, &timeout) == 0) {
-				close(sockfd);
-				return -2;
+				SCLOSE(sockfd);
+				sockfd = SOCK_ERR;
+				
+				continue;
 			}
 
-			/* if our descriptor has an error */
-			if (FD_ISSET(sockfd, &eset)) {
-				close(sockfd);
-				return -1;
+			ufds[0].fd = sockfd;
+			ufds[0].events = POLLIN | POLLOUT | POLLPRI;
+			while (1) {
+				sockerror = poll(ufds, 1, timeout);
+				
+				/* If an error occured when doing the poll */
+				if (sockerror == SOCK_ERR) {
+#ifndef DEBUGGER_FAIL_SILENTLY
+# if WIN32|WINNT
+					printf("create_debugger_socket(\"%s\", %d) WSAPoll: %d\n",
+								hostname, dport, WSAGetLastError());
+# else
+					printf("create_debugger_socket(\"%s\", %d) poll: %s\n",
+								hostname, dport, strerror(errno));
+# endif
+#endif
+					sockerror = SOCK_ERR;
+					break;
+				}
+				
+				/* A timeout occured when polling the socket */
+				if (sockerror == 0) {
+					sockerror = SOCK_TIMEOUT_ERR;
+					break;
+				}
+				
+				/* If the poll was successful but an error occured */
+				if (ufds[0].revents & (POLLERR | POLLHUP | POLLNVAL | POLLRDHUP)) {
+#ifndef DEBUGGER_FAIL_SILENTLY
+# if WIN32|WINNT
+					printf("create_debugger_socket(\"%s\", %d) WSAPoll: %d\n",
+								hostname, dport, WSAGetLastError());
+# else
+					printf("create_debugger_socket(\"%s\", %d) poll: %s\n",
+								hostname, dport, strerror(errno));
+# endif
+#endif
+					sockerror = SOCK_ERR;
+					break;
+				}
+				
+				/* If the poll was successful break out */
+				if (ufds[0].revents & (POLLIN | POLLOUT)) {
+					sockerror = sockfd;
+					break;
+				} else {
+					/* We should never get here, but added as a failsafe to break out from any loops */
+#ifndef DEBUGGER_FAIL_SILENTLY
+# if WIN32|WINNT
+					printf("create_debugger_socket(\"%s\", %d) WSAPoll: %d\n",
+								hostname, dport, WSAGetLastError());
+# else
+					printf("create_debugger_socket(\"%s\", %d) poll: %s\n",
+								hostname, dport, strerror(errno));
+# endif
+#endif
+					sockerror = SOCK_ERR;
+					break;
+				}
 			}
 
-			/* if our descriptor is ready break out */
-			if (FD_ISSET(sockfd, &wset) || FD_ISSET(sockfd, &rset)) {
-				break;
+			if (sockerror > 0) {
+				actually_connected = getpeername(sockfd, (struct sockaddr *)&sa, &size);
+				if (actually_connected == -1) {
+#ifndef DEBUGGER_FAIL_SILENTLY
+# if WIN32|WINNT
+					printf("create_debugger_socket(\"%s\", %d) getpeername: %d\n",
+								hostname, dport, WSAGetLastError());
+# else
+					printf("create_debugger_socket(\"%s\", %d) getpeername: %s\n",
+								hostname, dport, strerror(errno));
+# endif
+#endif
+					sockerror = SOCK_ERR;
+				}
+			}
+			
+			/* If there where some errors close the socket and continue with the next IP address */
+			if (sockerror < 0) {
+				SCLOSE(sockfd);
+				sockfd = sockerror;
+				
+				continue;
 			}
 		}
-
-		actually_connected = getpeername(sockfd, &sa, &size);
-		if (actually_connected == -1) {
-			close(sockfd);
-			return -1;
-		}
+		
+		break;
 	}
 
+	/* Free the result returned by getaddrinfo */
+	freeaddrinfo(remote);
 
+	/* If we got a socket, set the option "No delay" to true (1) */
+	if (sockfd > 0) {
 #ifdef WIN32
-	ioctlsocket(sockfd, FIONBIO, &no);
+		ioctlsocket(sockfd, FIONBIO, &no);
 #else
-	fcntl(sockfd, F_SETFL, 0);
+		fcntl(sockfd, F_SETFL, 0);
 #endif
 
-	setsockopt(sockfd, IPPROTO_TCP, TCP_NODELAY, &optval, sizeof(optval));
+		setsockopt(sockfd, IPPROTO_TCP, TCP_NODELAY, &optval, sizeof(optval));
+	}
+	
 	return sockfd;
 }
 

--- a/xdebug_com.h
+++ b/xdebug_com.h
@@ -13,15 +13,12 @@
    | xdebug@derickrethans.nl so we can mail you a copy immediately.       |
    +----------------------------------------------------------------------+
    | Authors:  Derick Rethans <derick@xdebug.org>                         |
+   |           Thomas Vanhaniemi <thomas.vanhaniemi@arcada.fi>            |
    +----------------------------------------------------------------------+
  */
 
 #ifndef __HAVE_XDEBUG_COM_H__
 #define __HAVE_XDEBUG_COM_H__
-
-#ifdef PHP_WIN32
-int inet_aton(const char *cp, struct in_addr *inp);
-#endif
 
 #if WIN32|WINNT
 # define SOCK_ERR INVALID_SOCKET
@@ -32,6 +29,8 @@ int inet_aton(const char *cp, struct in_addr *inp);
 # define SOCK_CONN_ERR -1
 # define SOCK_RECV_ERR -1
 #endif
+#define SOCK_TIMEOUT_ERR -2
+#define SOCK_ACCESS_ERR -3
 
 #if WIN32|WINNT
 #define SCLOSE(a) closesocket(a)


### PR DESCRIPTION
- Rewrote the xdebug_create_socket function so that it also supports
creating sockets for IPv6 addresses.
- Wrote a couple of tests that test both IPv4 and IPv6 connectivity.
- Added some functions to the DebugClient (some refactoring to make it
more extendable).
- Created a DebugClientIPv6 class that extends from DebugClient. This
communicates with Xdebug over IPv6.

### Known potential problems ###
- Haven't been tested on Windows.
- The DebugClientIPv6::isSupported() function isn't tested, so the SKIP for the test could be ignored on a machine that doesn't support IPv6.