### PR TITLE
Fix travis build error on php 7.1 and nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
     - php: nightly
 
 before_script:
-  - phpenv config-rm xdebug.ini
+  - phpenv config-rm xdebug.ini || echo "xdebug not available"
   - ./.travis.scripts/compile.sh
 
 notifications:


### PR DESCRIPTION
This fix the error below
```
phpenv config-rm xdebug.ini

File xdebug.ini does no exist.

The command "phpenv config-rm xdebug.ini" failed and exited with 1 during .
```