### PR TITLE
zif_handler exists in 7.2

### DIFF
--- a/xdebug_compat.h
+++ b/xdebug_compat.h
@@ -75,7 +75,7 @@ zend_bool xdebug_zend_hash_apply_protection_end(HashTable* ht);
 #  define XDEBUG_ZEND_CONSTANT_MODULE_NUMBER(v) ((v)->module_number)
 # endif
 
-# if PHP_VERSION_ID < 70300
+# if PHP_VERSION_ID < 70200
 typedef void (*zif_handler)(INTERNAL_FUNCTION_PARAMETERS);
 # endif
 


### PR DESCRIPTION
This breaks the build on PHP 7.2 with old GCC version (RHEL-6)

```
BUILDSTDERR: In file included from /builddir/build/BUILD/php72-php-pecl-xdebug-2.7.0~beta1/NTS/php_xdebug.h:33,
BUILDSTDERR:                  from /builddir/build/BUILD/php72-php-pecl-xdebug-2.7.0~beta1/NTS/xdebug_branch_info.c:15:
BUILDSTDERR: /builddir/build/BUILD/php72-php-pecl-xdebug-2.7.0~beta1/NTS/xdebug_compat.h:79: error: redefinition of typedef 'zif_handler'
BUILDSTDERR: /opt/remi/php72/root/usr/include/php/Zend/zend_compile.h:413: note: previous declaration of 'zif_handler' was here
BUILDSTDERR: make: *** [xdebug_branch_info.lo] Error 1

```