### PR TITLE
Fix executing php code from command line with option -r

### DIFF
--- a/xdebug_handler_dbgp.c
+++ b/xdebug_handler_dbgp.c
@@ -2146,7 +2146,7 @@ int xdebug_dbgp_init(xdebug_con *context, int mode)
 	xdebug_xml_add_text(child, xdstrdup(XDEBUG_COPYRIGHT));
 	xdebug_xml_add_child(response, child);
 
-	if (strcmp(context->program_name, "-") == 0) {
+	if (strcmp(context->program_name, "-") == 0 || strcmp(context->program_name, "Command line code") == 0) {
 		xdebug_xml_add_attribute_ex(response, "fileuri", xdstrdup("dbgp://stdin"), 0, 1);
 	} else {
 		xdebug_xml_add_attribute_ex(response, "fileuri", xdebug_path_to_url(context->program_name TSRMLS_CC), 0, 1);


### PR DESCRIPTION
Here are instructions to reproduce the bug:
xdebug config: https://gist.github.com/nikita2206/9d0e77942d04186f5d1c
```
php -v
PHP 5.6.5 (cli) (built: Jan 22 2015 18:29:09) 
Copyright (c) 1997-2014 The PHP Group
Zend Engine v2.6.0, Copyright (c) 1998-2014 Zend Technologies
    with Xdebug v2.3.0dev, Copyright (c) 2002-2015, by Derick Rethans
```
turn on debug listener in phpstorm, run `php -r 'echo "a";`
You'll get segfault, gdb backtrace is:
```
(gdb) bt
#0  0x00007ffff65f7589 in __memcpy_avx_unaligned () from /usr/lib/libc.so.6
#1  0x000000000062111d in ?? ()
#2  0x000000000066e621 in virtual_file_ex ()
#3  0x00007ffff5960528 in xdebug_path_to_url (fileurl=<optimized out>) at /home/nikita/projects/xdebug/usefulstuff.c:350
#4  0x00007ffff5951567 in xdebug_dbgp_init (context=0x7ffff5b6ea00 <xdebug_globals+768>, mode=19640264) at /home/nikita/projects/xdebug/xdebug_handler_dbgp.c:2152
#5  0x00007ffff5954bdb in xdebug_init_debugger () at /home/nikita/projects/xdebug/xdebug_stack.c:491
#6  0x00007ffff5943b54 in xdebug_execute_ex (execute_data=0x7ffff7f7a090) at /home/nikita/projects/xdebug/xdebug.c:1426
#7  0x000000000063bfb2 in zend_eval_stringl ()
#8  0x000000000063c0a9 in zend_eval_stringl_ex ()
#9  0x00000000006f806e in ?? ()
#10 0x00000000004262c0 in ?? ()
#11 0x00007ffff64f0040 in __libc_start_main () from /usr/lib/libc.so.6
#12 0x0000000000426401 in _start ()
```

I'm not sure if this was around here previously or some changes to php introduced this.