### PR TITLE
Fixed issue #1391: Add backtrack for xdebug_call_* functions

### DIFF
--- a/tests/xdebug_call.phpt
+++ b/tests/xdebug_call.phpt
@@ -56,20 +56,20 @@ echo "\n";
 $a->aa( 1 );
 ?>
 --EXPECTF--
-1: >{main} @ %sxdebug_call.php:33
+1: >{main} @ %sxdebug_call.php:0
 
-1: >{main} @ %sxdebug_call.php:35
-2: >c @ %sxdebug_call.php:25
+1: >{main} @ %sxdebug_call.php:0
+2: >c @ %sxdebug_call.php:35
 
-1: >{main} @ %sxdebug_call.php:37
-2: a>b @ %sxdebug_call.php:18
-3: >c @ %sxdebug_call.php:25
+1: >{main} @ %sxdebug_call.php:0
+2: a>b @ %sxdebug_call.php:37
+3: >c @ %sxdebug_call.php:18
 
-1: >{main} @ %sxdebug_call.php:39
-2: a>__construct @ %sxdebug_call.php:6
-3: >c @ %sxdebug_call.php:25
+1: >{main} @ %sxdebug_call.php:0
+2: a>__construct @ %sxdebug_call.php:39
+3: >c @ %sxdebug_call.php:6
 
-1: >{main} @ %sxdebug_call.php:41
-2: a>aa @ %sxdebug_call.php:12
-3: a>b @ %sxdebug_call.php:18
-4: >c @ %sxdebug_call.php:25
+1: >{main} @ %sxdebug_call.php:0
+2: a>aa @ %sxdebug_call.php:41
+3: a>b @ %sxdebug_call.php:12
+4: >c @ %sxdebug_call.php:18

--- a/tests/xdebug_call_depth-1.phpt
+++ b/tests/xdebug_call_depth-1.phpt
@@ -1,0 +1,75 @@
+--TEST--
+Test for xdebug_call_*(-1)
+--INI--
+xdebug.default_enable=1
+xdebug.auto_trace=0
+xdebug.trace_options=0
+xdebug.trace_output_dir=/tmp
+xdebug.collect_return=0
+xdebug.collect_params=0
+xdebug.auto_profile=0
+xdebug.profiler_enable=0
+xdebug.dump_globals=0
+xdebug.show_mem_delta=0
+xdebug.trace_format=0
+--FILE--
+<?php
+class a {
+	public function __construct( $var )
+	{
+		echo $var, ': ', xdebug_call_class(-1), '>', xdebug_call_function(-1), ' @ ', xdebug_call_file(-1), ':', xdebug_call_line(-1), "\n";
+		c( $var + 1);
+	}
+
+	public function aa( $var )
+	{
+		echo $var, ': ', xdebug_call_class(-1), '>', xdebug_call_function(-1), ' @ ', xdebug_call_file(-1), ':', xdebug_call_line(-1), "\n";
+		a::b( $var + 1 );
+	}
+
+	static public function b( $var )
+	{
+		echo $var, ': ', xdebug_call_class(-1), '>', xdebug_call_function(-1), ' @ ', xdebug_call_file(-1), ':', xdebug_call_line(-1), "\n";
+		c( $var + 1);
+	}
+}
+
+function c( $var )
+{
+	echo $var, ': ', xdebug_call_class(-1), '>', xdebug_call_function(-1), ' @ ', xdebug_call_file(-1), ':', xdebug_call_line(-1), "\n";
+	d( $var + 1 );
+}
+
+function d( $var )
+{
+	echo $var, ': ', xdebug_call_class(-1), '>', xdebug_call_function(-1), ' @ ', xdebug_call_file(-1), ':', xdebug_call_line(-1), "\n";
+}
+
+d( 1 );
+echo "\n";
+c( 1 );
+echo "\n";
+a::b( 1 );
+echo "\n";
+$a = new a( 1 );
+echo "\n";
+$a->aa( 1 );
+?>
+--EXPECTF--
+1: > @ :
+
+1: > @ :
+2: > @ :
+
+1: > @ :
+2: > @ :
+3: > @ :
+
+1: > @ :
+2: > @ :
+3: > @ :
+
+1: > @ :
+2: > @ :
+3: > @ :
+4: > @ :

