### PR TITLE
 Fixed bug #1515: Object property names with a NULL char are cut off at NULL char

### DIFF
--- a/tests/bug01514.phpt
+++ b/tests/bug01514.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Test for bug #1514: (Root) Variable names with a NULL char are cut off at NULL char
+Test for bug #1514: Variable names with a NULL char are cut off at NULL char
 --SKIPIF--
 <?php if (getenv("SKIP_DBGP_TESTS")) { exit("skip Excluding DBGp tests"); } ?>
 --FILE--
@@ -12,8 +12,8 @@ $commands = array(
 	'step_into',
 	'step_into',
 	'context_get',
-	'property_get -d 0 -c 0 -n $with_\0_null_char',
-	'property_get -d 0 -c 0 -n "$with_\\\0_null_char"',
+	'feature_set -n extended_properties -v 1',
+	'context_get',
 );
 
 dbgpRun( $data, $commands );
@@ -36,12 +36,12 @@ dbgpRun( $data, $commands );
 
 -> context_get -i 4
 <?xml version="1.0" encoding="iso-8859-1"?>
-<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="http://xdebug.org/dbgp/xdebug" command="context_get" transaction_id="4" context="0"><property name="$name" fullname="$name" type="string" size="16" encoding="base64"><![CDATA[d2l0aF8AX251bGxfY2hhcg==]]></property><property name="$with_&#0;_null_char" fullname="$with_&#0;_null_char" type="uninitialized"></property></response>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="http://xdebug.org/dbgp/xdebug" command="context_get" transaction_id="4" context="0"><property name="$name" fullname="$name" type="string" size="16" encoding="base64"><![CDATA[d2l0aF8AX251bGxfY2hhcg==]]></property><property name="$with_&#0;_null_char" fullname="$with_&#0;_null_char" type="int"><![CDATA[42]]></property></response>
 
--> property_get -i 5 -d 0 -c 0 -n $with_\0_null_char
+-> feature_set -i 5 -n extended_properties -v 1
 <?xml version="1.0" encoding="iso-8859-1"?>
-<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="http://xdebug.org/dbgp/xdebug" command="property_get" transaction_id="5"><property name="$with_\0_null_char" fullname="$with_\0_null_char" type="int"><![CDATA[42]]></property></response>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="http://xdebug.org/dbgp/xdebug" command="feature_set" transaction_id="5" feature="extended_properties" success="1"></response>
 
--> property_get -i 6 -d 0 -c 0 -n "$with_\\0_null_char"
+-> context_get -i 6
 <?xml version="1.0" encoding="iso-8859-1"?>
-<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="http://xdebug.org/dbgp/xdebug" command="property_get" transaction_id="6"><property name="$with_\0_null_char" fullname="$with_\0_null_char" type="int"><![CDATA[42]]></property></response>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="http://xdebug.org/dbgp/xdebug" command="context_get" transaction_id="6" context="0"><property name="$name" fullname="$name" type="string" size="16" encoding="base64"><![CDATA[d2l0aF8AX251bGxfY2hhcg==]]></property><property type="int"><name encoding="base64"><![CDATA[JHdpdGhfAF9udWxsX2NoYXI=]]></name><fullname encoding="base64"><![CDATA[JHdpdGhfAF9udWxsX2NoYXI=]]></fullname><value encoding="base64"><![CDATA[NDI=]]></value></property></response>

--- a/xdebug_str.h
+++ b/xdebug_str.h
@@ -25,6 +25,8 @@
 #define XDEBUG_STR_PREALLOC 1024
 #define xdebug_str_dtor(str)     xdfree(str.d)
 
