### PR TITLE
Fix IPV6 client creation in unit tests (Was swapped)

### DIFF
--- a/tests/dbgp/dbgpclient.php
+++ b/tests/dbgp/dbgpclient.php
@@ -201,11 +201,11 @@ function dbgpRun( $data, $commands, array $ini_options = null, $flags = XDEBUG_D
 {
 	if ( $flags == XDEBUG_DBGP_IPV6 )
 	{
-		$t = new DebugClient();
+		$t = new DebugClientIPv6();
 	}
 	else
 	{
-		$t = new DebugClientIPv6();
+		$t = new DebugClient();
 	}
 
 	$t->runTest( $data, $commands, $ini_options );


### PR DESCRIPTION
This was creating IPV4 clients when IPV6 flag was passed in, and vice
versa.