### PR TITLE
VC14 fixes, cherry pick them

### DIFF
--- a/xdebug_code_coverage.c
+++ b/xdebug_code_coverage.c
@@ -510,9 +510,13 @@ static int xdebug_find_jump(zend_op_array *opa, unsigned int position, long *jmp
 {
 #if PHP_VERSION_ID < 70000
 	zend_op *base_address = &(opa->opcodes[0]);
+#else
+	zend_op base_address;
+	base_address = opa->opcodes[0];
 #endif
 
 	zend_op opcode = opa->opcodes[position];
+	
 	if (opcode.opcode == ZEND_JMP) {
 #if PHP_VERSION_ID >= 70000
 		*jmp1 = XDEBUG_ZNODE_JMP_LINE(opcode.op1, position, base_address);

--- a/xdebug_monitor.c
+++ b/xdebug_monitor.c
@@ -59,7 +59,7 @@ static void xdebug_hash_function_monitor_dtor(char *function)
 
 static xdebug_monitored_function_entry *xdebug_monitored_function_init(char *func_name, char *filename, int lineno)
 {
-	xdebug_monitored_function_entry *tmp = xdmalloc(sizeof(xdebug_monitored_function_dtor));
+	xdebug_monitored_function_entry *tmp = xdmalloc(sizeof(xdebug_monitored_function_entry));
 
 	tmp->func_name = xdstrdup(func_name);
 	tmp->filename = xdstrdup(filename);

--- a/xdebug_stack.c
+++ b/xdebug_stack.c
@@ -693,7 +693,7 @@ void xdebug_error_cb(int type, const char *error_filename, const uint error_line
 
 #ifdef PHP_WIN32
 			if (type==E_CORE_ERROR || type==E_CORE_WARNING) {
-				MessageBox(NULL, buffer, error_type_str, MB_OK|ZEND_SERVICE_MB_STYLE);
+				MessageBox(NULL, buffer, error_type_str, MB_OK);
 			}
 #endif
 			xdebug_log_stack(error_type_str, buffer, error_filename, error_lineno TSRMLS_CC);

--- a/xdebug_var.c
+++ b/xdebug_var.c
@@ -1612,11 +1612,19 @@ static int object_item_add_zend_prop_to_merged_hash(zend_property_info *zpp TSRM
 	item = xdmalloc(sizeof(xdebug_object_item));
 	item->type = object_type;
 #if ZTS
+# if PHP_VERSION_ID >= 70000
+	if (ce->type == 1) {
+		item->zv   = &CG(static_members_table)[(zend_intptr_t) ce->static_members_table][zpp->offset];
+	} else {
+		item->zv   = &ce->static_members_table[zpp->offset];
+	}
+# else
 	if (ce->type == 1) {
 		item->zv   = CG(static_members_table)[(zend_intptr_t) ce->static_members_table][zpp->offset];
 	} else {
 		item->zv   = ce->static_members_table[zpp->offset];
 	}
+# endif
 #else
 # if PHP_VERSION_ID >= 70000
 	item->zv   = &ce->static_members_table[zpp->offset];


### PR DESCRIPTION
@derickr Pick whatever you like of these fixes. I am not sure if tey are all correct, but they fixed compiling with VC14. php_xdebug.dll is still crashing, but given the failed tests (on Centos 6 as well) this does not surprise me. Moreover, with xdebug.so I also experienced segfaults on Centos.

You have a long way to go. Good luck with that.