### PR TITLE
Reset remote_addr after getting first IP

### DIFF
--- a/tests/bug01656.phpt
+++ b/tests/bug01656.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Test for bug #1656: remote_connect_back alters remote_addr_value
+--SKIPIF--
+<?php if (substr(PHP_OS, 0, 3) == "WIN") die("skip Not for Windows"); ?>
+<?php if (getenv("SKIP_UNPARALLEL_TESTS")) { exit("skip Excluding tests that can not be run in parallel"); } ?>
+--ENV--
+HTTP_X_FORWARDED_FOR=host1, host2
+--INI--
+xdebug.remote_enable=1
+xdebug.remote_log=/tmp/bug01656.txt
+xdebug.remote_autostart=1
+xdebug.remote_connect_back=1
+xdebug.remote_port=9003
+--FILE--
+<?php
+echo $_SERVER["HTTP_X_FORWARDED_FOR"], "\n";
+unlink( sys_get_temp_dir() . "/bug01656.txt" );
+?>
+--EXPECTF--
+host1, host2

--- a/xdebug_com.c
+++ b/xdebug_com.c
@@ -413,11 +413,15 @@ static void xdebug_init_debugger()
 		if (remote_addr) {
 			/* Use first IP according to RFC 7239 */
 			char *cp = strchr(Z_STRVAL_P(remote_addr), ',');
-			if (cp) {
+			int cp_found = (cp != NULL);
+			if (cp_found) {
 				*cp = '\0';
 			}
 			XDEBUG_LOG_PRINT(XG(remote_log_file), "[%ld] I: Remote address found, connecting to %s:%ld.\n", pid, Z_STRVAL_P(remote_addr), (long int) XG(remote_port));
 			XG(context).socket = xdebug_create_socket(Z_STRVAL_P(remote_addr), XG(remote_port), XG(remote_connect_timeout));
+			if (cp_found) {
+				*cp = ',';
+			}
 		} else {
 			XDEBUG_LOG_PRINT(XG(remote_log_file), "[%ld] W: Remote address not found, connecting to configured address/port: %s:%ld. :-|\n", pid, XG(remote_host), (long int) XG(remote_port));
 			XG(context).socket = xdebug_create_socket(XG(remote_host), XG(remote_port), XG(remote_connect_timeout));


### PR DESCRIPTION
Getting the  first IP for remote_connect_back modifies the configured HTTP_HEADER, so reset the value after xdebug_create_socket