### PR TITLE
Always read property silently

### DIFF
--- a/xdebug_var.c
+++ b/xdebug_var.c
@@ -549,10 +549,10 @@ static zval* fetch_zval_from_symbol_table(zval *parent, char* name, unsigned int
 
 #if PHP_VERSION_ID >= 70000
 				zval dummy;
-				tmp_val = zend_read_property(cce, parent, name, name_length, 0, &dummy);
+				tmp_val = zend_read_property(cce, parent, name, name_length, 1, &dummy);
 				if (tmp_val && tmp_val != &EG(uninitialized_zval)) {
 #else
-				tmp_val = zend_read_property(cce, parent, name, name_length, 0 TSRMLS_CC);
+				tmp_val = zend_read_property(cce, parent, name, name_length, 1 TSRMLS_CC);
 				if (tmp_val && tmp_val != EG(uninitialized_zval_ptr)) {
 #endif
 					retval_p = tmp_val;


### PR DESCRIPTION
As was mentioned in #316 we can use "silent" reads in `property_get`, this gets rid of Notices when inspecting variables in the debugging session.