+#define XDEBUG_STR_WRAP_CHAR(v) (&((xdebug_str){strlen(v), strlen(v)+1, ((char*)(v))}))
+
 typedef struct xdebug_str {
 	signed long l;
 	signed long a;

--- a/xdebug_superglobals.c
+++ b/xdebug_superglobals.c
@@ -33,8 +33,6 @@ void xdebug_superglobals_dump_dtor(void *user, void *ptr)
 
 static void dump_hash_elem(zval *z, const char *name, long index_key, const char *elem, int html, xdebug_str *str TSRMLS_DC)
 {
-	int  len;
-
 	if (html) {
 		if (elem) {
 			xdebug_str_add(str, xdebug_sprintf("<tr><td colspan='2' align='right' bgcolor='#eeeeec' valign='top'><pre>$%s['%s']&nbsp;=</pre></td>", name, elem), 1);
@@ -44,18 +42,22 @@ static void dump_hash_elem(zval *z, const char *name, long index_key, const char
 	}
 
 	if (z != NULL) {
-		char *val;
+		xdebug_str *val;
 
 		if (html) {
-			val = xdebug_get_zval_value_fancy(NULL, z, &len, 0, NULL TSRMLS_CC);
-			xdebug_str_add(str, xdebug_sprintf("<td colspan='3' bgcolor='#eeeeec'>"), 1);
-			xdebug_str_addl(str, val, len, 0);
-			xdebug_str_add(str, "</td>", 0);
+			val = xdebug_get_zval_value_fancy(NULL, z, 0, NULL);
+
+			xdebug_str_addl(str, "<td colspan='3' bgcolor='#eeeeec'>", 34, 0);
+			xdebug_str_add_str(str, val);
+			xdebug_str_addl(str, "</td>", 5, 0);
 		} else {
 			val = xdebug_get_zval_value(z, 0, NULL);
-			xdebug_str_add(str, xdebug_sprintf("\n   $%s['%s'] = %s", name, elem, val), 1);
+
+			xdebug_str_add(str, xdebug_sprintf("\n   $%s['%s'] = ", name, elem), 1);
+			xdebug_str_add_str(str, val);
 		}
-		xdfree(val);
+
+		xdebug_str_free(val);
 	} else {
 		/* not found */
 		if (html) {

--- a/xdebug_var.h
+++ b/xdebug_var.h
@@ -51,8 +51,7 @@ typedef struct xdebug_var_export_options {
 #define XDEBUG_VAR_TYPE_STATIC   0x01
 #define XDEBUG_VAR_TYPE_CONSTANT 0x02
 
-void xdebug_get_php_symbol(zval *retval, char* name TSRMLS_DC);
-const char* xdebug_get_property_info(char *mangled_property, int mangled_len, char **property_name, char **class_name);
+void xdebug_get_php_symbol(zval *retval, xdebug_str* name);
 
 xdebug_var_export_options* xdebug_var_export_options_from_ini(TSRMLS_D);
 xdebug_var_export_options* xdebug_var_get_nolimit_options(TSRMLS_D);
@@ -63,29 +62,28 @@ void xdebug_var_export_text_ansi(zval **struc, xdebug_str *str, int mode, int le
 #define debug_var_export_ansi(struc, str, level, debug_zval, options) xdebug_var_export_text_ansi(struc, str, 1, level, debug_zval, options TSRMLS_CC);
 void xdebug_var_export_xml(zval **struc, xdebug_str *str, int level TSRMLS_DC);
 void xdebug_var_export_fancy(zval **struc, xdebug_str *str, int level, int debug_zval, xdebug_var_export_options *options TSRMLS_DC);
-void xdebug_var_export_xml_node(zval **struc, char *name, xdebug_xml_node *node, xdebug_var_export_options *options, int level TSRMLS_DC);
+void xdebug_var_export_xml_node(zval **struc, xdebug_str *name, xdebug_xml_node *node, xdebug_var_export_options *options, int level);
 
 char* xdebug_xmlize(char *string, size_t len, size_t *newlen);
 char* xdebug_error_type_simple(int type);
 char* xdebug_error_type(int type);
 zval *xdebug_get_zval(zend_execute_data *zdata, int node_type, const znode_op *node, int *is_var);
-char* xdebug_get_zval_value(zval *val, int debug_zval, xdebug_var_export_options *options);
-char* xdebug_get_zval_value_text_ansi(zval *val, int mode, int debug_zval, xdebug_var_export_options *options TSRMLS_DC);
+xdebug_str* xdebug_get_zval_value(zval *val, int debug_zval, xdebug_var_export_options *options);
+xdebug_str* xdebug_get_zval_value_text_ansi(zval *val, int mode, int debug_zval, xdebug_var_export_options *options);
 #define xdebug_get_zval_value_text(v,d,o) xdebug_get_zval_value_text_ansi(v,0,d,o TSRMLS_CC);
 #define xdebug_get_zval_value_ansi(v,d,o) xdebug_get_zval_value_text_ansi(v,1,d,o TSRMLS_CC);
-char* xdebug_get_zval_value_xml(char *name, zval *val);
-char* xdebug_get_zval_value_fancy(char *name, zval *val, int *len, int debug_zval, xdebug_var_export_options *options TSRMLS_DC);
-char* xdebug_get_zval_value_serialized(zval *val, int debug_zval, xdebug_var_export_options *options TSRMLS_DC);
+xdebug_str* xdebug_get_zval_value_fancy(char *name, zval *val, int debug_zval, xdebug_var_export_options *options);
+xdebug_str* xdebug_get_zval_value_serialized(zval *val, int debug_zval, xdebug_var_export_options *options);
 
 void xdebug_attach_static_vars(xdebug_xml_node *node, xdebug_var_export_options *options, zend_class_entry *ce TSRMLS_DC);
 void xdebug_attach_uninitialized_var(xdebug_var_export_options *options, xdebug_xml_node *node, xdebug_str *name);
 void xdebug_attach_static_var_with_contents(zval **zv TSRMLS_DC, int num_args, va_list args, zend_hash_key *hash_key);
 #define xdebug_get_zval_value_xml_node(name, val, options) xdebug_get_zval_value_xml_node_ex(name, val, XDEBUG_VAR_TYPE_NORMAL, options)
-xdebug_xml_node* xdebug_get_zval_value_xml_node_ex(char *name, zval *val, int var_type, xdebug_var_export_options *options TSRMLS_DC);
+xdebug_xml_node* xdebug_get_zval_value_xml_node_ex(xdebug_str *name, zval *val, int var_type, xdebug_var_export_options *options);
 
-char* xdebug_get_zval_synopsis(zval *val, int debug_zval, xdebug_var_export_options *options);
-char* xdebug_get_zval_synopsis_text_ansi(zval *val, int mode, int debug_zval, xdebug_var_export_options *options TSRMLS_DC);
-char* xdebug_get_zval_synopsis_fancy(const char *name, zval *val, int *len, int debug_zval, xdebug_var_export_options *options TSRMLS_DC);
+xdebug_str* xdebug_get_zval_synopsis(zval *val, int debug_zval, xdebug_var_export_options *options);
+xdebug_str* xdebug_get_zval_synopsis_text_ansi(zval *val, int mode, int debug_zval, xdebug_var_export_options *options);
+xdebug_str* xdebug_get_zval_synopsis_fancy(const char *name, zval *val, int debug_zval, xdebug_var_export_options *options);
 
 char* xdebug_show_fname(xdebug_func t, int html, int flags TSRMLS_DC);
 


### PR DESCRIPTION
No worries, I'll restore xdebug_debug_zval_stdout().