### PR TITLE
tracefile-analyzer: Trim the newline left by fgets

### DIFF
--- a/contrib/tracefile-analyser.php
+++ b/contrib/tracefile-analyser.php
@@ -132,6 +132,7 @@ class drXdebugTraceFileParser
 		{
 			$buffer = fgets( $this->handle, 4096 );
 			$read += strlen( $buffer );
+			$buffer = rtrim( $buffer, PHP_EOL );
 			$this->parseLine( $buffer );
 			$c++;
 


### PR DESCRIPTION
Currently, a warning is generated from within `parseLine` for each line of input from the tracefile:

```
PHP Notice:  A non well formed numeric value encountered in /xdebug/contrib/tracefile-analyser.php on line 185
```

The last element being parsed contains a newline, which is left behind after calling`fgets`. Snippet from the docs on [php.net](http://php.net/manual/en/function.fgets.php):

> Reading ends when length - 1 bytes have been read, or a newline (which is included in the return value), or an EOF (whichever comes first). 

This PR eliminates that warning by adding a call to `rtrim` before `parseLine`, but after incrementing the read counter.