### PR TITLE
Use early return before getpid() to gain few % of coverage time

### DIFF
--- a/xdebug_com.c
+++ b/xdebug_com.c
@@ -494,14 +494,23 @@ int xdebug_is_debug_connection_active()
 
 int xdebug_is_debug_connection_active_for_current_pid()
 {
+	zend_ulong pid;
+
+	/* Early return to save some getpid() calls */
+	if (!xdebug_is_debug_connection_active()) {
+		return 0;
+	}
+
+	pid = xdebug_get_pid();
+
 	/* Start debugger if previously a connection was established and this
 	 * process no longer has the same PID */
-	if ((xdebug_is_debug_connection_active() && (XG(remote_connection_pid) != xdebug_get_pid()))) {
+	if (XG(remote_connection_pid) != pid) {
 		xdebug_restart_debugger();
 	}
 
 	return (
-		XG(remote_connection_enabled) && (XG(remote_connection_pid) == xdebug_get_pid())
+		XG(remote_connection_enabled) && (XG(remote_connection_pid) == pid)
 	);
 }
 


### PR DESCRIPTION
Accidentally stumbled upon stracing the php with xdebug during coverage run, and the getpid() syscall was quite frequent, for a sample straced test run:

> Time: 48,36 seconds, Memory: 48,25MB
> 
> OK (4 tests, 42 assertions)
> 
> Generating code coverage report in HTML format ... done

```
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ----------------
 98,74   25,746040           1  14731714           getpid
  0,30    0,078282           2     30204        41 stat
  0,26    0,068584           3     18951      7195 access
  0,14    0,036525           4      8268       113 openat
  0,11    0,029765           2     13153           read
  0,10    0,025439           1     15517           fstat
```

without strace, xdebug-2.7.0beta1:

> Time: 9,19 seconds, Memory: 48,25MB

after applying this patch:

> Time: 8,9 seconds, Memory: 48,25MB

Not much, but still an optimization.
