### PR TITLE
Port garbage_stats extension into a new xdebug feature.

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -30,7 +30,7 @@ if test "$PHP_XDEBUG" != "no"; then
 
   CPPFLAGS=$old_CPPFLAGS
 
-  PHP_NEW_EXTENSION(xdebug, xdebug.c xdebug_branch_info.c xdebug_code_coverage.c xdebug_com.c xdebug_compat.c xdebug_filter.c xdebug_handler_dbgp.c xdebug_handlers.c xdebug_llist.c xdebug_monitor.c xdebug_hash.c xdebug_private.c xdebug_profiler.c xdebug_set.c xdebug_stack.c xdebug_str.c xdebug_superglobals.c xdebug_tracing.c xdebug_trace_textual.c xdebug_trace_computerized.c xdebug_trace_html.c xdebug_var.c xdebug_xml.c usefulstuff.c, $ext_shared,,,,yes)
+  PHP_NEW_EXTENSION(xdebug, xdebug.c xdebug_branch_info.c xdebug_code_coverage.c xdebug_com.c xdebug_compat.c xdebug_gc_stats.c xdebug_filter.c xdebug_handler_dbgp.c xdebug_handlers.c xdebug_llist.c xdebug_monitor.c xdebug_hash.c xdebug_private.c xdebug_profiler.c xdebug_set.c xdebug_stack.c xdebug_str.c xdebug_superglobals.c xdebug_tracing.c xdebug_trace_textual.c xdebug_trace_computerized.c xdebug_trace_html.c xdebug_var.c xdebug_xml.c usefulstuff.c, $ext_shared,,,,yes)
   PHP_SUBST(XDEBUG_SHARED_LIBADD)
   PHP_ADD_MAKEFILE_FRAGMENT
 fi

