### PR TITLE
Remove unused Git attributes ident

### DIFF
--- a/contrib/online_profiling_prepend.php
+++ b/contrib/online_profiling_prepend.php
@@ -3,8 +3,6 @@
 /* 
  * Online profiling dump - Written by Jani Taskinen <sniper@iki.fi> A.D. 2007
  *
- * $Id: online_profiling_prepend.php,v 1.3 2007-07-24 10:34:15 sniper Exp $
- *
  * Usage:
  *
  * You can either have this file included by using the php.ini

--- a/debugclient/Makefile.am
+++ b/debugclient/Makefile.am
@@ -1,6 +1,3 @@
-## $Id: Makefile.am,v 1.3 2003-09-22 09:04:55 derick Exp $
-##
-
 ## This source file is subject to version 1.0 of the Xdebug license,
 ## that is bundled with this package in the file LICENSE, and is
 ## available at through the world-wide-web at

--- a/debugclient/acinclude.m4
+++ b/debugclient/acinclude.m4
@@ -1,6 +1,3 @@
-dnl
-dnl $Id: acinclude.m4,v 1.3 2007-02-26 14:38:42 derick Exp $
-dnl
 dnl This file contains local autoconf functions.
 dnl This source file is subject to version 1.0 of the Xdebug license,
 dnl that is bundled with this package in the file LICENSE, and is

--- a/debugclient/build/buildcheck.sh
+++ b/debugclient/build/buildcheck.sh
@@ -15,9 +15,6 @@
 #  | Authors: Stig Bakken <ssb@fast.no>                                   |
 #  |          Sascha Schumann <sascha@schumann.cx>                        |
 #  +----------------------------------------------------------------------+
-#
-# $Id: buildcheck.sh,v 1.3 2008-12-09 20:27:24 derick Exp $ 
-#
 
 echo "buildconf: checking installation..."
 

--- a/debugclient/configure.in
+++ b/debugclient/configure.in
@@ -1,4 +1,3 @@
-dnl $Id: configure.in,v 1.7 2009-07-05 19:57:59 derick Exp $
 dnl
 dnl Process this file with autoconf to produce a configure script.
 dnl

--- a/xdebug_compat.c
+++ b/xdebug_compat.c
@@ -38,7 +38,6 @@
    | IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                        |
    +----------------------------------------------------------------------+
  */
-/* $Id: xdebug_compat.c,v 1.13 2010-05-07 20:39:13 derick Exp $ */
 
 #include "php.h"
 #include "main/php_version.h"


### PR DESCRIPTION
Hello,

The `$Id$` keywords were used in Subversion where they can be substituted with filename, last revision number change, last changed date, and last user who changed it.

In Git this functionality is different and can be done with Git attribute ident. These need to be defined manually for each file in the `.gitattributes` file and are afterwards replaced with 40-character hexadecimal blob object name which is based only on the particular file contents.

This patch simplifies handling of `$Id$` keywords by removing them since they are not used anymore and some outdated.

Thanks.