### PR TITLE
Fix set_time_limit hanging on PHP 5.6 when pcntl_exec does not exist

### DIFF
--- a/xdebug.c
+++ b/xdebug.c
@@ -1292,7 +1292,9 @@ PHP_RINIT_FUNCTION(xdebug)
 #if PHP_VERSION_ID >= 70000
 	orig = zend_hash_str_find_ptr(EG(function_table), "pcntl_exec", sizeof("pcntl_exec") - 1);
 #else
-	zend_hash_find(EG(function_table), "pcntl_exec", sizeof("pcntl_exec"), (void **)&orig);
+	if (zend_hash_find(EG(function_table), "pcntl_exec", sizeof("pcntl_exec"), (void **)&orig) == FAILURE) {
+		orig = NULL;
+	}
 #endif
 	if (orig) {
 		XG(orig_pcntl_exec_func) = orig->internal_function.handler;


### PR DESCRIPTION
This is a fix for https://bugs.xdebug.org/view.php?id=1424 where set_time_limit() would hang until the old time limit expired, if pcntl_exec is not defined, when using PHP 5.6.