--- a/tests/xdebug_call_depth0.phpt
+++ b/tests/xdebug_call_depth0.phpt
@@ -1,0 +1,75 @@
+--TEST--
+Test for xdebug_call_*(0)
+--INI--
+xdebug.default_enable=1
+xdebug.auto_trace=0
+xdebug.trace_options=0
+xdebug.trace_output_dir=/tmp
+xdebug.collect_return=0
+xdebug.collect_params=0
+xdebug.auto_profile=0
+xdebug.profiler_enable=0
+xdebug.dump_globals=0
+xdebug.show_mem_delta=0
+xdebug.trace_format=0
+--FILE--
+<?php
+class a {
+	public function __construct( $var )
+	{
+		echo $var, ': ', xdebug_call_class(0), '>', xdebug_call_function(0), ' @ ', xdebug_call_file(0), ':', xdebug_call_line(0), "\n";
+		c( $var + 1);
+	}
+
+	public function aa( $var )
+	{
+		echo $var, ': ', xdebug_call_class(0), '>', xdebug_call_function(0), ' @ ', xdebug_call_file(0), ':', xdebug_call_line(0), "\n";
+		a::b( $var + 1 );
+	}
+
+	static public function b( $var )
+	{
+		echo $var, ': ', xdebug_call_class(0), '>', xdebug_call_function(0), ' @ ', xdebug_call_file(0), ':', xdebug_call_line(0), "\n";
+		c( $var + 1);
+	}
+}
+
+function c( $var )
+{
+	echo $var, ': ', xdebug_call_class(0), '>', xdebug_call_function(0), ' @ ', xdebug_call_file(0), ':', xdebug_call_line(0), "\n";
+	d( $var + 1 );
+}
+
+function d( $var )
+{
+	echo $var, ': ', xdebug_call_class(0), '>', xdebug_call_function(0), ' @ ', xdebug_call_file(0), ':', xdebug_call_line(0), "\n";
+}
+
+d( 1 );
+echo "\n";
+c( 1 );
+echo "\n";
+a::b( 1 );
+echo "\n";
+$a = new a( 1 );
+echo "\n";
+$a->aa( 1 );
+?>
+--EXPECTF--
+1: >xdebug_call_function @ %sxdebug_call_depth0.php:30
+
+1: >xdebug_call_function @ %sxdebug_call_depth0.php:24
+2: >xdebug_call_function @ %sxdebug_call_depth0.php:30
+
+1: >xdebug_call_function @ %sxdebug_call_depth0.php:17
+2: >xdebug_call_function @ %sxdebug_call_depth0.php:24
+3: >xdebug_call_function @ %sxdebug_call_depth0.php:30
+
+1: >xdebug_call_function @ %sxdebug_call_depth0.php:5
+2: >xdebug_call_function @ %sxdebug_call_depth0.php:24
+3: >xdebug_call_function @ %sxdebug_call_depth0.php:30
+
+1: >xdebug_call_function @ %sxdebug_call_depth0.php:11
+2: >xdebug_call_function @ %sxdebug_call_depth0.php:17
+3: >xdebug_call_function @ %sxdebug_call_depth0.php:24
+4: >xdebug_call_function @ %sxdebug_call_depth0.php:30

--- a/tests/xdebug_call_depth1.phpt
+++ b/tests/xdebug_call_depth1.phpt
@@ -56,20 +56,20 @@ echo "\n";
 $a->aa( 1 );
 ?>
 --EXPECTF--
-1: > @ %sxdebug_call_depth.php:0
+1: >d @ %sxdebug_call_depth1.php:33
 
-1: > @ %sxdebug_call_depth.php:0
-2: >{main} @ %sxdebug_call_depth.php:35
+1: >c @ %sxdebug_call_depth1.php:35
+2: >d @ %sxdebug_call_depth1.php:25
 
-1: > @ %sxdebug_call_depth.php:0
-2: >{main} @ %sxdebug_call_depth.php:37
-3: a>b @ %sxdebug_call_depth.php:18
+1: a>b @ %sxdebug_call_depth1.php:37
+2: >c @ %sxdebug_call_depth1.php:18
+3: >d @ %sxdebug_call_depth1.php:25
 
-1: > @ %sxdebug_call_depth.php:0
-2: >{main} @ %sxdebug_call_depth.php:39
-3: a>__construct @ %sxdebug_call_depth.php:6
+1: a>__construct @ %sxdebug_call_depth1.php:39
+2: >c @ %sxdebug_call_depth1.php:6
+3: >d @ %sxdebug_call_depth1.php:25
 
