### PR TITLE
Changed fetching static class method to ZEND_FETCH_CLASS_AUTO instead of SELF.

### DIFF
--- a/xdebug_handler_dbgp.c
+++ b/xdebug_handler_dbgp.c
@@ -1731,11 +1731,13 @@ next_constant:
 		/* Check for static variables and constants, but only if it's a static
 		 * method call as we attach constants and static properties to "this"
 		 * too normally. */
+		
 		if (fse->function.type == XFUNC_STATIC_MEMBER) {
-			zend_class_entry *ce = zend_fetch_class(fse->function.class, strlen(fse->function.class), ZEND_FETCH_CLASS_SELF TSRMLS_CC);
+			zend_class_entry *ce = zend_fetch_class(fse->function.class, strlen(fse->function.class), ZEND_FETCH_CLASS_AUTO TSRMLS_CC);
 
 			xdebug_attach_static_vars(node, options, ce TSRMLS_CC);
 		}
+		
 
 		XG(active_symbol_table) = NULL;
 		XG(active_execute_data) = NULL;


### PR DESCRIPTION
I stumbled onto a bug with either the Zend engine or Xdebug. Using PHPStrom, trying to move in a stack frame, I got an error from the zend engine: "Cannot access self:: when no class scope is active". I traced the bug to the changed call in xdebug, and further into the zend engine source. Changing the value to AUTO seemed to resolve the bug, everything is working as expected now.
