### PR TITLE
Fix overload_var_dump type 

### DIFF
--- a/php_xdebug.h
+++ b/php_xdebug.h
@@ -153,7 +153,7 @@ ZEND_BEGIN_MODULE_GLOBALS(xdebug)
 	iniLONG       force_error_reporting;
 	iniLONG       halt_level;
 
-	zend_bool     overload_var_dump;
+	iniLONG       overload_var_dump;
 	void        (*orig_var_dump_func)(INTERNAL_FUNCTION_PARAMETERS);
 	void        (*orig_set_time_limit_func)(INTERNAL_FUNCTION_PARAMETERS);
 	void        (*orig_pcntl_exec_func)(INTERNAL_FUNCTION_PARAMETERS);

--- a/tests/bug00714.phpt
+++ b/tests/bug00714.phpt
@@ -58,7 +58,7 @@ calls=1 0 0
 
 fl=(1)
 fn=(1)
-4 20%d
+4 2%d
 
 fl=(2)
 fn=(4) sleep20
@@ -66,7 +66,7 @@ fn=(4) sleep20
 cfl=(1)
 cfn=(1)
 calls=1 0 0
-4 20%d
+4 2%d
 
 fl=(1)
 fn=(5) php::xdebug_get_profiler_filename


### PR DESCRIPTION
Test build https://koji.fedoraproject.org/koji/taskinfo?taskID=22518900

Test suite passes on all arch.