### PR TITLE
Fixed issue #1386: Executable code not shown as executed/executable

### DIFF
--- a/tests/bug01386-class1.inc
+++ b/tests/bug01386-class1.inc
@@ -1,0 +1,12 @@
+<?php
+// TestClass.php
+class TestClass extends TestClass2 {
+
+    public function test()
+    {
+        $a = 5*5;
+        $b = $a*2;
+        return $b;
+    }
+}
+?>

--- a/tests/bug01386-class2.inc
+++ b/tests/bug01386-class2.inc
@@ -1,0 +1,12 @@
+<?php
+// TestClass2.php
+class TestClass2 {
+
+    public function test()
+    {
+        $a = 5*5;
+        $b = $a*2;
+        return $b;
+    }
+}
+?>

--- a/tests/bug01386.phpt
+++ b/tests/bug01386.phpt
@@ -1,0 +1,67 @@
+--TEST--
+Test for bug #1386: Executable code not shown as executed/executable
+--INI--
+xdebug.default_enable=1
+xdebug.auto_trace=0
+xdebug.trace_options=0
+xdebug.trace_output_dir=/tmp
+xdebug.collect_params=1
+xdebug.collect_return=0
+xdebug.collect_assignments=0
+xdebug.auto_profile=0
+xdebug.profiler_enable=0
+xdebug.dump_globals=0
+xdebug.show_mem_delta=0
+xdebug.trace_format=0
+xdebug.extended_info=1
+xdebug.coverage_enable=1
+xdebug.overload_var_dump=0
+--FILE--
+<?php
+xdebug_start_code_coverage(XDEBUG_CC_UNUSED | XDEBUG_CC_DEAD_CODE);
+
+include 'bug01386-class2.inc';
+include 'bug01386-class1.inc';
+
+$Test1 = new TestClass();
+
+$cc = xdebug_get_code_coverage();
+ksort($cc);
+var_dump(array_slice($cc, 0, 2));
+
+xdebug_stop_code_coverage(false);
+?>
+--EXPECTF--
+array(2) {
+  ["%sbug01386-class1.inc"]=>
+  array(6) {
+    [3]=>
+    int(1)
+    [7]=>
+    int(-1)
+    [8]=>
+    int(-1)
+    [9]=>
+    int(-1)
+    [10]=>
+    int(-2)
+    [13]=>
+    int(1)
+  }
+  ["%sbug01386-class2.inc"]=>
+  array(6) {
+    [3]=>
+    int(1)
+    [7]=>
+    int(-1)
+    [8]=>
+    int(-1)
+    [9]=>
+    int(-1)
+    [10]=>
+    int(-2)
+    [13]=>
+    int(1)
+  }
+}
+

--- a/xdebug_private.h
+++ b/xdebug_private.h
@@ -129,7 +129,7 @@ typedef struct xdebug_var {
 
 #define XDEBUG_ERROR_ENCODING_NOT_SUPPORTED        900
 
-#define ZEND_XDEBUG_VISITED 0x1000000
+#define ZEND_XDEBUG_VISITED 0x10000000
 
 typedef struct _xdebug_func {
 	char *class;


### PR DESCRIPTION
This was due to a clash between ZEND_ACC_USE_GUARDS and ZEND_XDEBUG_VISITED.