### PR TITLE
Wrapper elements on strings to allow for styling

### DIFF
--- a/xdebug_stack.c
+++ b/xdebug_stack.c
@@ -66,7 +66,7 @@ static char* ansi_formats[11] = {
 
 static char* html_formats[13] = {
 	"<br />\n<font size='1'><table class='xdebug-error xe-%s%s' dir='ltr' border='1' cellspacing='0' cellpadding='1'>\n",
-	"<tr><th align='left' bgcolor='#f57900' colspan=\"5\"><span style='background-color: #cc0000; color: #fce94f; font-size: x-large;'>( ! )</span> %s: %s in %s on line <i>%d</i></th></tr>\n",
+	"<tr><th align='left' bgcolor='#f57900' colspan=\"5\"><span style='background-color: #cc0000; color: #fce94f; font-size: x-large;'>( ! )</span> <span class='xdebug-error-type'>%s</span>: <span class='xdebug-error-type-info'>%s</span> in <span class='xdebug-error-file'>%s</span> on line <span class='xdebug-error-line'><i>%d</i></span></th></tr>\n",
 	"<tr><th align='left' bgcolor='#e9b96e' colspan='5'>Call Stack</th></tr>\n<tr><th align='center' bgcolor='#eeeeec'>#</th><th align='left' bgcolor='#eeeeec'>Time</th><th align='left' bgcolor='#eeeeec'>Memory</th><th align='left' bgcolor='#eeeeec'>Function</th><th align='left' bgcolor='#eeeeec'>Location</th></tr>\n",
 	"<tr><td bgcolor='#eeeeec' align='center'>%d</td><td bgcolor='#eeeeec' align='center'>%.4F</td><td bgcolor='#eeeeec' align='right'>%ld</td><td bgcolor='#eeeeec'>%s( ",
 	"<font color='#00bb00'>'%s'</font>",


### PR DESCRIPTION
The chosen class names should accurately represent the data, if I used the wrong terminology please correct. I've appended them to the table class so they are not generic enough for a user to accidentally style.