### PR TITLE
switch from efree to STR_FREE

### DIFF
--- a/xdebug_stack.c
+++ b/xdebug_stack.c
@@ -247,7 +247,7 @@ void xdebug_append_error_description(xdebug_str *str, int html, const char *erro
 		xdebug_str_add(str, xdebug_sprintf(formats[1], error_type_str, escaped, error_filename, error_lineno), 1);
 	}
 
-	efree(escaped);
+	STR_FREE(escaped);
 }
 
 void xdebug_append_printable_stack(xdebug_str *str, int html TSRMLS_DC)


### PR DESCRIPTION
I receive lot of segfault report about this efree call.
See https://retrace.fedoraproject.org/faf/reports/672411/

In 5.6, php_escape_html_entities can return NULL, but can also return an empty string which is interned (and so can't be efree).

STR_FREE macro exists since 5.0, and should secure this.
