### PR TITLE
fix crash when reporting errors in eval()ed code

### DIFF
--- a/xdebug_handler_dbgp.c
+++ b/xdebug_handler_dbgp.c
@@ -2468,7 +2468,7 @@ int xdebug_dbgp_notification(xdebug_con *context, const char *file, long lineno,
 		char *tmp_filename = (char*) file;
 		int tmp_lineno = lineno;
 		if (check_evaled_code(NULL, &tmp_filename, &tmp_lineno, 0 TSRMLS_CC)) {
-			xdebug_xml_add_attribute_ex(error_container, "filename", xdstrdup(tmp_filename), 1, 1);
+			xdebug_xml_add_attribute_ex(error_container, "filename", xdstrdup(tmp_filename), 0, 1);
 		} else {
 			xdebug_xml_add_attribute_ex(error_container, "filename", xdebug_path_to_url(file TSRMLS_CC), 0, 1);
 		}


### PR DESCRIPTION
I noticed an issue where FPM would die with a SIGABRT when a remote debugging session was in progress and the debugged script was using `eval()` which was then causing a notice to be raised.

I've tracked the issue down to `xdebug_dbgp_notification` which in the eval case is calling `xdebug_xml_add_attribute_ex()` with the `free_name` argument set to 1. 

So when destructing the response, xdebug_xml_node_dtor() would then try to free() the string literal "filename" which will cause a crash in most cases.