### PR TITLE
Fixed issue #1508: Code coverage filter not checked in xdebug_common_assign_dim handler

### DIFF
--- a/tests/bug01508-black.phpt
+++ b/tests/bug01508-black.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Test for bug #1508: Code coverage filter not checked in xdebug_common_assign_dim handler (black list)
+--INI--
+xdebug.auto_trace=0
+xdebug.collect_return=1
+xdebug.collect_params=4
+xdebug.collect_assignments=0
+xdebug.trace_format=0
+--FILE--
+<?php
+$cwd = __DIR__; $s = DIRECTORY_SEPARATOR;
+xdebug_set_filter(XDEBUG_FILTER_CODE_COVERAGE, XDEBUG_PATH_BLACKLIST, [ "{$cwd}{$s}filter{$s}bug01508.php" ] );
+
+$tf = xdebug_start_code_coverage( XDEBUG_CC_DEAD_CODE | XDEBUG_CC_UNUSED );
+
+$file = "{$cwd}/filter/bug01508.php";
+include "{$file}";
+
+Filter::bug1508();
+	
+$result = xdebug_get_code_coverage();
+
+echo array_key_exists( $file, $result ) ? "File '{$file}' is present in code coverage" : "File is not present in code coverage", "\n";
+?>
+--EXPECTF--
+File is not present in code coverage

--- a/tests/bug01508-white.phpt
+++ b/tests/bug01508-white.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Test for bug #1508: Code coverage filter not checked in xdebug_common_assign_dim handler (white list)
+--INI--
+xdebug.auto_trace=0
+xdebug.collect_return=1
+xdebug.collect_params=4
+xdebug.collect_assignments=0
+xdebug.trace_format=0
+--FILE--
+<?php
+$cwd = __DIR__; $s = DIRECTORY_SEPARATOR;
+xdebug_set_filter(XDEBUG_FILTER_CODE_COVERAGE, XDEBUG_PATH_WHITELIST, [] );
+
+$tf = xdebug_start_code_coverage( XDEBUG_CC_DEAD_CODE | XDEBUG_CC_UNUSED );
+
+$file = "{$cwd}/filter/bug01508.php";
+include "{$file}";
+
+Filter::bug1508();
+	
+$result = xdebug_get_code_coverage();
+
+echo array_key_exists( $file, $result ) ? "File '{$file}' is present in code coverage" : "File is not present in code coverage", "\n";
+?>
+--EXPECTF--
+File is not present in code coverage

--- a/tests/filter/bug01508.php
+++ b/tests/filter/bug01508.php
@@ -1,0 +1,10 @@
+<?php
+class Filter
+{
+	static function bug1508()
+	{
+		/* Should not show up */
+		$foo = 1;	
+	}
+}
+

--- a/xdebug_code_coverage.c
+++ b/xdebug_code_coverage.c
@@ -363,7 +363,7 @@ static int xdebug_common_assign_dim_handler(char *op, int do_cc, zend_execute_da
 //		return ZEND_USER_OPCODE_DISPATCH;
 //	}
 
-	if (XG(do_code_coverage)) {
+	if (!op_array->reserved[XG(code_coverage_filter_offset)] && XG(do_code_coverage)) {
 		xdebug_print_opcode_info('=', execute_data, cur_opcode TSRMLS_CC);
 
 		if (do_cc) {


### PR DESCRIPTION
Fixes the issue mentioned in https://github.com/sebastianbergmann/php-code-coverage/issues/514#issuecomment-354654930 (/cc @sebastianbergmann)