### PR TITLE
Add missing TSRMLS for master

### DIFF
--- a/xdebug.c
+++ b/xdebug.c
@@ -2105,9 +2105,16 @@ ZEND_DLEXPORT void xdebug_statement_call(zend_op_array *op_array)
 
 ZEND_DLEXPORT int xdebug_zend_startup(zend_extension *extension)
 {
+#if ZEND_EXTENSION_API_NO > 220131106
+	TSRMLS_FETCH();
+#endif
 	zend_xdebug_initialised = 1;
 
+#if ZEND_EXTENSION_API_NO > 220131106
+	return zend_startup_module(&xdebug_module_entry TSRMLS_CC);
+#else
 	return zend_startup_module(&xdebug_module_entry);
+#endif
 }
 
 ZEND_DLEXPORT void xdebug_zend_shutdown(zend_extension *extension)

--- a/xdebug_stack.c
+++ b/xdebug_stack.c
@@ -749,7 +749,11 @@ void xdebug_error_cb(int type, const char *error_filename, const uint error_line
 				/* the parser would return 1 (failure), we can bail out nicely */
 				if (type != E_PARSE) {
 					/* restore memory limit */
+		#if ZEND_EXTENSION_API_NO > 220131106
+					zend_set_memory_limit(PG(memory_limit) TSRMLS_CC);
+		#else
 					zend_set_memory_limit(PG(memory_limit));
+		#endif
 					zend_objects_store_mark_destructed(&EG(objects_store) TSRMLS_CC);
 					zend_bailout();
 					return;


### PR DESCRIPTION
There were some ABI changes in PHP master (TSRMLS_FETCH crusade). This patch adds some ifdefs to fix compilation errors on PHP 5.6 and master
