### PR TITLE
support the old error callback hook and old exception callback.

### DIFF
--- a/xdebug_stack.c
+++ b/xdebug_stack.c
@@ -13,6 +13,7 @@
    | xdebug@derickrethans.nl so we can mail you a copy immediately.       |
    +----------------------------------------------------------------------+
    | Authors:  Derick Rethans <derick@xdebug.org>                         |
+   |           Neeke Gao <neeke@php.net>                                  |
    +----------------------------------------------------------------------+
  */
 #include "php_xdebug.h"
@@ -33,6 +34,9 @@
 #endif
 
 #include "main/php_ini.h"
+
+/* error callback replacement functions */
+void (*xdebug_old_error_cb)(int type, const char *error_filename, const uint error_lineno, const char *format, va_list args);
 
 ZEND_EXTERN_MODULE_GLOBALS(xdebug)
 
@@ -83,7 +87,7 @@ static char* html_formats[13] = {
 static char** select_formats(int html TSRMLS_DC) {
 	if (html) {
 		return html_formats;
-	} 
+	}
 	else if ((XG(cli_color) == 1 && xdebug_is_output_tty(TSRMLS_C)) || (XG(cli_color) == 2)) {
 		return ansi_formats;
 	}
@@ -418,7 +422,7 @@ void xdebug_append_printable_stack(xdebug_str *str, int html TSRMLS_DC)
 			unsigned int j = 0; /* Counter */
 			char *tmp_name;
 			int variadic_opened = 0;
-			
+
 			i = XDEBUG_LLIST_VALP(le);
 			tmp_name = xdebug_show_fname(i->function, html, 0 TSRMLS_CC);
 			if (html) {
@@ -527,7 +531,7 @@ void xdebug_append_printable_stack(xdebug_str *str, int html TSRMLS_DC)
 
 		if (XG(show_local_vars) && XG(stack) && XDEBUG_LLIST_TAIL(XG(stack))) {
 			int scope_nr = XG(stack)->size;
-			
+
 			i = XDEBUG_LLIST_VALP(XDEBUG_LLIST_TAIL(XG(stack)));
 			if (i->user_defined == XDEBUG_INTERNAL && XDEBUG_LLIST_PREV(XDEBUG_LLIST_TAIL(XG(stack))) && XDEBUG_LLIST_VALP(XDEBUG_LLIST_PREV(XDEBUG_LLIST_TAIL(XG(stack))))) {
 				i = XDEBUG_LLIST_VALP(XDEBUG_LLIST_PREV(XDEBUG_LLIST_TAIL(XG(stack))));
@@ -689,6 +693,11 @@ void xdebug_error_cb(int type, const char *error_filename, const uint error_line
 
 	TSRMLS_FETCH();
 
+     /* call back the old error handler */
+    if (xdebug_old_error_cb) {
+        xdebug_old_error_cb(type, error_filename, error_lineno, format, args);
+    }
+
 	buffer_len = vspprintf(&buffer, PG(log_errors_max_len), format, args);
 
 	error_type_str = xdebug_error_type(type);
@@ -762,7 +771,7 @@ void xdebug_error_cb(int type, const char *error_filename, const uint error_line
 #endif
 				xdebug_str str = {0, 0, NULL};
 				char *tmp_buf, *p;
-				
+
 				/* find first new line */
 				p = strchr(buffer, '\n');
 				if (!p) {
@@ -911,11 +920,11 @@ PHP_FUNCTION(xdebug_print_function_stack)
 	function_stack_entry *i;
 	char *tmp;
 	long options = 0;
-  
+
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|sl", &message, &message_len, &options) == FAILURE) {
 		return;
 	}
- 
+
 	i = xdebug_get_stack_frame(0 TSRMLS_CC);
 	if (message) {
 		tmp = get_printable_stack(PG(html_errors), 0, message, i->filename, i->lineno, !(options & XDEBUG_STACK_NO_DESC) TSRMLS_CC);
@@ -1419,7 +1428,7 @@ function_stack_entry *xdebug_add_stack_frame(zend_execute_data *zdata, zend_op_a
 					}
 #else
 					if (p) {
-						param = (zval **) p++;				
+						param = (zval **) p++;
 						tmp->var[tmp->varc].addr = *param;
 					}
 #endif
@@ -1445,7 +1454,7 @@ function_stack_entry *xdebug_add_stack_frame(zend_execute_data *zdata, zend_op_a
 	if (XG(do_code_coverage)) {
 		xdebug_count_line(tmp->filename, tmp->lineno, 0, 0 TSRMLS_CC);
 	}
-	
+
 	if (XG(do_monitor_functions)) {
 		char *func_name = xdebug_show_fname(tmp->function, 0, 0 TSRMLS_CC);
 		int   func_name_len = strlen(func_name);
@@ -1676,7 +1685,7 @@ PHP_FUNCTION(xdebug_get_function_stack)
 void xdebug_attach_used_var_names(void *return_value, xdebug_hash_element *he)
 {
 	char *name = (char*) he->ptr;
-	
+
 	add_next_index_string(return_value, name ADD_STRING_COPY);
 }
 
@@ -1692,7 +1701,7 @@ PHP_FUNCTION(xdebug_get_declared_vars)
 	le = XDEBUG_LLIST_TAIL(XG(stack));
 	le = XDEBUG_LLIST_PREV(le);
 	i = XDEBUG_LLIST_VALP(le);
-	
+
 	/* Add declared vars */
 	if (i->used_vars) {
 		tmp_hash = xdebug_used_var_hash_from_llist(i->used_vars);


### PR DESCRIPTION
Support the old error callback hook and old exception callback with the other extensions.

For example the PHP-APM and PHP-SeasLog.