-1: > @ %sxdebug_call_depth.php:0
-2: >{main} @ %sxdebug_call_depth.php:41
-3: a>aa @ %sxdebug_call_depth.php:12
-4: a>b @ %sxdebug_call_depth.php:18
+1: a>aa @ %sxdebug_call_depth1.php:41
+2: a>b @ %sxdebug_call_depth1.php:12
+3: >c @ %sxdebug_call_depth1.php:18
+4: >d @ %sxdebug_call_depth1.php:25

--- a/tests/xdebug_call_depth2.phpt
+++ b/tests/xdebug_call_depth2.phpt
@@ -56,20 +56,20 @@ echo "\n";
 $a->aa( 1 );
 ?>
 --EXPECTF--
-1: > @ :
+1: >{main} @ %sxdebug_call_depth2.php:0
 
-1: > @ :
-2: > @ %sxdebug_call_depth2.php:0
+1: >{main} @ %sxdebug_call_depth2.php:0
+2: >c @ %sxdebug_call_depth2.php:35
 
-1: > @ :
-2: > @ %sxdebug_call_depth2.php:0
-3: >{main} @ %sxdebug_call_depth2.php:37
+1: >{main} @ %sxdebug_call_depth2.php:0
+2: a>b @ %sxdebug_call_depth2.php:37
+3: >c @ %sxdebug_call_depth2.php:18
 
-1: > @ :
-2: > @ %sxdebug_call_depth2.php:0
-3: >{main} @ %sxdebug_call_depth2.php:39
+1: >{main} @ %sxdebug_call_depth2.php:0
+2: a>__construct @ %sxdebug_call_depth2.php:39
+3: >c @ %sxdebug_call_depth2.php:6
 
-1: > @ :
-2: > @ %sxdebug_call_depth2.php:0
-3: >{main} @ %sxdebug_call_depth2.php:41
-4: a>aa @ %sxdebug_call_depth2.php:12
+1: >{main} @ %sxdebug_call_depth2.php:0
+2: a>aa @ %sxdebug_call_depth2.php:41
+3: a>b @ %sxdebug_call_depth2.php:12
+4: >c @ %sxdebug_call_depth2.php:18

--- a/tests/xdebug_call_depth3.phpt
+++ b/tests/xdebug_call_depth3.phpt
@@ -1,0 +1,75 @@
+--TEST--
+Test for xdebug_call_*(3)
+--INI--
+xdebug.default_enable=1
+xdebug.auto_trace=0
+xdebug.trace_options=0
+xdebug.trace_output_dir=/tmp
+xdebug.collect_return=0
+xdebug.collect_params=0
+xdebug.auto_profile=0
+xdebug.profiler_enable=0
+xdebug.dump_globals=0
+xdebug.show_mem_delta=0
+xdebug.trace_format=0
+--FILE--
+<?php
+class a {
+	public function __construct( $var )
+	{
+		echo $var, ': ', xdebug_call_class(3), '>', xdebug_call_function(3), ' @ ', xdebug_call_file(3), ':', xdebug_call_line(3), "\n";
+		c( $var + 1);
+	}
+
+	public function aa( $var )
+	{
+		echo $var, ': ', xdebug_call_class(3), '>', xdebug_call_function(3), ' @ ', xdebug_call_file(3), ':', xdebug_call_line(3), "\n";
+		a::b( $var + 1 );
+	}
+
+	static public function b( $var )
+	{
+		echo $var, ': ', xdebug_call_class(3), '>', xdebug_call_function(3), ' @ ', xdebug_call_file(3), ':', xdebug_call_line(3), "\n";
+		c( $var + 1);
+	}
+}
+
+function c( $var )
+{
+	echo $var, ': ', xdebug_call_class(3), '>', xdebug_call_function(3), ' @ ', xdebug_call_file(3), ':', xdebug_call_line(3), "\n";
+	d( $var + 1 );
+}
+
+function d( $var )
+{
+	echo $var, ': ', xdebug_call_class(3), '>', xdebug_call_function(3), ' @ ', xdebug_call_file(3), ':', xdebug_call_line(3), "\n";
+}
+
+d( 1 );
+echo "\n";
+c( 1 );
+echo "\n";
+a::b( 1 );
+echo "\n";
+$a = new a( 1 );
+echo "\n";
+$a->aa( 1 );
+?>
+--EXPECTF--
+1: > @ :
+
+1: > @ :
+2: >{main} @ %sxdebug_call_depth3.php:0
+
+1: > @ :
+2: >{main} @ %sxdebug_call_depth3.php:0
+3: a>b @ %sxdebug_call_depth3.php:37
+
+1: > @ :
+2: >{main} @ %sxdebug_call_depth3.php:0
+3: a>__construct @ %sxdebug_call_depth3.php:39
+
+1: > @ :
+2: >{main} @ %sxdebug_call_depth3.php:0
+3: a>aa @ %sxdebug_call_depth3.php:41
+4: a>b @ %sxdebug_call_depth3.php:12

