### PR TITLE
Fix duplicate symbol xdebug_old_gc_collect_cycles

### DIFF
--- a/xdebug_gc_stats.c
+++ b/xdebug_gc_stats.c
@@ -26,6 +26,7 @@ ZEND_EXTERN_MODULE_GLOBALS(xdebug)
 
 static void xdebug_gc_stats_print_run(xdebug_gc_run *run);
 static void xdebug_gc_stats_run_free(xdebug_gc_run *run);
+int (*xdebug_old_gc_collect_cycles)(void);
 
 int xdebug_gc_collect_cycles(void)
 {

--- a/xdebug_gc_stats.h
+++ b/xdebug_gc_stats.h
@@ -28,7 +28,7 @@ typedef struct _xdebug_gc_run {
 	char        *class_name;
 } xdebug_gc_run;
 
-int (*xdebug_old_gc_collect_cycles)(void);
+extern int (*xdebug_old_gc_collect_cycles)(void);
 
 int xdebug_gc_stats_init(char *fname, char *script_name);
 void xdebug_gc_stats_stop();


### PR DESCRIPTION
Compiling with PHP 7.2.0 on OSX 10.13.2 failed with:

```
cc ${wl}-flat_namespace ${wl}-undefined ${wl}suppress -o .libs/xdebug.so -bundle  .libs/xdebug.o .libs/xdebug_branch_info.o .libs/xdebug_code_coverage.o .libs/xdebug_com.o .libs/xdebug_compat.o .libs/xdebug_gc_stats.o .libs/xdebug_filter.o .libs/xdebug_handler_dbgp.o .libs/xdebug_handlers.o .libs/xdebug_llist.o .libs/xdebug_monitor.o .libs/xdebug_hash.o .libs/xdebug_private.o .libs/xdebug_profiler.o .libs/xdebug_set.o .libs/xdebug_stack.o .libs/xdebug_str.o .libs/xdebug_superglobals.o .libs/xdebug_tracing.o .libs/xdebug_trace_textual.o .libs/xdebug_trace_computerized.o .libs/xdebug_trace_html.o .libs/xdebug_var.o .libs/xdebug_xml.o .libs/usefulstuff.o  -lm
duplicate symbol _xdebug_old_gc_collect_cycles in:
    .libs/xdebug.o
    .libs/xdebug_gc_stats.o
ld: 1 duplicate symbol for architecture x86_64
```