### PR TITLE
Fixes a crash/memory read error with the tests/array_map-php55.phpt test...

### DIFF
--- a/xdebug_compat.c
+++ b/xdebug_compat.c
@@ -72,6 +72,9 @@ void *php_zend_memrchr(const void *s, int c, size_t n)
 
 zval *xdebug_zval_ptr(int op_type, XDEBUG_ZNODE *node, zend_execute_data *zdata TSRMLS_DC)
 {
+	if (!zdata->opline) {
+		return NULL;
+	}
 	switch (op_type & 0x0F) {
 		case IS_CONST:
 #if PHP_VERSION_ID >= 50399


### PR DESCRIPTION
....

Would only really show up with USE_ZEND_ALLOC=0 and valgrind.
