### PR TITLE
Issue #1353 Make static function xdebug_dbgp_parse_option() extern

### DIFF
--- a/xdebug_handler_dbgp.c
+++ b/xdebug_handler_dbgp.c
@@ -2097,7 +2097,7 @@ duplicate_opts:
 	return XDEBUG_ERROR_DUP_ARG;
 }
 
-static int xdebug_dbgp_parse_option(xdebug_con *context, char* line, int flags, xdebug_xml_node *retval TSRMLS_DC)
+int xdebug_dbgp_parse_option(xdebug_con *context, char* line, int flags, xdebug_xml_node *retval TSRMLS_DC)
 {
 	char *cmd = NULL;
 	int res, ret = 0;

--- a/xdebug_handler_dbgp.h
+++ b/xdebug_handler_dbgp.h
@@ -96,6 +96,8 @@ int xdebug_dbgp_stream_output(const char *string, unsigned int length TSRMLS_DC)
 int xdebug_dbgp_register_eval_id(xdebug_con *context, function_stack_entry *fse);
 char *xdebug_dbgp_get_revision(void);
 
+int xdebug_dbgp_parse_option(xdebug_con *context, char* line, int flags, xdebug_xml_node *retval TSRMLS_DC);
+
 #define xdebug_handler_dbgp {       \
 	xdebug_dbgp_init,               \
 	xdebug_dbgp_deinit,             \


### PR DESCRIPTION
This small patch simply makes the `xdebug_dbgp_parse_option()` function extern linkage.

Please see https://bugs.xdebug.org/view.php?id=1353 for a detailed rationale.

The patch is currently for the master branch. If this patch is accepted, it should also be folded into the xdebug_2_4 branch. (Please let me know if I should create a separate PR for that).
