### PR TITLE
honours TEST_PHP_ARGS for sub-process

### DIFF
--- a/tests/dbgp/dbgpclient.php
+++ b/tests/dbgp/dbgpclient.php
@@ -70,7 +70,7 @@ class DebugClient
 			$ini_options = array();
 		}
 		
-		$options = '';
+		$options = (getenv('TEST_PHP_ARGS') ?: '');
 		$ini_options = array_merge( $default_options, $ini_options );
 		foreach ( $ini_options as $key => $value )
 		{


### PR DESCRIPTION
This allow to run test suite more easily as non-root user (unable to install extensions, including the xdebug one) and having lot of extension build as shared.

```
$ export TEST_PHP_EXECUTABLE=/usr/bin/php
$ export TEST_PHP_ARGS="-n -d extension=simplexml.so -d zend_extension=$PWD/modules/xdebug.so  -d xdebug.auto_trace=0 "
$ mv tests/bug00886-php7.phpt tests/bug00886-php7.phpt.off
$ php -n run-tests.php -q -x --show-diff
...
=====================================================================
Number of tests :  526               369
Tests skipped   :  157 ( 29.8%) --------
Tests warned    :    0 (  0.0%) (  0.0%)
Tests failed    :    0 (  0.0%) (  0.0%)
Expected fail   :    0 (  0.0%) (  0.0%)
Tests passed    :  369 ( 70.2%) (100.0%)
---------------------------------------------------------------------
Time taken      :   17 seconds
=====================================================================
```