### PR TITLE
0001650: Add possibility to start/stop debugger from PHP

### DIFF
--- a/php_xdebug.h
+++ b/php_xdebug.h
@@ -97,6 +97,10 @@ PHP_FUNCTION(xdebug_is_enabled);
 PHP_FUNCTION(xdebug_is_debugger_active);
 PHP_FUNCTION(xdebug_break);
 
+/* custom */
+PHP_FUNCTION(xdebug_start_debugger);
+PHP_FUNCTION(xdebug_abort_debugger);
+
 /* tracing functions */
 PHP_FUNCTION(xdebug_start_trace);
 PHP_FUNCTION(xdebug_stop_trace);

--- a/php_xdebug.h
+++ b/php_xdebug.h
@@ -97,10 +97,6 @@ PHP_FUNCTION(xdebug_is_enabled);
 PHP_FUNCTION(xdebug_is_debugger_active);
 PHP_FUNCTION(xdebug_break);
 
-/* custom */
-PHP_FUNCTION(xdebug_start_debugger);
-PHP_FUNCTION(xdebug_abort_debugger);
-
 /* tracing functions */
 PHP_FUNCTION(xdebug_start_trace);
 PHP_FUNCTION(xdebug_stop_trace);
@@ -134,6 +130,10 @@ PHP_FUNCTION(xdebug_get_headers);
 PHP_FUNCTION(xdebug_memory_usage);
 PHP_FUNCTION(xdebug_peak_memory_usage);
 PHP_FUNCTION(xdebug_time_index);
+
+/* debugger functions */
+PHP_FUNCTION(xdebug_start_debugger);
+PHP_FUNCTION(xdebug_stop_debugger);
 
 /* filter functions */
 PHP_FUNCTION(xdebug_set_filter);

--- a/xdebug.c
+++ b/xdebug.c
@@ -200,7 +200,7 @@ zend_function_entry xdebug_functions[] = {
 	PHP_FE(xdebug_break,                 xdebug_void_args)
 
 	PHP_FE(xdebug_start_debugger,        xdebug_void_args)
-	PHP_FE(xdebug_abort_debugger,        xdebug_void_args)
+	PHP_FE(xdebug_stop_debugger,         xdebug_void_args)
 
 	PHP_FE(xdebug_start_trace,           xdebug_start_trace_args)
 	PHP_FE(xdebug_stop_trace,            xdebug_void_args)
@@ -2408,7 +2408,7 @@ PHP_FUNCTION(xdebug_start_debugger)
 	RETURN_TRUE;
 }
 
-PHP_FUNCTION(xdebug_abort_debugger)
+PHP_FUNCTION(xdebug_stop_debugger)
 {
 	xdebug_abort_debugger();
 

--- a/xdebug.c
+++ b/xdebug.c
@@ -199,6 +199,9 @@ zend_function_entry xdebug_functions[] = {
 	PHP_FE(xdebug_is_debugger_active,    xdebug_void_args)
 	PHP_FE(xdebug_break,                 xdebug_void_args)
 
+	PHP_FE(xdebug_start_debugger,        xdebug_void_args)
+	PHP_FE(xdebug_abort_debugger,        xdebug_void_args)
+
 	PHP_FE(xdebug_start_trace,           xdebug_start_trace_args)
 	PHP_FE(xdebug_stop_trace,            xdebug_void_args)
 	PHP_FE(xdebug_get_tracefile_name,    xdebug_void_args)
@@ -2395,6 +2398,20 @@ PHP_FUNCTION(xdebug_break)
 	xdebug_do_jit(TSRMLS_C);
 
 	XG(context).do_break = 1;
+	RETURN_TRUE;
+}
+
+PHP_FUNCTION(xdebug_start_debugger)
+{
+	xdebug_start_debugger();
+
+	RETURN_TRUE;
+}
+
+PHP_FUNCTION(xdebug_abort_debugger)
+{
+	xdebug_abort_debugger();
+
 	RETURN_TRUE;
 }
 

--- a/xdebug_com.c
+++ b/xdebug_com.c
@@ -462,6 +462,11 @@ static void xdebug_init_debugger()
 	}
 }
 
+void xdebug_start_debugger()
+{
+	xdebug_init_debugger();
+}
+
 void xdebug_abort_debugger()
 {
 	if (XG(remote_connection_enabled)) {

--- a/xdebug_com.h
+++ b/xdebug_com.h
@@ -73,4 +73,7 @@ void xdebug_mark_debug_connection_pending(void);
 void xdebug_do_jit(TSRMLS_D);
 void xdebug_do_req();
 
+void xdebug_start_debugger(void);
+void xdebug_abort_debugger(void);
+
 #endif


### PR DESCRIPTION
Exposed debugger's start and stop functions to PHP to allow long running scripts to control the debugger's flow.

```
while(true){
    if (extension_loaded('xdebug') && function_exists('xdebug_start_debugger')) {
        xdebug_start_debugger();
    }

    doSomething();

    if (extension_loaded('xdebug') && function_exists('xdebug_stop_debugger')) {
        xdebug_stop_debugger();
    }
}
```