### PR TITLE
Fix path_info leak, Leak appears in 362 test cases (all unskipped tests in php 7.1)

### DIFF
--- a/xdebug_branch_info.c
+++ b/xdebug_branch_info.c
@@ -279,6 +279,7 @@ void xdebug_path_info_dtor(xdebug_path_info *path_info)
 		xdebug_hash_destroy(path_info->path_hash);
 		path_info->path_hash = NULL;
 	}
+	xdfree(path_info);
 }
 
 void xdebug_create_key_for_path(xdebug_path *path, xdebug_str *str)


### PR DESCRIPTION
Some basic test cases that leak only here(and not leaking anywhere else)
```
001.phpt
assert_test001.phpt through 003
assignment-trace1.phpt through 11
auto_trace.phpt
```
The memory tests may not pick up this leak if you're not using --leak-check=yes

changing line 1854 of the generate run-tests.php to 

```
$cmd = "valgrind -q --leak-check=yes --tool=memcheck --trace-children=yes --vex-iropt-register-updates=allregs-at-mem-access --log-file=$memcheck_filename $cmd";
```

does the trick for me.