### PR TITLE
Fix leak several memory leaks

### DIFF
--- a/tests/function_breakpoint_leak.inc
+++ b/tests/function_breakpoint_leak.inc
@@ -1,0 +1,4 @@
+<?php
+z();
+function z(){}
+?>

--- a/tests/function_breakpoint_leak.phpt
+++ b/tests/function_breakpoint_leak.phpt
@@ -19,7 +19,7 @@ dbgpRun( $data, $commands );
 ?>
 --EXPECTF--
 <?xml version="1.0" encoding="iso-8859-1"?>
-<init xmlns="urn:debugger_protocol_v1" xmlns:xdebug="http://xdebug.org/dbgp/xdebug" fileuri="file:///%sxdebug-dbgp-test.php" language="PHP" xdebug:language_version="" protocol_version="1.0" appid=""><engine version=""><![CDATA[Xdebug]]></engine><author><![CDATA[Derick Rethans]]></author><url><![CDATA[http://xdebug.org]]></url><copyright><![CDATA[Copyright (c) 2002-2099 by Derick Rethans]]></copyright></init>
+<init xmlns="urn:debugger_protocol_v1" xmlns:xdebug="http://xdebug.org/dbgp/xdebug" fileuri="file:///%sxdebug-dbgp-test.php" language="PHP" xdebug:language_version="" protocol_version="1.0" appid=""><engine version=""><![CDATA[Xdebug]]></engine><author><![CDATA[Derick Rethans]]></author><url><![CDATA[http://xdebug.org]]></url><copyright><![CDATA[Copyright (c) 2002-%d by Derick Rethans]]></copyright></init>
 
 -> step_into -i 1
 <?xml version="1.0" encoding="iso-8859-1"?>

--- a/tests/function_breakpoint_leak.phpt
+++ b/tests/function_breakpoint_leak.phpt
@@ -19,11 +19,11 @@ dbgpRun( $data, $commands );
 ?>
 --EXPECTF--
 <?xml version="1.0" encoding="iso-8859-1"?>
-<init xmlns="urn:debugger_protocol_v1" xmlns:xdebug="http://xdebug.org/dbgp/xdebug" fileuri="file:///tmp/xdebug-dbgp-test.php" language="PHP" xdebug:language_version="" protocol_version="1.0" appid=""><engine version=""><![CDATA[Xdebug]]></engine><author><![CDATA[Derick Rethans]]></author><url><![CDATA[http://xdebug.org]]></url><copyright><![CDATA[Copyright (c) 2002-2099 by Derick Rethans]]></copyright></init>
+<init xmlns="urn:debugger_protocol_v1" xmlns:xdebug="http://xdebug.org/dbgp/xdebug" fileuri="file:///%sxdebug-dbgp-test.php" language="PHP" xdebug:language_version="" protocol_version="1.0" appid=""><engine version=""><![CDATA[Xdebug]]></engine><author><![CDATA[Derick Rethans]]></author><url><![CDATA[http://xdebug.org]]></url><copyright><![CDATA[Copyright (c) 2002-2099 by Derick Rethans]]></copyright></init>
 
 -> step_into -i 1
 <?xml version="1.0" encoding="iso-8859-1"?>
-<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="http://xdebug.org/dbgp/xdebug" command="step_into" transaction_id="1" status="break" reason="ok"><xdebug:message filename="file:///tmp/xdebug-dbgp-test.php" lineno="2"></xdebug:message></response>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="http://xdebug.org/dbgp/xdebug" command="step_into" transaction_id="1" status="break" reason="ok"><xdebug:message filename="file:///%sxdebug-dbgp-test.php" lineno="2"></xdebug:message></response>
 
 -> breakpoint_set -i 2 -t call -m z
 <?xml version="1.0" encoding="iso-8859-1"?>
@@ -35,7 +35,7 @@ dbgpRun( $data, $commands );
 
 -> run -i 4
 <?xml version="1.0" encoding="iso-8859-1"?>
-<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="http://xdebug.org/dbgp/xdebug" command="run" transaction_id="4" status="break" reason="ok"><xdebug:message filename="file:///tmp/xdebug-dbgp-test.php" lineno="4"></xdebug:message></response>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="http://xdebug.org/dbgp/xdebug" command="run" transaction_id="4" status="break" reason="ok"><xdebug:message filename="file:///%sxdebug-dbgp-test.php" lineno="3"></xdebug:message></response>
 
 -> detach -i 5
 <?xml version="1.0" encoding="iso-8859-1"?>

--- a/tests/function_breakpoint_leak.phpt
+++ b/tests/function_breakpoint_leak.phpt
@@ -19,7 +19,7 @@ dbgpRun( $data, $commands );
 ?>
 --EXPECTF--
 <?xml version="1.0" encoding="iso-8859-1"?>
-<init xmlns="urn:debugger_protocol_v1" xmlns:xdebug="http://xdebug.org/dbgp/xdebug" fileuri="file:///%sxdebug-dbgp-test.php" language="PHP" xdebug:language_version="" protocol_version="1.0" appid=""><engine version=""><![CDATA[Xdebug]]></engine><author><![CDATA[Derick Rethans]]></author><url><![CDATA[http://xdebug.org]]></url><copyright><![CDATA[Copyright (c) 2002-%d by Derick Rethans]]></copyright></init>
+<init xmlns="urn:debugger_protocol_v1" xmlns:xdebug="http://xdebug.org/dbgp/xdebug" fileuri="file:///%sxdebug-dbgp-test.php" language="PHP" xdebug:language_version="" protocol_version="1.0" appid="" idekey=""><engine version=""><![CDATA[Xdebug]]></engine><author><![CDATA[Derick Rethans]]></author><url><![CDATA[http://xdebug.org]]></url><copyright><![CDATA[Copyright (c) 2002-%d by Derick Rethans]]></copyright></init>
 
 -> step_into -i 1
 <?xml version="1.0" encoding="iso-8859-1"?>

--- a/tests/function_breakpoint_leak.phpt
+++ b/tests/function_breakpoint_leak.phpt
@@ -1,0 +1,42 @@
+--TEST--
+Test for memory leak; calling breakpoint_list after setting exception/function breakpoints leaks
+--SKIPIF--
+<?php if (getenv("SKIP_DBGP_TESTS")) { exit("skip Excluding DBGp tests"); } ?>
+--FILE--
+<?php
+require 'dbgp/dbgpclient.php';
+$data = file_get_contents(dirname(__FILE__) . '/function_breakpoint_leak.inc');
+
+$commands = array(
+	'step_into',
+	'breakpoint_set -t call -m z',
+	'breakpoint_list',
+	'run',
+	'detach'
+);
+
+dbgpRun( $data, $commands );
+?>
+--EXPECTF--
+<?xml version="1.0" encoding="iso-8859-1"?>
+<init xmlns="urn:debugger_protocol_v1" xmlns:xdebug="http://xdebug.org/dbgp/xdebug" fileuri="file:///tmp/xdebug-dbgp-test.php" language="PHP" xdebug:language_version="" protocol_version="1.0" appid=""><engine version=""><![CDATA[Xdebug]]></engine><author><![CDATA[Derick Rethans]]></author><url><![CDATA[http://xdebug.org]]></url><copyright><![CDATA[Copyright (c) 2002-2099 by Derick Rethans]]></copyright></init>
+
+-> step_into -i 1
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="http://xdebug.org/dbgp/xdebug" command="step_into" transaction_id="1" status="break" reason="ok"><xdebug:message filename="file:///tmp/xdebug-dbgp-test.php" lineno="2"></xdebug:message></response>
+
+-> breakpoint_set -i 2 -t call -m z
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="http://xdebug.org/dbgp/xdebug" command="breakpoint_set" transaction_id="2" id=""></response>
+
+-> breakpoint_list -i 3
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="http://xdebug.org/dbgp/xdebug" command="breakpoint_list" transaction_id="3"><breakpoint type="call" function="z" state="enabled" hit_count="0" hit_value="0" id=""></breakpoint></response>
+
+-> run -i 4
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="http://xdebug.org/dbgp/xdebug" command="run" transaction_id="4" status="break" reason="ok"><xdebug:message filename="file:///tmp/xdebug-dbgp-test.php" lineno="4"></xdebug:message></response>
+
+-> detach -i 5
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="http://xdebug.org/dbgp/xdebug" command="detach" transaction_id="5" status="stopping" reason="ok"></response>

--- a/xdebug_handler_dbgp.c
+++ b/xdebug_handler_dbgp.c
@@ -541,13 +541,14 @@ static xdebug_brk_info* breakpoint_brk_info_fetch(int type, char *hkey)
 {
 	xdebug_llist_element *le;
 	xdebug_brk_info      *brk_info = NULL;
-	xdebug_arg           *parts = (xdebug_arg*) xdmalloc(sizeof(xdebug_arg));
+	xdebug_arg           *parts = NULL;
 
 	TSRMLS_FETCH();
 
 	switch (type) {
 		case BREAKPOINT_TYPE_LINE:
 			/* First we split the key into filename and linenumber */
+			parts = (xdebug_arg*) xdmalloc(sizeof(xdebug_arg));
 			xdebug_arg_init(parts);
 			xdebug_explode("$", hkey, parts, -1);
 

--- a/xdebug_handler_dbgp.c
+++ b/xdebug_handler_dbgp.c
@@ -586,13 +586,14 @@ static int breakpoint_remove(int type, char *hkey)
 {
 	xdebug_llist_element *le;
 	xdebug_brk_info      *brk_info = NULL;
-	xdebug_arg           *parts = (xdebug_arg*) xdmalloc(sizeof(xdebug_arg));
+	xdebug_arg           *parts = NULL;
 	int                   retval = FAILURE;
 	TSRMLS_FETCH();
 
 	switch (type) {
 		case BREAKPOINT_TYPE_LINE:
 			/* First we split the key into filename and linenumber */
+			parts = (xdebug_arg*) xdmalloc(sizeof(xdebug_arg));
 			xdebug_arg_init(parts);
 			xdebug_explode("$", hkey, parts, -1);
 

--- a/xdebug_handler_dbgp.c
+++ b/xdebug_handler_dbgp.c
@@ -366,6 +366,7 @@ static char* return_eval_source(char *id, int begin, int end TSRMLS_DC)
 		xdebug_arg_dtor(parts);
 		return joined;
 	}
+	xdfree(parts);
 	return NULL;
 }
 


### PR DESCRIPTION
Fixes a leak caused by setting function/exception breakpoints then listing them with a breakpoint_list command.

Test case added.

Note, --leak-check=yes needs to be added to the `valgrind` command genereated by `run-tests.php` to test for leaks

