### PR TITLE
Fix build for PHP 7.3

### DIFF
--- a/xdebug_code_coverage.c
+++ b/xdebug_code_coverage.c
@@ -621,7 +621,11 @@ static int xdebug_find_jumps(zend_op_array *opa, unsigned int position, size_t *
 		HashTable *myht;
 		zval *val;
 
+# if PHP_VERSION_ID >= 70300
+		array_value = RT_CONSTANT(&opa->opcodes[position], opcode.op2);
+# else
 		array_value = RT_CONSTANT_EX(opa->literals, opcode.op2);
+# endif
 		myht = Z_ARRVAL_P(array_value);
 
 		/* All 'case' statements */
@@ -879,11 +883,19 @@ static int prefill_from_class_table(zend_class_entry *class_entry)
 		if (!(ce->ce_flags & ZEND_XDEBUG_VISITED)) {
 			zend_op_array *val;
 			ce->ce_flags |= ZEND_XDEBUG_VISITED;
+#if PHP_VERSION_ID >= 70300
+			GC_PROTECT_RECURSION(&ce->function_table);
+#else
 			ZEND_HASH_INC_APPLY_COUNT(&ce->function_table);
+#endif
 			ZEND_HASH_FOREACH_PTR(&ce->function_table, val) {
 				prefill_from_function_table(val);
 			} ZEND_HASH_FOREACH_END();
+#if PHP_VERSION_ID >= 70300
+			GC_UNPROTECT_RECURSION(&ce->function_table);
+#else
 			ZEND_HASH_DEC_APPLY_COUNT(&ce->function_table);
+#endif
 		}
 	}
 
@@ -899,17 +911,33 @@ void xdebug_prefill_code_coverage(zend_op_array *op_array TSRMLS_DC)
 		prefill_from_oparray((char*) STR_NAME_VAL(op_array->filename), op_array TSRMLS_CC);
 	}
 
+#if PHP_VERSION_ID >= 70300
+	GC_PROTECT_RECURSION(CG(function_table));
+#else
 	ZEND_HASH_INC_APPLY_COUNT(CG(function_table));
+#endif
 	ZEND_HASH_FOREACH_PTR(CG(function_table), function_op_array) {
 		prefill_from_function_table(function_op_array);
 	} ZEND_HASH_FOREACH_END();
+#if PHP_VERSION_ID >= 70300
+	GC_UNPROTECT_RECURSION(CG(function_table));
+#else
 	ZEND_HASH_DEC_APPLY_COUNT(CG(function_table));
+#endif
 
+#if PHP_VERSION_ID >= 70300
+	GC_PROTECT_RECURSION(CG(class_table));
+#else
 	ZEND_HASH_INC_APPLY_COUNT(CG(class_table));
+#endif
 	ZEND_HASH_FOREACH_PTR(CG(class_table), class_entry) {
 		prefill_from_class_table(class_entry);
 	} ZEND_HASH_FOREACH_END();
+#if PHP_VERSION_ID >= 70300
+	GC_UNPROTECT_RECURSION(CG(class_table));
+#else
 	ZEND_HASH_DEC_APPLY_COUNT(CG(class_table));
+#endif
 }
 
 void xdebug_code_coverage_start_of_function(zend_op_array *op_array, char *function_name TSRMLS_DC)

