### PR TITLE
skip test if localhost doesn't resolve as IPv6

### DIFF
--- a/tests/bug00998-ipv6_localhost.phpt
+++ b/tests/bug00998-ipv6_localhost.phpt
@@ -6,6 +6,7 @@ if (getenv("SKIP_IPV6_TESTS")) { exit("skip Excluding IPv6 tests"); }
 if (getenv("SKIP_DBGP_TESTS")) { exit("skip Excluding DBGp tests"); }
 require 'dbgp/dbgpclient.php';
 if (!DebugClientIPv6::isSupported($errno, $errstr)) echo "skip IPv6 support is not configured. Error: $errstr, errno: $errno\n";
+if (strstr(exec("getent ahostsv6 localhost"), '::1')===false) echo "skip localhost doesn't resolve as IPv6";
 ?>
 --FILE--
 <?php


### PR DESCRIPTION
I use the strstr, way as getent will return something like `::ffff:127.0.0.1`