### PR TITLE
Set FD_CLOEXEC on remote debugging sockets

### DIFF
--- a/xdebug_com.c
+++ b/xdebug_com.c
@@ -73,6 +73,11 @@ static int xdebug_create_socket_unix(const char *path TSRMLS_DC)
 		return (errno == EACCES) ? SOCK_ACCESS_ERR : SOCK_ERR;
 	}
 
+	/* Prevent the socket from being inherited by exec'd children */
+	if (fcntl(sockfd, F_SETFD, FD_CLOEXEC) < 0) {
+		XDEBUG_LOG_PRINT(XG(remote_log_file), "W: Creating socket for 'unix://%s', fcntl(FD_CLOEXEC): %s.\n", path, strerror(errno));
+	}
+
 	return sockfd;
 }
 #endif
@@ -155,6 +160,13 @@ int xdebug_create_socket(const char *hostname, int dport TSRMLS_DC)
 		}
 #else
 		fcntl(sockfd, F_SETFL, O_NONBLOCK);
+#endif
+
+#if !WIN32 && !WINNT
+		/* Prevent the socket from being inherited by exec'd children on *nix (not necessary on Win) */
+	        if (fcntl(sockfd, F_SETFD, FD_CLOEXEC) < 0) {
+        	        XDEBUG_LOG_PRINT(XG(remote_log_file), "W: Creating socket for '%s:%d', fcntl(FD_CLOEXEC): %s.\n", hostname, dport, strerror(errno));
+        	}
 #endif
 
 		/* Try to connect to the newly created socket */


### PR DESCRIPTION
As suggested at phpnw17.

Fixes the underlying issue behind https://youtrack.jetbrains.com/issue/WI-31522 and generally keeps everything tidy by not leaking fds unnecessarily.