### PR TITLE
fix build on i686

### DIFF
--- a/xdebug_code_coverage.c
+++ b/xdebug_code_coverage.c
@@ -554,7 +554,7 @@ static zend_brk_cont_element* xdebug_find_brk_cont(zend_uint nest_levels, int ar
 
 static int xdebug_find_jump(zend_op_array *opa, unsigned int position, long *jmp1, long *jmp2)
 {
-#if PHP_VERSION_ID < 70000
+#if defined(ZEND_USE_ABS_JMP_ADDR) || PHP_VERSION_ID < 70000
 	zend_op *base_address = &(opa->opcodes[0]);
 #endif
 


### PR DESCRIPTION
     /builddir/build/BUILD/php-pecl-xdebug-2.4.0/NTS/xdebug_code_coverage.c: In function 'xdebug_find_jump':
     /builddir/build/BUILD/php-pecl-xdebug-2.4.0/NTS/xdebug_code_coverage.c:564:61: error: 'base_address' undeclared (first use in this function)
        *jmp1 = XDEBUG_ZNODE_JMP_LINE(opcode.op1, position, base_address);
