### PR TITLE
Fixed issue #1641: Move getpid() syscall so it gets called less often…

### DIFF
--- a/xdebug_com.c
+++ b/xdebug_com.c
@@ -485,16 +485,14 @@ int xdebug_is_debug_connection_active()
 
 int xdebug_is_debug_connection_active_for_current_pid()
 {
-	long pid = getpid();
-
 	/* Start debugger if previously a connection was established and this
 	 * process no longer has the same PID */
-	if ((xdebug_is_debug_connection_active() && (XG(remote_connection_pid) != pid))) {
+	if ((xdebug_is_debug_connection_active() && (XG(remote_connection_pid) != getpid()))) {
 		xdebug_restart_debugger();
 	}
 
 	return (
-		XG(remote_connection_enabled) && (XG(remote_connection_pid) == pid)
+		XG(remote_connection_enabled) && (XG(remote_connection_pid) == getpid())
 	);
 }
 


### PR DESCRIPTION
But it probably will still be an issue when you are remote debugging. Apparently the function gets called quite often.