### PR TITLE
Add support for unix domain sockets

### DIFF
--- a/tests/remote_log-unix-2.phpt
+++ b/tests/remote_log-unix-2.phpt
@@ -1,0 +1,40 @@
+--TEST--
+Test for Xdebug's remote log (with unix sockets and header)
+--SKIPIF--
+<?php if (substr(PHP_OS, 0, 3) == "WIN") die("skip Not for Windows"); ?>
+--ENV--
+I_LIKE_COOKIES=unix:///tmp/haxx0r.sock
+--INI--
+xdebug.remote_enable=1
+xdebug.remote_log=/tmp/remote-log4.txt
+xdebug.remote_autostart=1
+xdebug.remote_connect_back=1
+xdebug.remote_host=unix:///tmp/xdbg.sock
+xdebug.remote_port=0
+xdebug.remote_addr_header=I_LIKE_COOKIES
+--FILE--
+<?php
+if (sys_get_temp_dir() !== '/tmp') die('Unexpected temp dir: '.sys_get_temp_dir());
+echo strlen("foo"), "\n";
+echo file_get_contents(sys_get_temp_dir() . "/remote-log4.txt");
+unlink (sys_get_temp_dir() . "/remote-log4.txt");
+?>
+--EXPECTF--
+3
+Log opened at %d-%d-%d %d:%d:%d
+I: Checking remote connect back address.
+I: Checking user configured header 'I_LIKE_COOKIES'.
+W: Invalid remote address provided containing URI spec 'unix:///tmp/haxx0r.sock'.
+W: Remote address not found, connecting to configured address/port: unix:///tmp/xdbg.sock:0. :-|
+W: Creating socket for 'unix:///tmp/xdbg.sock', connect: No such file or directory.
+E: Could not connect to client. :-(
+Log closed at %d-%d-%d %d:%d:%d
+
+Log opened at %d-%d-%d %d:%d:%d
+I: Checking remote connect back address.
+I: Checking user configured header 'I_LIKE_COOKIES'.
+W: Invalid remote address provided containing URI spec 'unix:///tmp/haxx0r.sock'.
+W: Remote address not found, connecting to configured address/port: unix:///tmp/xdbg.sock:0. :-|
+W: Creating socket for 'unix:///tmp/xdbg.sock', connect: No such file or directory.
+E: Could not connect to client. :-(
+Log closed at %d-%d-%d %d:%d:%d

--- a/tests/remote_log-unix.phpt
+++ b/tests/remote_log-unix.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Test for Xdebug's remote log (with unix sockets)
+--SKIPIF--
+<?php if (substr(PHP_OS, 0, 3) == "WIN") die("skip Not for Windows"); ?>
+--ENV--
+I_LIKE_COOKIES=doesnotexist3
+--INI--
+xdebug.remote_enable=1
+xdebug.remote_log=/tmp/remote-log4.txt
+xdebug.remote_autostart=1
+xdebug.remote_host=unix:///tmp/xdbg.sock
+xdebug.remote_port=0
+--FILE--
+<?php
+if (sys_get_temp_dir() !== '/tmp') die('Unexpected temp dir: '.sys_get_temp_dir());
+echo strlen("foo"), "\n";
+echo file_get_contents(sys_get_temp_dir() . "/remote-log4.txt");
+unlink (sys_get_temp_dir() . "/remote-log4.txt");
+?>
+--EXPECTF--
+3
+Log opened at %d-%d-%d %d:%d:%d
+I: Connecting to configured address/port: unix:///tmp/xdbg.sock:0.
+W: Creating socket for 'unix:///tmp/xdbg.sock', connect: No such file or directory.
+E: Could not connect to client. :-(
+Log closed at %d-%d-%d %d:%d:%d
+
+Log opened at %d-%d-%d %d:%d:%d
+I: Connecting to configured address/port: unix:///tmp/xdbg.sock:0.
+W: Creating socket for 'unix:///tmp/xdbg.sock', connect: No such file or directory.
+E: Could not connect to client. :-(
+Log closed at %d-%d-%d %d:%d:%d

--- a/xdebug_stack.c
+++ b/xdebug_stack.c
@@ -619,6 +619,12 @@ void xdebug_init_debugger(TSRMLS_D)
 			XDEBUG_LOG_PRINT(XG(remote_log_file), "I: Checking header 'REMOTE_ADDR'.\n");
 			XDEBUG_ZEND_HASH_STR_FIND(PG(http_globals)[TRACK_VARS_SERVER], "REMOTE_ADDR", HASH_KEY_SIZEOF("REMOTE_ADDR"), remote_addr);
 		}
+
+		if (remote_addr && strstr(XDEBUG_ZEND_HASH_RETURN_VALUE(remote_addr), "://")) {
+			XDEBUG_LOG_PRINT(XG(remote_log_file), "W: Invalid remote address provided containing URI spec '%s'.\n", XDEBUG_ZEND_HASH_RETURN_VALUE(remote_addr));
+			remote_addr = NULL;
+		}
+
 		if (remote_addr) {
 			XDEBUG_LOG_PRINT(XG(remote_log_file), "I: Remote address found, connecting to %s:%ld.\n", XDEBUG_ZEND_HASH_RETURN_VALUE(remote_addr), (long int) XG(remote_port));
 			XG(context).socket = xdebug_create_socket(XDEBUG_ZEND_HASH_RETURN_VALUE(remote_addr), XG(remote_port) TSRMLS_CC);


### PR DESCRIPTION
xdebug.remote_host = unix:///var/run/xdebug.sock

The unix socket path is much lighter weight than the TCP path since:
a) We don't have to #ifdef all over the place about windows
b) async connects are a non-issue
c) No getaddrinfo abstraction