### PR TITLE
Fix compilation on Windows (VC15)

### DIFF
--- a/xdebug_collection.c
+++ b/xdebug_collection.c
@@ -46,7 +46,7 @@ void xdebug_ptr_collection_dtor(xdebug_ptr_collection *ptr_collection)
 //fprintf(stderr, "Freeing PTR collector\n");
 }
 
-inline void xdebug_ptr_collection_add(xdebug_ptr_collection *ptr_collection, void *ptr)
+void xdebug_ptr_collection_add(xdebug_ptr_collection *ptr_collection, void *ptr)
 {
 	if (ptr_collection->count == ptr_collection->size) {
 		ptr_collection->size *= 2;


### PR DESCRIPTION
Xdebug2.6.0-dev doesn’t compile on Windows

Verified with VC15.3.5 x64 NTS with `configure --with-mp=4 --enable-object-out-dir=../build/ --disable-all --enable-cli --enable-zlib --enable-hash --enable-session --without-gd --with-bz2 --with-xdebug=shared --disable-zts`

Compiler link error is (in french sorry) : `xdebug_var.obj : error LNK2019: symbole externe non résolu xdebug_ptr_collection_add référencé dans la fonction fetch_zval_from_symbol_table`

Disabling inline for xdebug_ptr_collection_add function in xdebug_collection.c L. 49, correct the problem 