--- a/config.w32
+++ b/config.w32
@@ -4,13 +4,14 @@
 ARG_WITH("xdebug", "Xdebug support", "no");
 
 if (PHP_XDEBUG != 'no') {
-	var files = 'xdebug.c xdebug_branch_info.c xdebug_code_coverage.c ' + 
-		    'xdebug_com.c xdebug_compat.c xdebug_filter.c xdebug_handler_dbgp.c ' + 
-		    'xdebug_handlers.c xdebug_llist.c xdebug_monitor.c ' + 
-		    'xdebug_hash.c xdebug_private.c xdebug_profiler.c ' + 
-		    'xdebug_set.c xdebug_stack.c xdebug_str.c xdebug_superglobals.c ' + 
-		    'xdebug_tracing.c xdebug_trace_textual.c xdebug_trace_computerized.c ' +
-		    'xdebug_trace_html.c xdebug_var.c xdebug_xml.c usefulstuff.c';
+	var files = 'xdebug.c xdebug_branch_info.c xdebug_code_coverage.c ' +
+		'xdebug_com.c xdebug_compat.c xdebug_filter.c xdebug_gc_stats.c ' +
+		'xdebug_handler_dbgp.c ' +
+		'xdebug_handlers.c xdebug_llist.c xdebug_monitor.c ' +
+		'xdebug_hash.c xdebug_private.c xdebug_profiler.c ' +
+		'xdebug_set.c xdebug_stack.c xdebug_str.c xdebug_superglobals.c ' +
+		'xdebug_tracing.c xdebug_trace_textual.c xdebug_trace_computerized.c ' +
+		'xdebug_trace_html.c xdebug_var.c xdebug_xml.c usefulstuff.c';
 
 	if (typeof(ZEND_EXTENSION) == 'undefined') {
 		EXTENSION('xdebug', files);

--- a/php_xdebug.h
+++ b/php_xdebug.h
@@ -117,6 +117,11 @@ PHP_FUNCTION(xdebug_get_profiler_filename);
 PHP_FUNCTION(xdebug_dump_aggr_profiling_data);
 PHP_FUNCTION(xdebug_clear_aggr_profiling_data);
 
+/* gc stats functions */
+PHP_FUNCTION(xdebug_start_gcstats);
+PHP_FUNCTION(xdebug_stop_gcstats);
+PHP_FUNCTION(xdebug_get_gcstats_filename);
+
 /* misc functions */
 PHP_FUNCTION(xdebug_dump_superglobals);
 PHP_FUNCTION(xdebug_get_headers);
@@ -289,6 +294,14 @@ ZEND_BEGIN_MODULE_GLOBALS(xdebug)
 	/* scream */
 	zend_bool  do_scream;
 	zend_bool  in_at;
+
+	/* garbage stats */
+	zend_bool  gc_stats_enable;
+	zend_bool  gc_stats_enabled;
+	char      *gc_stats_output_dir;
+	char      *gc_stats_output_name;
+	FILE      *gc_stats_file;
+	char      *gc_stats_filename;
 
 	/* in-execution checking */
 	zend_bool  in_execution;

--- a/php_xdebug.h
+++ b/php_xdebug.h
@@ -121,6 +121,8 @@ PHP_FUNCTION(xdebug_clear_aggr_profiling_data);
 PHP_FUNCTION(xdebug_start_gcstats);
 PHP_FUNCTION(xdebug_stop_gcstats);
 PHP_FUNCTION(xdebug_get_gcstats_filename);
+PHP_FUNCTION(xdebug_get_gc_run_count);
+PHP_FUNCTION(xdebug_get_gc_total_collected_roots);
 
 /* misc functions */
 PHP_FUNCTION(xdebug_dump_superglobals);

--- a/tests/xdebug_gc_stats1.phpt
+++ b/tests/xdebug_gc_stats1.phpt
@@ -1,0 +1,18 @@
+--TEST--
+GC Stats: No memleak, return empty runs
+--INI--
+zend.enable_gc=1
+xdebug.gc_stats_enable=1
+--FILE--
+<?php
+echo file_get_contents(xdebug_get_gcstats_filename());
+xdebug_stop_gcstats();
+unlink(xdebug_get_gcstats_filename());
+?>
+--EXPECTF--
+Garbage Collection Report
+version: 1
+creator: xdebug %d.%s (PHP %s)
+
+Collected | Efficiency% | Duration | Memory Before | Memory After | Reduction% | Function
+----------+-------------+----------+---------------+--------------+------------+---------

--- a/tests/xdebug_gc_stats2.phpt
+++ b/tests/xdebug_gc_stats2.phpt
@@ -1,0 +1,31 @@
+--TEST--
+GC Stats: Run gc_collect_cyles(); and collect stats
+--INI--
+zend.enable_gc=1
+xdebug.gc_stats_enable=1
+--FILE--
+<?php
+var_dump(ini_get("xdebug.gc_stats_enable"));
+
+for ($i = 0; $i < 100; $i++) {
+	$a = new stdClass();
+	$b = new stdClass();
+	$b->a = $a;
+	$a->b = $b;
+	unset($a, $b);
+}
+gc_collect_cycles();
+
+echo file_get_contents(xdebug_get_gcstats_filename());
+xdebug_stop_gcstats();
+unlink(xdebug_get_gcstats_filename());
+?>
+--EXPECTF--
+string(1) "1"
+Garbage Collection Report
+version: 1
+creator: xdebug %d.%s (PHP %s)
+
+Collected | Efficiency% | Duration | Memory Before | Memory After | Reduction% | Function
+----------+-------------+----------+---------------+--------------+------------+---------
+      200 |      2.00 % |  %s ms |        %d |       %d |   %s % | gc_collect_cycles

--- a/tests/xdebug_gc_stats3.phpt
+++ b/tests/xdebug_gc_stats3.phpt
@@ -1,0 +1,36 @@
+--TEST--
+GC Stats: Stats about trigger garbage collection automatically
+--INI--
+zend.enable_gc=1
+xdebug.gc_stats_enable=1
+--FILE--
+<?php
+
+gc_enable();
+
+function foo()
+{
+	bar();
+}
+
+function bar()
+{
+	for ($i = 0; $i < 20000; $i++) {
+		$a = new stdClass();
+		$b = new stdClass();
+		$b->a = $a;
+		$a->b = $b;
+		unset($a, $b);
+	}
+}
+
+foo();
+
+$lines = file(xdebug_get_gcstats_filename());
+xdebug_stop_gcstats();
+unlink(xdebug_get_gcstats_filename());
+
+var_dump(count($lines) >= 6);
+?>
+--EXPECTF--
+bool(true)

--- a/tests/xdebug_gc_stats4.phpt
+++ b/tests/xdebug_gc_stats4.phpt
@@ -1,0 +1,61 @@
+--TEST--
+GC Stats: Class with garbage
+--INI--
+zend.enable_gc=1
+xdebug.gc_stats_enable=1
+--FILE--
+<?php
+
+function foo()
+{
+	bar();
+}
+
+function bar()
+{
+	for ($i = 0; $i < 20000; $i++)
+	{
+		$a = new stdClass();
+		$b = new stdClass();
+		$b->a = $a;
+		$a->b = $b;
+		unset($a, $b);
+	}
+}
+
+class Garbage
+{
+	public function produce()
+	{
+		$foo = new stdClass();
+
+		for ($i = 0; $i < 20000; $i++)
+		{
+			$a = new stdClass();
+			$b = new stdClass();
+			$b->foo = $foo;
+			$b->a = $a;
+			$a->b = $b;
+			unset($a, $b);
+		}
+
+		unset($foo);
+		gc_collect_cycles();
+	}
+}
+
+foo();
+(new Garbage())->produce();
+
+$data = file_get_contents(xdebug_get_gcstats_filename());
+xdebug_stop_gcstats();
+unlink(xdebug_get_gcstats_filename());
+
+var_dump(substr_count($data, "bar") >= 3);
+var_dump(substr_count($data, "Garbage::produce") >= 4);
+var_dump(substr_count($data, "gc_collect_cycles") == 1);
+?>
+--EXPECTF--
+bool(true)
+bool(true)
+bool(true)

--- a/tests/xdebug_gc_stats5.phpt
+++ b/tests/xdebug_gc_stats5.phpt
@@ -1,0 +1,46 @@
+--TEST--
+GC Stats: Start with xdebug_start_gcstats()
+--INI--
+zend.enable_gc=1
+xdebug.gc_stats_enable=0
+--FILE--
+<?php
+
+var_dump(ini_get("xdebug.gc_stats_enable"));
+
+for ($i = 0; $i < 100; $i++)
+{
+	$a = new stdClass();
+	$b = new stdClass();
+	$b->a = $a;
+	$a->b = $b;
+	unset($a, $b);
+}
+gc_collect_cycles();
+
+xdebug_start_gcstats();
+
+for ($i = 0; $i < 100; $i++)
+{
+	$a = new stdClass();
+	$b = new stdClass();
+	$b->a = $a;
+	$a->b = $b;
+	unset($a, $b);
+}
+gc_collect_cycles();
+
+echo file_get_contents(xdebug_get_gcstats_filename());
+xdebug_stop_gcstats();
+unlink(xdebug_get_gcstats_filename());
+?>
+--EXPECTF--
+string(1) "0"
+Garbage Collection Report
+version: 1
+creator: xdebug %d.%s (PHP %s)
+
+Collected | Efficiency% | Duration | Memory Before | Memory After | Reduction% | Function
+----------+-------------+----------+---------------+--------------+------------+---------
+      200 |      2.00 % |  %s ms |        %d |       %d |   %s % | gc_collect_cycles
+

--- a/tests/xdebug_gc_stats6.phpt
+++ b/tests/xdebug_gc_stats6.phpt
@@ -1,0 +1,21 @@
+--TEST--
+GC Stats: Start with xdebug_start_gcstats() and filename
+--INI--
+zend.enable_gc=1
+xdebug.gc_stats_enable=0
+--FILE--
+<?php
+var_dump(xdebug_get_gcstats_filename());
+
+$filename = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'gcstats.txt';
+$actual = xdebug_start_gcstats($filename);
+
+var_dump($actual === $filename);
+var_dump(xdebug_get_gcstats_filename());
+xdebug_stop_gcstats();
+unlink(xdebug_get_gcstats_filename());
+?>
+--EXPECTF--
+bool(false)
+bool(true)
+string(%d) "%sgcstats.txt"

--- a/tests/xdebug_gc_stats7.phpt
+++ b/tests/xdebug_gc_stats7.phpt
@@ -1,0 +1,22 @@
+--TEST--
+GC Stats: userland statistic functions
+--INI--
+zend.enable_gc=1
+--FILE--
+<?php
+
+for ($i = 0; $i < 100; $i++) {
+	$a = new stdClass();
+	$b = new stdClass();
+	$b->a = $a;
+	$a->b = $b;
+	unset($a, $b);
+}
+gc_collect_cycles();
+
+printf("runs: %d\n", xdebug_get_gc_run_count());
+printf("collected: %d\n", xdebug_get_gc_total_collected_roots());
+?>
+--EXPECTF--
+runs: 1
+collected: 200

--- a/xdebug.c
+++ b/xdebug.c
@@ -209,6 +209,8 @@ zend_function_entry xdebug_functions[] = {
 	PHP_FE(xdebug_start_gcstats,         xdebug_start_gcstats_args)
 	PHP_FE(xdebug_stop_gcstats,          xdebug_stop_gcstats_args)
 	PHP_FE(xdebug_get_gcstats_filename,  xdebug_void_args)
+	PHP_FE(xdebug_get_gc_run_count,      xdebug_void_args)
+	PHP_FE(xdebug_get_gc_total_collected_roots, xdebug_void_args)
 
 	PHP_FE(xdebug_memory_usage,          xdebug_void_args)
 	PHP_FE(xdebug_peak_memory_usage,     xdebug_void_args)

--- a/xdebug.c
+++ b/xdebug.c
@@ -54,6 +54,7 @@
 #include "xdebug_code_coverage.h"
 #include "xdebug_com.h"
 #include "xdebug_filter.h"
+#include "xdebug_gc_stats.h"
 #include "xdebug_llist.h"
 #include "xdebug_mm.h"
 #include "xdebug_monitor.h"
@@ -159,10 +160,21 @@ ZEND_BEGIN_ARG_INFO_EX(xdebug_stop_code_coverage_args, ZEND_SEND_BY_VAL, ZEND_RE
 	ZEND_ARG_INFO(0, cleanup)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(xdebug_start_gcstats_args, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 0)
+	ZEND_ARG_INFO(0, fname)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(xdebug_stop_gcstats_args, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(xdebug_set_filter_args, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 3)
 	ZEND_ARG_INFO(0, filter_group)
 	ZEND_ARG_INFO(0, filter_type)
 	ZEND_ARG_INFO(0, array_of_filters)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(xdebug_get_gc_stats_args, ZEND_SEND_BY_VAL, ZEND_RETURN_VALUE, 0)
+    ZEND_ARG_INFO(0, clear)
 ZEND_END_ARG_INFO()
 
 zend_function_entry xdebug_functions[] = {
@@ -193,6 +205,10 @@ zend_function_entry xdebug_functions[] = {
 	PHP_FE(xdebug_get_profiler_filename, xdebug_void_args)
 	PHP_FE(xdebug_dump_aggr_profiling_data, xdebug_dump_aggr_profiling_data_args)
 	PHP_FE(xdebug_clear_aggr_profiling_data, xdebug_void_args)
+
+	PHP_FE(xdebug_start_gcstats,         xdebug_start_gcstats_args)
+	PHP_FE(xdebug_stop_gcstats,          xdebug_stop_gcstats_args)
+	PHP_FE(xdebug_get_gcstats_filename,  xdebug_void_args)
 
 	PHP_FE(xdebug_memory_usage,          xdebug_void_args)
 	PHP_FE(xdebug_peak_memory_usage,     xdebug_void_args)
@@ -384,6 +400,11 @@ PHP_INI_BEGIN()
 
 	/* Scream support */
 	STD_PHP_INI_BOOLEAN("xdebug.scream",                 "0",           PHP_INI_ALL,    OnUpdateBool,   do_scream,            zend_xdebug_globals, xdebug_globals)
+
+	/* GC Stats support */
+	STD_PHP_INI_BOOLEAN("xdebug.gc_stats_enable",    "0",               PHP_INI_SYSTEM|PHP_INI_PERDIR, OnUpdateBool,   gc_stats_enable,      zend_xdebug_globals, xdebug_globals)
+	STD_PHP_INI_ENTRY("xdebug.gc_stats_output_dir",  XDEBUG_TEMP_DIR,   PHP_INI_SYSTEM|PHP_INI_PERDIR, OnUpdateString, gc_stats_output_dir,  zend_xdebug_globals, xdebug_globals)
+	STD_PHP_INI_ENTRY("xdebug.gc_stats_output_name", "gcstats.%p",      PHP_INI_SYSTEM|PHP_INI_PERDIR, OnUpdateString, gc_stats_output_name, zend_xdebug_globals, xdebug_globals)
 PHP_INI_END()
 
 static void php_xdebug_init_globals (zend_xdebug_globals *xg TSRMLS_DC)
@@ -429,6 +450,10 @@ static void php_xdebug_init_globals (zend_xdebug_globals *xg TSRMLS_DC)
 	xg->filter_type_code_coverage = XDEBUG_FILTER_NONE;
 	xg->filters_tracing           = NULL;
 	xg->filters_code_coverage     = NULL;
+
+	xg->gc_stats_file = NULL;
+	xg->gc_stats_filename = NULL;
+	xg->gc_stats_enabled = 0;
 
 	xdebug_llist_init(&xg->server, xdebug_superglobals_dump_dtor);
 	xdebug_llist_init(&xg->get, xdebug_superglobals_dump_dtor);
@@ -721,6 +746,10 @@ PHP_MINIT_FUNCTION(xdebug)
 	xdebug_old_error_cb = zend_error_cb;
 	xdebug_new_error_cb = xdebug_error_cb;
 
+    /* Replace garbage collection handler with our own */
+    xdebug_old_gc_collect_cycles = gc_collect_cycles;
+    gc_collect_cycles = xdebug_gc_collect_cycles;
+
 	/* Get reserved offsets */
 	zend_xdebug_cc_run_offset = zend_get_resource_handle(&dummy_ext);
 	zend_xdebug_filter_offset = zend_get_resource_handle(&dummy_ext);
@@ -876,6 +905,7 @@ PHP_MSHUTDOWN_FUNCTION(xdebug)
 	zend_execute_ex = xdebug_old_execute_ex;
 	zend_execute_internal = xdebug_old_execute_internal;
 	zend_error_cb = xdebug_old_error_cb;
+	gc_collect_cycles = xdebug_old_gc_collect_cycles;
 
 	zend_hash_destroy(&XG(aggr_calls));
 
@@ -1182,6 +1212,9 @@ PHP_RINIT_FUNCTION(xdebug)
 	XG(code_coverage_filter_offset) = zend_xdebug_filter_offset;
 	XG(previous_filename) = "";
 	XG(previous_file) = NULL;
+	XG(gc_stats_file) = NULL;
+	XG(gc_stats_filename) = NULL;
+	XG(gc_stats_enabled) = 0;
 
 	xdebug_init_auto_globals(TSRMLS_C);
 
@@ -1301,6 +1334,14 @@ ZEND_MODULE_POST_ZEND_DEACTIVATE_D(xdebug)
 	xdebug_hash_destroy(XG(profile_functionname_refs));
 	XG(profile_filename_refs) = NULL;
 	XG(profile_functionname_refs) = NULL;
+
+	if (XG(gc_stats_enabled)) {
+		xdebug_gc_stats_stop();
+	}
+
+	if (XG(gc_stats_filename)) {
+		xdfree(XG(gc_stats_filename));
+	}
 
 	if (XG(ide_key)) {
 		xdfree(XG(ide_key));
@@ -1762,6 +1803,12 @@ void xdebug_execute_ex(zend_execute_data *execute_data TSRMLS_DC)
 			/* In case we do an auto-trace we are not interested in the return
 			 * value, but we still have to free it. */
 			xdfree(xdebug_start_trace(NULL, STR_NAME_VAL(op_array->filename), XG(trace_options) TSRMLS_CC));
+		}
+
+		if (!XG(gc_stats_enabled) && XG(gc_stats_enable)) {
+			if (xdebug_gc_stats_init(NULL, STR_NAME_VAL(op_array->filename)) == SUCCESS) {
+				XG(gc_stats_enabled) = 1;
+			}
 		}
 	}
 

--- a/xdebug_gc_stats.c
+++ b/xdebug_gc_stats.c
@@ -1,0 +1,245 @@
+/*
+   +----------------------------------------------------------------------+
+   | Xdebug                                                               |
+   +----------------------------------------------------------------------+
+   | Copyright (c) 2002-2017 Derick Rethans                               |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 1.0 of the Xdebug license,    |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available at through the world-wide-web at                           |
+   | http://xdebug.derickrethans.nl/license.php                           |
+   | If you did not receive a copy of the Xdebug license and are unable   |
+   | to obtain it through the world-wide-web, please send a note to       |
+   | xdebug@derickrethans.nl so we can mail you a copy immediately.       |
+   +----------------------------------------------------------------------+
+   | Authors: Benjamin Eberlei <kontakt@beberlei.de>                      |
+   +----------------------------------------------------------------------+
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "php.h"
+#include "php_xdebug.h"
+#include "xdebug_gc_stats.h"
+#include "zend_builtin_functions.h"
+#include "SAPI.h"
+
+ZEND_EXTERN_MODULE_GLOBALS(xdebug)
+
+int xdebug_gc_collect_cycles(void)
+{
+	int                ret;
+	uint32_t           collected;
+	xdebug_gc_run     *run;
+	zend_execute_data *execute_data;
+	zend_function     *current_function;
+	long int           memory;
+	double             start;
+
+	if (!XG(gc_stats_enabled)) {
+		return xdebug_old_gc_collect_cycles();
+	}
+
+	execute_data = EG(current_execute_data);
+
+	collected = GC_G(collected);
+	start = xdebug_get_utime();
+	memory = zend_memory_usage(0);
+
+	ret = xdebug_old_gc_collect_cycles();
+
+	run = xdmalloc(sizeof(xdebug_gc_run));
+	run->function_name = NULL;
+	run->class_name = NULL;
+
+	run->collected = GC_G(collected) - collected;
+	run->duration = xdebug_get_utime() - start;
+	run->memory_before = memory;
+	run->memory_after = zend_memory_usage(0);
+
+	if (execute_data && execute_data->func) {
+		current_function = execute_data->func;
+
+		if (current_function->common.function_name) {
+			run->function_name = zend_string_copy(current_function->common.function_name);
+		}
+
+		if (current_function->common.scope && current_function->common.scope->name) {
+			run->class_name = zend_string_copy(current_function->common.scope->name);
+		}
+	}
+
+	zend_fetch_debug_backtrace(&(run->stack), 0, DEBUG_BACKTRACE_IGNORE_ARGS, 0 TSRMLS_CC);
+
+	xdebug_gc_stats_print_run(run);
+
+	xdebug_gc_stats_run_free(run);
+
+	return ret;
+}
+
+void xdebug_gc_stats_run_free(xdebug_gc_run *run)
+{
+	if (run) {
+		if (run->function_name) {
+			zend_string_release(run->function_name);
+		}
+		if (run->class_name) {
+			zend_string_release(run->class_name);
+		}
+		zval_ptr_dtor(&(run->stack));
+		xdfree(run);
+	}
+}
+
+int xdebug_gc_stats_init(char *fname, char *script_name)
+{
+	char *filename = NULL;
+
+	if (fname && strlen(fname)) {
+		filename = xdstrdup(fname);
+	} else {
+		if (!strlen(XG(gc_stats_output_name)) ||
+			xdebug_format_output_filename(&fname, XG(gc_stats_output_name), script_name) <= 0)
+		{
+			return FAILURE;
+		}
+
+		if (IS_SLASH(XG(gc_stats_output_dir)[strlen(XG(gc_stats_output_dir)) - 1])) {
+			filename = xdebug_sprintf("%s%s", XG(gc_stats_output_dir), fname);
+		} else {
+			filename = xdebug_sprintf("%s%c%s", XG(gc_stats_output_dir), DEFAULT_SLASH, fname);
+		}
+		xdfree(fname);
+	}
+
+	XG(gc_stats_file) = xdebug_fopen(filename, "w", NULL, &XG(gc_stats_filename));
+	xdfree(filename);
+
+	if (!XG(gc_stats_file)) {
+		return FAILURE;
+	}
+
+	fprintf(XG(gc_stats_file), "Garbage Collection Report\n");
+	fprintf(XG(gc_stats_file), "version: 1\ncreator: xdebug %s (PHP %s)\n\n", XDEBUG_VERSION, PHP_VERSION);
+
+	fprintf(XG(gc_stats_file), "Collected | Efficiency%% | Duration | Memory Before | Memory After | Reduction%% | Function\n");
+	fprintf(XG(gc_stats_file), "----------+-------------+----------+---------------+--------------+------------+---------\n");
+
+	fflush(XG(gc_stats_file));
+
+	return SUCCESS;
+}
+
+void xdebug_gc_stats_stop()
+{
+	XG(gc_stats_enabled) = 0;
+
+	if (XG(gc_stats_file)) {
+		fclose(XG(gc_stats_file));
+		XG(gc_stats_file) = NULL;
+	}
+}
+
+void xdebug_gc_stats_print_run(xdebug_gc_run *run)
+{
+	if (!XG(gc_stats_file)) {
+		return;
+	}
+
+	if (!run->function_name) {
+		fprintf(XG(gc_stats_file),
+			"%9lu | %9.2f %% | %5.2f ms | %13lu | %12lu | %8.2f %% | -\n",
+			run->collected,
+			(run->collected / 10000.0) * 100.0,
+			run->duration / 1000.0,
+			run->memory_before,
+			run->memory_after,
+			(float)run->memory_after / (float)run->memory_before * 100.0
+		);
+	} else if (!run->class_name && run->function_name) {
+		fprintf(XG(gc_stats_file),
+			"%9lu | %9.2f %% | %5.2f ms | %13lu | %12lu | %8.2f %% | %s\n",
+			run->collected,
+			(run->collected / 10000.0) * 100.0,
+			run->duration / 1000.0,
+			run->memory_before,
+			run->memory_after,
+			(float)run->memory_after / (float)run->memory_before * 100.0,
+			ZSTR_VAL(run->function_name)
+		);
+	} else if (run->class_name && run->function_name) {
+		fprintf(XG(gc_stats_file),
+			"%9lu | %9.2f %% | %5.2f ms | %13lu | %12lu | %8.2f %% | %s::%s\n",
+			run->collected,
+			(run->collected / 10000.0) * 100.0,
+			run->duration / 1000.0,
+			run->memory_before,
+			run->memory_after,
+			(float)run->memory_after / (float)run->memory_before * 100.0,
+			ZSTR_VAL(run->class_name),
+			ZSTR_VAL(run->function_name)
+		);
+	}
+
+	fflush(XG(gc_stats_file));
+}
+
+/* {{{ proto void xdebug_get_gcstats_filename()
+   Returns the name of the current garbage collection statistics report file */
+PHP_FUNCTION(xdebug_get_gcstats_filename)
+{
+	if (XG(gc_stats_filename)) {
+		RETURN_STRING(XG(gc_stats_filename));
+	} else {
+		RETURN_FALSE;
+	}
+}
+/* }}} */
+
+/* {{{ proto void xdebug_start_gcstats([string $fname])
+   Start collecting garbage collection statistics */
+PHP_FUNCTION(xdebug_start_gcstats)
+{
+	char                 *fname = NULL;
+	size_t                fname_len = 0;
+	function_stack_entry *fse;
+
+	if (XG(gc_stats_enabled) == 0) {
+		if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|s", &fname, &fname_len) == FAILURE) {
+			return;
+		}
+
+		fse = xdebug_get_stack_frame(0 TSRMLS_CC);
+
+		if (xdebug_gc_stats_init(fname, fse->filename) == SUCCESS) {
+			XG(gc_stats_enabled) = 1;
+			RETVAL_STRING(XG(gc_stats_filename));
+			return;
+		} else {
+			php_error(E_NOTICE, "Garbage Collection statistics could not be started");
+		}
+
+		XG(gc_stats_enabled) = 0;
+		RETURN_FALSE;
+	} else {
+		php_error(E_NOTICE, "Garbage Collection statistics are already being collected.");
+		RETURN_FALSE;
+	}
+}
+/* }}} */
+
+/* {{{ proto void xdebug_stop_gcstats()
+   Stop collecting garbage collection statistics */
+PHP_FUNCTION(xdebug_stop_gcstats)
+{
+	if (XG(gc_stats_enabled) == 1) {
+		RETVAL_STRING(XG(gc_stats_filename));
+		xdebug_gc_stats_stop();
+	} else {
+		RETVAL_FALSE;
+		php_error(E_NOTICE, "Function trace was not started");
+	}
+}

--- a/xdebug_gc_stats.c
+++ b/xdebug_gc_stats.c
@@ -240,6 +240,20 @@ PHP_FUNCTION(xdebug_stop_gcstats)
 		xdebug_gc_stats_stop();
 	} else {
 		RETVAL_FALSE;
-		php_error(E_NOTICE, "Function trace was not started");
+		php_error(E_NOTICE, "Garbage Collection statistics was not started");
 	}
+}
+
+/* {{{ proto void xdebug_get_gc_run_count()
+   Return number of times garbage collection was triggered. */
+PHP_FUNCTION(xdebug_get_gc_run_count)
+{
+    RETURN_LONG(GC_G(gc_runs));
+}
+
+/* {{{ proto void xdebug_get_gc_total_collected_roots()
+   Return total number of collected root variables during garbage collection. */
+PHP_FUNCTION(xdebug_get_gc_total_collected_roots)
+{
+    RETURN_LONG(GC_G(collected));
 }

--- a/xdebug_gc_stats.h
+++ b/xdebug_gc_stats.h
@@ -1,0 +1,41 @@
+/*
+   +----------------------------------------------------------------------+
+   | Xdebug                                                               |
+   +----------------------------------------------------------------------+
+   | Copyright (c) 2002-2017 Derick Rethans                               |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 1.0 of the Xdebug license,    |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available at through the world-wide-web at                           |
+   | http://xdebug.derickrethans.nl/license.php                           |
+   | If you did not receive a copy of the Xdebug license and are unable   |
+   | to obtain it through the world-wide-web, please send a note to       |
+   | xdebug@derickrethans.nl so we can mail you a copy immediately.       |
+   +----------------------------------------------------------------------+
+   | Authors: Benjamin Eberlei <kontakt@beberlei.de>					  |
+   +----------------------------------------------------------------------+
+ */
+
+#ifndef __XDEBUG_GC_STATS_H__
+#define __XDEBUG_GC_STATS_H__
+
+typedef struct _xdebug_gc_run {
+	zend_long    collected;
+	zend_long    duration;
+	zend_long    memory_before;
+	zend_long    memory_after;
+	zend_string *function_name;
+	zend_string *class_name;
+	zval stack;
+} xdebug_gc_run;
+
+int (*xdebug_old_gc_collect_cycles)(void);
+int xdebug_gc_collect_cycles(void);
+int xdebug_gc_stats_init(char *fname, char *script_name);
+void xdebug_gc_stats_print_run(xdebug_gc_run *run);
+void xdebug_gc_stats_run_free(xdebug_gc_run *run);
+void xdebug_gc_stats_stop();
+
+void xdebug_gc_stats_show_report();
+
+#endif


### PR DESCRIPTION
Configuration is done through INI settings:

    xdebug.gc_stats_enable=1 Enables the collection of Garbage collection stats
    xdebug.gc_stats_output_dir=/tmp
    xdebug.gc_stats_output_name=gcstats.%p

Currently the file format is only human readable (tabular), a machine readable version (JSON) may be following later.

    Collected | Efficiency% | Duration | Memory Before | Memory After | Reduction% | Function
    ----------+-------------+----------+---------------+--------------+------------+---------
        10000 |    100.00 % |  0.00 ms |       5539880 |       579880 |   -10.47 % | bar
        10000 |    100.00 % |  0.00 ms |       5540040 |       580040 |   -10.47 % | Garbage::produce
         4001 |     40.01 % |  0.00 ms |       2563048 |       578968 |   -22.59 % | gc_collect_cycles

You can get the concrete filename at runtime with `xdebug_get_gcstats_filename()`.

You can also start the gcstats from within the PHP userland with `xdebug_start_gcstats()` and stop it with `xdebug_stop_gcstats()`.

Documentation PR here https://github.com/xdebug/xdebug.org/pull/45