--- a/xdebug_private.c
+++ b/xdebug_private.c
@@ -48,6 +48,10 @@ function_stack_entry *xdebug_get_stack_frame(int nr TSRMLS_DC)
 		return NULL;
 	}
 
+	if (nr < 0) {
+		return NULL;
+	}
+
 	while (nr) {
 		nr--;
 		le = XDEBUG_LLIST_PREV(le);

--- a/xdebug_stack.c
+++ b/xdebug_stack.c
@@ -860,16 +860,20 @@ PHP_FUNCTION(xdebug_get_formatted_function_stack)
 PHP_FUNCTION(xdebug_call_class)
 {
 	function_stack_entry *i;
-	zend_long depth = 0;
+	zend_long depth = 2;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|l", &depth) == FAILURE) {
 		return;
 	}
-	i = xdebug_get_stack_frame(2 + depth TSRMLS_CC);
+	i = xdebug_get_stack_frame(depth TSRMLS_CC);
 	if (i) {
-		RETURN_STRING(i->function.class ? i->function.class : "");
+		if (i->function.class) {
+			RETURN_STRING(i->function.class);
+		} else {
+			RETURN_FALSE;
+		}
 	} else {
-		RETURN_FALSE;
+		return;
 	}
 }
 /* }}} */
@@ -879,16 +883,20 @@ PHP_FUNCTION(xdebug_call_class)
 PHP_FUNCTION(xdebug_call_function)
 {
 	function_stack_entry *i;
-	zend_long depth = 0;
+	zend_long depth = 2;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|l", &depth) == FAILURE) {
 		return;
 	}
-	i = xdebug_get_stack_frame(2 + depth TSRMLS_CC);
+	i = xdebug_get_stack_frame(depth TSRMLS_CC);
 	if (i) {
-		RETURN_STRING(i->function.function ? i->function.function : "{}");
+		if (i->function.function) {
+			RETURN_STRING(i->function.function);
+		} else {
+			RETURN_FALSE;
+		}
 	} else {
-		RETURN_FALSE;
+		return;
 	}
 }
 /* }}} */
@@ -898,16 +906,16 @@ PHP_FUNCTION(xdebug_call_function)
 PHP_FUNCTION(xdebug_call_line)
 {
 	function_stack_entry *i;
-	zend_long depth = 0;
+	zend_long depth = 2;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|l", &depth) == FAILURE) {
 		return;
 	}
-	i = xdebug_get_stack_frame(1 + depth TSRMLS_CC);
+	i = xdebug_get_stack_frame(depth TSRMLS_CC);
 	if (i) {
 		RETURN_LONG(i->lineno);
 	} else {
-		RETURN_FALSE;
+		return;
 	}
 }
 /* }}} */
@@ -917,16 +925,16 @@ PHP_FUNCTION(xdebug_call_line)
 PHP_FUNCTION(xdebug_call_file)
 {
 	function_stack_entry *i;
-	zend_long depth = 0;
+	zend_long depth = 2;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|l", &depth) == FAILURE) {
 		return;
 	}
-	i = xdebug_get_stack_frame(1 + depth TSRMLS_CC);
+	i = xdebug_get_stack_frame(depth TSRMLS_CC);
 	if (i) {
 		RETURN_STRING(i->filename);
 	} else {
-		RETURN_FALSE;
+		return;
 	}
 }
 /* }}} */


### PR DESCRIPTION
This was already sort of implemented, but not well, and no documentation
either. So this is a minor BC of an undocumented feature.