### PR TITLE
fix usage of virtual_file_ex

### DIFF
--- a/usefulstuff.c
+++ b/usefulstuff.c
@@ -344,7 +344,11 @@ char *xdebug_path_to_url(const char *fileurl TSRMLS_DC)
 			cwd[0] = '\0';
 		}
 
+#if PHP_VERSION_ID < 50600
 		new_state.cwd = strdup(cwd);
+#else
+		new_state.cwd = estrdup(cwd);
+#endif
 		new_state.cwd_length = strlen(cwd);
 
 		if (!virtual_file_ex(&new_state, fileurl, NULL, 1 TSRMLS_CC)) {
@@ -352,7 +356,11 @@ char *xdebug_path_to_url(const char *fileurl TSRMLS_DC)
 			tmp = xdebug_sprintf("file://%s",s);
 			efree(s);
 		}
+#if PHP_VERSION_ID < 50600
 		free(new_state.cwd);
+#else
+		efree(new_state.cwd);
+#endif
 
 	} else if (fileurl[1] == '/' || fileurl[1] == '\\') {
 		/* convert UNC paths (eg. \\server\sharepath) */


### PR DESCRIPTION
In 5.6, TSRM/tsrm_virtual_cwd.c have moved to Zend/zend_virtual_cwd.c, thus is now use emalloc instead of malloc function. (yes, an awfull BC)

See https://bugzilla.redhat.com/1214111 a Fedora bug report, with a backtrace