### PR TITLE
Make remote log immutable for bug00932 test

### DIFF
--- a/tests/bug00932.phpt
+++ b/tests/bug00932.phpt
@@ -12,10 +12,11 @@ xdebug.force_error_reporting=0
 --FILE--
 <?php
 touch("/tmp/bug932.log");
-chmod("/tmp/bug932.log", 0);
+shell_exec("chattr +i /tmp/bug932.log");
 
 @trigger_error('foo');
 
+shell_exec("chattr -i /tmp/bug932.log");
 unlink("/tmp/bug932.log");
 ?>
 --EXPECTF--


### PR DESCRIPTION
Even with chmod 0, the log can still be written to. By adding the immutable attribute to the file, this fixes the problem and the test runs as expected.