### PR TITLE
Fix segfault in xdebug_execute_internal

### DIFF
--- a/xdebug.c
+++ b/xdebug.c
@@ -1673,7 +1673,9 @@ void xdebug_execute_internal(zend_execute_data *current_execute_data, struct _ze
 		}
 	}
 
-	xdebug_llist_remove(XG(stack), XDEBUG_LLIST_TAIL(XG(stack)), xdebug_stack_element_dtor);
+	if (XG(stack)) {
+		xdebug_llist_remove(XG(stack), XDEBUG_LLIST_TAIL(XG(stack)), xdebug_stack_element_dtor);
+	}
 	XG(level)--;
 }
 


### PR DESCRIPTION
When compiling a script inside an extensions RINIT callback
xdebug would segfault inside xdebug_execute_internal, because
the stack is not properly setup here. This is already
checked for in xdebug_execute for non internal functions.
