### PR TITLE
Include <poll.h> instead of <sys/poll.h>

### DIFF
--- a/xdebug_com.c
+++ b/xdebug_com.c
@@ -23,7 +23,7 @@
 #include <stdio.h>
 #include <fcntl.h>
 #ifndef PHP_WIN32
-# include <sys/poll.h>
+# include <poll.h>
 # include <unistd.h>
 # include <sys/socket.h>
 # include <netinet/tcp.h>


### PR DESCRIPTION
Hello, when compiling xdebug extension on Alpine Linux, there appears the following warning:

```
In file included from /build/main/php7.1-xdebug/src/xdebug-2.5.5/xdebug_com.c:26:0:
/usr/include/sys/poll.h:1:2: warning: #warning redirecting incorrect #include <sys/poll.h> to <poll.h> [-Wcpp]
 #warning redirecting incorrect #include <sys/poll.h> to <poll.h>
  ^~~~~~~
```

Alpine Linux uses musl libc instead of glibc.

The [POSIX](http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/poll.h.html) recommends including `poll.h`  instead of `sys/poll.h`. Glibc has `poll.h` also as an option since few years ago (very old versions might fail the compilation).

Would this be a good enough patch or should the included header be checked using if else clause? Thank you for taking a look at it.
