### PR TITLE
Fixed issue #1532: SIGABRT when using remote debugging and an error is thrown in eval()

### DIFF
--- a/tests/bug01532.phpt
+++ b/tests/bug01532.phpt
@@ -1,0 +1,43 @@
+--TEST--
+Test for bug #1532: SIGABRT when using remote debugging and an error is thrown in eval()
+--SKIPIF--
+<?php
+if (getenv("SKIP_DBGP_TESTS")) { exit("skip Excluding DBGp tests"); }
+?>
+--FILE--
+<?php
+require 'dbgp/dbgpclient.php';
+
+$data = '<?php eval(\'trigger_error("flupp", E_USER_NOTICE);\');';
+
+$commands = array(
+    'feature_set -n notify_ok -v 1',
+    'step_into',
+    'run',
+    'detach'
+);
+
+dbgpRun( $data, $commands );
+?>
+--EXPECTF--
+<?xml version="1.0" encoding="iso-8859-1"?>
+<init xmlns="urn:debugger_protocol_v1" xmlns:xdebug="http://xdebug.org/dbgp/xdebug" fileuri="file:///%sxdebug-dbgp-test.php" language="PHP" xdebug:language_version="" protocol_version="1.0" appid="" idekey=""><engine version=""><![CDATA[Xdebug]]></engine><author><![CDATA[Derick Rethans]]></author><url><![CDATA[http://xdebug.org]]></url><copyright><![CDATA[Copyright (c) 2002-%d by Derick Rethans]]></copyright></init>
+
+-> feature_set -i 1 -n notify_ok -v 1
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="http://xdebug.org/dbgp/xdebug" command="feature_set" transaction_id="1" feature="notify_ok" success="1"></response>
+
+-> step_into -i 2
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="http://xdebug.org/dbgp/xdebug" command="step_into" transaction_id="2" status="break" reason="ok"><xdebug:message filename="file:///%sxdebug-dbgp-test.php" lineno="1"></xdebug:message></response>
+
+-> run -i 3
+<?xml version="1.0" encoding="iso-8859-1"?>
+<notify xmlns="urn:debugger_protocol_v1" xmlns:xdebug="http://xdebug.org/dbgp/xdebug" name="error"><xdebug:message filename="dbgp://1" lineno="1" type="Notice"><![CDATA[flupp]]></xdebug:message></notify>
+
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="http://xdebug.org/dbgp/xdebug" command="run" transaction_id="3" status="stopping" reason="ok"></response>
+
+-> detach -i 4
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="http://xdebug.org/dbgp/xdebug" command="detach" transaction_id="4" status="stopping" reason="ok"></response>

--- a/xdebug_handler_dbgp.c
+++ b/xdebug_handler_dbgp.c
@@ -2468,7 +2468,7 @@ int xdebug_dbgp_notification(xdebug_con *context, const char *file, long lineno,
 		char *tmp_filename = (char*) file;
 		int tmp_lineno = lineno;
 		if (check_evaled_code(NULL, &tmp_filename, &tmp_lineno, 0 TSRMLS_CC)) {
-			xdebug_xml_add_attribute_ex(error_container, "filename", xdstrdup(tmp_filename), 1, 1);
+			xdebug_xml_add_attribute_ex(error_container, "filename", xdstrdup(tmp_filename), 0, 1);
 		} else {
 			xdebug_xml_add_attribute_ex(error_container, "filename", xdebug_path_to_url(file TSRMLS_CC), 0, 1);
 		}


### PR DESCRIPTION
This is a followup PR to #416 now including a test-case and an issue reference.

I noticed that the test-runner doesn't really handle the crash with the SIGABRT very well. It does eventually fail, but only after a socket timeout expires.

However, the various log files in `sys_get_temp_dir()` do show the crash happening and the test will properly fail.

The simplest test-case is to run xdebug with remote debugging enabled against

```php
eval('trigger_error("flupp", E_USER_NOTICE);');
```
with a debugging client that supports notifications and has enabled them with `notify_ok`.

This will immediately cause the interpreter to crash with a SIGABRT.

The cause is in `xdebug_dbgp_notification()` where it calls`xdebug_xml_add_attribute_ex()` with the `free_name` argument set to 1.

Then, whendestructing the response, `xdebug_xml_node_dtor` would then try to `free()` the string literal "filename" which will cause a crash in most cases.