--- a/xdebug_compat.c
+++ b/xdebug_compat.c
@@ -53,7 +53,11 @@ zval *xdebug_zval_ptr(int op_type, const znode_op *node, zend_execute_data *zdat
 {
 	zend_free_op should_free;
 
+#if PHP_VERSION_ID >= 70300
+	return zend_get_zval_ptr(zdata->opline, op_type, node, zdata, &should_free, BP_VAR_R);
+#else
 	return zend_get_zval_ptr(op_type, node, zdata, &should_free, BP_VAR_R);
+#endif
 }
 
 char *xdebug_str_to_str(char *haystack, size_t length, const char *needle, size_t needle_len, const char *str, size_t str_len, size_t *new_len)

--- a/xdebug_gc_stats.c
+++ b/xdebug_gc_stats.c
@@ -37,6 +37,9 @@ int xdebug_gc_collect_cycles(void)
 	long int           memory;
 	double             start;
 	xdebug_func        tmp;
+#if PHP_VERSION_ID >= 70300
+	zend_gc_status     status;
+#endif
 
 	if (!XG(gc_stats_enabled)) {
 		return xdebug_old_gc_collect_cycles();
@@ -44,7 +47,12 @@ int xdebug_gc_collect_cycles(void)
 
 	execute_data = EG(current_execute_data);
 
+#if PHP_VERSION_ID >= 70300
+	zend_gc_get_status(&status);
+	collected = status.collected;
+#else
 	collected = GC_G(collected);
+#endif
 	start = xdebug_get_utime();
 	memory = zend_memory_usage(0);
 
@@ -54,7 +62,12 @@ int xdebug_gc_collect_cycles(void)
 	run->function_name = NULL;
 	run->class_name = NULL;
 
+#if PHP_VERSION_ID >= 70300
+	zend_gc_get_status(&status);
+	run->collected = status.collected - collected;
+#else
 	run->collected = GC_G(collected) - collected;
+#endif
 	run->duration = xdebug_get_utime() - start;
 	run->memory_before = memory;
 	run->memory_after = zend_memory_usage(0);
@@ -240,12 +253,30 @@ PHP_FUNCTION(xdebug_stop_gcstats)
    Return number of times garbage collection was triggered. */
 PHP_FUNCTION(xdebug_get_gc_run_count)
 {
+#if PHP_VERSION_ID >= 70300
+	zend_gc_status status;
+#endif
+
+#if PHP_VERSION_ID >= 70300
+	zend_gc_get_status(&status);
+	RETURN_LONG(status.runs);
+#else
     RETURN_LONG(GC_G(gc_runs));
+#endif
 }
 
 /* {{{ proto void xdebug_get_gc_total_collected_roots()
    Return total number of collected root variables during garbage collection. */
 PHP_FUNCTION(xdebug_get_gc_total_collected_roots)
 {
+#if PHP_VERSION_ID >= 70300
+	zend_gc_status status;
+#endif
+
+#if PHP_VERSION_ID >= 70300
+	zend_gc_get_status(&status);
+	RETURN_LONG(status.collected);
+#else
     RETURN_LONG(GC_G(collected));
+#endif
 }

--- a/xdebug_trace_computerized.c
+++ b/xdebug_trace_computerized.c
@@ -138,7 +138,11 @@ void xdebug_trace_computerized_function_entry(void *ctxt, function_stack_entry *
 		if (fse->function.type == XFUNC_EVAL) {
 			zend_string *i_filename = zend_string_init(fse->include_filename, strlen(fse->include_filename), 0);
 			zend_string *escaped;
+#if PHP_VERSION_ID >= 70300
+			escaped = php_addcslashes(i_filename, (char*) "'\\\0..\37", 6);
+#else
 			escaped = php_addcslashes(i_filename, 0, (char*) "'\\\0..\37", 6);
+#endif
 			xdebug_str_add(&str, xdebug_sprintf("'%s'", escaped->val), 1);
 			zend_string_release(escaped);
 			zend_string_release(i_filename);

--- a/xdebug_trace_textual.c
+++ b/xdebug_trace_textual.c
@@ -185,7 +185,11 @@ void xdebug_trace_textual_function_entry(void *ctxt, function_stack_entry *fse, 
 		if (fse->function.type == XFUNC_EVAL) {
 			zend_string *i_filename = zend_string_init(fse->include_filename, strlen(fse->include_filename), 0);
 			zend_string *escaped;
+#if PHP_VERSION_ID >= 70300
+			escaped = php_addcslashes(i_filename, (char*) "'\\\0..\37", 6);
+#else
 			escaped = php_addcslashes(i_filename, 0, (char*) "'\\\0..\37", 6);
+#endif
 			xdebug_str_add(&str, xdebug_sprintf("'%s'", escaped->val), 1);
 			zend_string_release(escaped);
 			zend_string_release(i_filename);


### PR DESCRIPTION
We cater to all internal API changes in PHP 7.3 so far, namely:

* Run-time constant operand addressing[1]
* Array/Object recursion protection[2]
* GC_G[3]
* php_add[c]slashes[3]

[1] <https://github.com/php/php-src/blob/0896a3a/UPGRADING.INTERNALS#L41-L56>
[2] <https://github.com/php/php-src/blob/0896a3a/UPGRADING.INTERNALS#L58-L69>
[3] <https://github.com/php/php-src/blob/0896a3a/UPGRADING.INTERNALS#L143-L144>
[4] <https://github.com/php/php-src/blob/0896a3a/UPGRADING.INTERNALS#L146-L148>