### PR TITLE
Used EG(active) instead of Removed EG(valid_symbol_table) - 7.2.0alpha3

### DIFF
--- a/xdebug_stack.c
+++ b/xdebug_stack.c
@@ -800,7 +800,11 @@ void xdebug_error_cb(int type, const char *error_filename, const uint error_line
 			break;
 	}
 
+#if PHP_VERSION_ID >= 70200
+	if (PG(track_errors) && EG(active)) {
+#else
 	if (PG(track_errors) && EG(valid_symbol_table)) {
+#endif
 		zval tmp;
 		ZVAL_STRINGL(&tmp, buffer, buffer_len);
 


### PR DESCRIPTION
Related to https://bugs.xdebug.org/view.php?id=1452
See http://git.php.net/?p=php-src.git;a=commitdiff;h=caaeb4849aa56cbbdc66ea015c11a58bd47a43ff
