### PR TITLE
xdebug.max_nesting_level default value

### DIFF
--- a/xdebug.ini
+++ b/xdebug.ini
@@ -447,14 +447,14 @@
 ; -----------------------------------------------------------------------------
 ; xdebug.max_nesting_level
 ;
-; Type: integer, Default value: 100
+; Type: integer, Default value: 256
 ;
 ; Controls the protection mechanism for infinite recursion protection. The value
 ; of this setting is the maximum level of nested functions that are allowed
 ; before the script will be aborted.
 ;
 ;
-;xdebug.max_nesting_level = 100
+;xdebug.max_nesting_level = 256
 
 ; -----------------------------------------------------------------------------
 ; xdebug.overload_var_dump


### PR DESCRIPTION
Should't the `xdebug.max_nesting_level` default value be 256?

https://github.com/xdebug/xdebug/blob/4a89b66c3c82c3853f6d6130849b33d919e7d848/xdebug.c#L260