### PR TITLE
Install valgrind in the travis install step, run tests with valgrind. Requires sudo.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: false
-
 language: php
 
 php:
@@ -7,9 +5,17 @@ php:
   - 7.1
   - nightly
 
+env:
+  matrix:
+    -
+    - VALGRIND=1 SKIP_DBGP_TESTS=1
+
 matrix:
   allow_failures:
     - php: nightly
+
+install:
+  - if [ "$VALGRIND" -eq 1 ]; then sudo apt-get update -qq; sudo apt-get install -qq valgrind; export TEST_PHP_ARGS="-m"; valgrind --version; fi
 
 before_script:
   - phpenv config-rm xdebug.ini || echo "xdebug not available"

--- a/tests/bug00998-ipv6.phpt
+++ b/tests/bug00998-ipv6.phpt
@@ -3,6 +3,7 @@ Test for bug #998: Test that Xdebug connects back on IPv6
 --SKIPIF--
 <?php
 if (getenv("SKIP_DBGP_TESTS")) { exit("skip Excluding DBGp tests"); }
+if (getenv("TRAVIS")) { exit("skip flaky travis ipv6 support"); }
 require 'dbgp/dbgpclient.php';
 if (!DebugClientIPv6::isSupported()) echo "skip IPv6 support is not configured.\n";
 ?>

--- a/tests/bug00998-ipv6_localhost.phpt
+++ b/tests/bug00998-ipv6_localhost.phpt
@@ -3,6 +3,7 @@ Test for bug #998: Test that Xdebug connects back on IPv6 with localhost as the 
 --SKIPIF--
 <?php
 if (getenv("SKIP_DBGP_TESTS")) { exit("skip Excluding DBGp tests"); }
+if (getenv("TRAVIS")) { exit("skip flaky travis DBGp support"); }
 require 'dbgp/dbgpclient.php';
 if (!DebugClientIPv6::isSupported()) echo "skip IPv6 support is not configured.\n";
 ?>


### PR DESCRIPTION
This is taken from https://github.com/igbinary/igbinary/blob/master/.travis.yml

Aside: The linked yaml file also has scripts to compile and test 32-bit php and php extensions in travis. (7.1 is currently out of date)

Reverts 55b67f7884d16153a43139516e7474335691caee