### PR TITLE
IP retrieval from X-Forwarded-For should comply with rfc7239

### DIFF
--- a/tests/bug00964-1.phpt
+++ b/tests/bug00964-1.phpt
@@ -12,7 +12,7 @@ xdebug.remote_connect_back=1
 xdebug.remote_port=9003
 --FILE--
 <?php
-preg_match("#Remote address found, connecting to (192\.168\.111\.111):9003#", file_get_contents(sys_get_temp_dir() . "/bug964.txt"), $match);
+preg_match("#Remote address found, connecting to ([^:]+):9003#", file_get_contents(sys_get_temp_dir() . "/bug964.txt"), $match);
 unlink (sys_get_temp_dir() . "/bug964.txt");
 echo $match[1];
 ?>

--- a/tests/bug00964-1.phpt
+++ b/tests/bug00964-1.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Test for bug #964: IP retrival from X-Forwarded-For complies with rfc7239 (without comma)
+--SKIPIF--
+<?php if (substr(PHP_OS, 0, 3) == "WIN") die("skip Not for Windows"); ?>
+--ENV--
+HTTP_X_FORWARDED_FOR=192.168.111.111
+--INI--
+xdebug.remote_enable=1
+xdebug.remote_log=/tmp/bug964.txt
+xdebug.remote_autostart=1
+xdebug.remote_connect_back=1
+xdebug.remote_port=9003
+--FILE--
+<?php
+preg_match("#Remote address found, connecting to (192\.168\.111\.111):9003#", file_get_contents(sys_get_temp_dir() . "/bug964.txt"), $match);
+unlink (sys_get_temp_dir() . "/bug964.txt");
+echo $match[1];
+?>
+--EXPECTF--
+192.168.111.111

--- a/tests/bug00964-2.phpt
+++ b/tests/bug00964-2.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Test for bug #964: IP retrival from X-Forwarded-For complies with rfc7239 (with comma)
+--SKIPIF--
+<?php if (substr(PHP_OS, 0, 3) == "WIN") die("skip Not for Windows"); ?>
+--ENV--
+HTTP_X_FORWARDED_FOR=192.168.111.111, 10.1.2.3, 10.1.2.4
+--INI--
+xdebug.remote_enable=1
+xdebug.remote_log=/tmp/bug964.txt
+xdebug.remote_autostart=1
+xdebug.remote_connect_back=1
+xdebug.remote_port=9003
+--FILE--
+<?php
+preg_match("#Remote address found, connecting to ([^:]+):9003#", file_get_contents(sys_get_temp_dir() . "/bug964.txt"), $match);
+unlink (sys_get_temp_dir() . "/bug964.txt");
+echo $match[1];
+?>
+--EXPECTF--
+192.168.111.111

--- a/xdebug_stack.c
+++ b/xdebug_stack.c
@@ -618,6 +618,11 @@ void xdebug_init_debugger(TSRMLS_D)
 			XDEBUG_ZEND_HASH_STR_FIND(PG(http_globals)[TRACK_VARS_SERVER], "REMOTE_ADDR", HASH_KEY_SIZEOF("REMOTE_ADDR"), remote_addr);
 		}
 		if (remote_addr) {
+			/* Use first IP according to rfc7239 */
+			char *cp = strchr(XDEBUG_ZEND_HASH_RETURN_VALUE(remote_addr), ',');
+			if (cp) {
+				*cp = '\0';
+			}
 			XDEBUG_LOG_PRINT(XG(remote_log_file), "I: Remote address found, connecting to %s:%ld.\n", XDEBUG_ZEND_HASH_RETURN_VALUE(remote_addr), (long int) XG(remote_port));
 			XG(context).socket = xdebug_create_socket(XDEBUG_ZEND_HASH_RETURN_VALUE(remote_addr), XG(remote_port) TSRMLS_CC);
 		} else {


### PR DESCRIPTION
Fixes https://bugs.xdebug.org/view.php?id=964 by making the parsing of X-Forwarded-For more compliant with rfc7239.
