### PR TITLE
uint and ulong typedefs are removed as of PHP 7.4.0

### DIFF
--- a/xdebug.c
+++ b/xdebug.c
@@ -81,9 +81,9 @@ static int xdebug_post_startup(void);
 #endif
 
 /* error callback replacement functions */
-void (*xdebug_old_error_cb)(int type, const char *error_filename, const uint error_lineno, const char *format, va_list args) ZEND_ATTRIBUTE_PTR_FORMAT(printf, 4, 0);
-void (*xdebug_new_error_cb)(int type, const char *error_filename, const uint error_lineno, const char *format, va_list args);
-void xdebug_error_cb(int type, const char *error_filename, const uint error_lineno, const char *format, va_list args);
+void (*xdebug_old_error_cb)(int type, const char *error_filename, const unsigned int error_lineno, const char *format, va_list args) ZEND_ATTRIBUTE_PTR_FORMAT(printf, 4, 0);
+void (*xdebug_new_error_cb)(int type, const char *error_filename, const unsigned int error_lineno, const char *format, va_list args);
+void xdebug_error_cb(int type, const char *error_filename, const unsigned int error_lineno, const char *format, va_list args);
 
 static int xdebug_header_handler(sapi_header_struct *h, sapi_header_op_enum op, sapi_headers_struct *s TSRMLS_DC);
 static size_t xdebug_ub_write(const char *string, size_t length TSRMLS_DC);
@@ -2052,7 +2052,7 @@ void xdebug_execute_internal(zend_execute_data *current_execute_data, zval *retu
 	int                   function_nr = 0;
 
 	int                   restore_error_handler_situation = 0;
-	void                (*tmp_error_cb)(int type, const char *error_filename, const uint error_lineno, const char *format, va_list args) ZEND_ATTRIBUTE_PTR_FORMAT(printf, 4, 0) = NULL;
+	void                (*tmp_error_cb)(int type, const char *error_filename, const unsigned int error_lineno, const char *format, va_list args) ZEND_ATTRIBUTE_PTR_FORMAT(printf, 4, 0) = NULL;
 
 	XG(level)++;
 	if ((signed long) XG(level) > XG(max_nesting_level) && (XG(max_nesting_level) != -1)) {

--- a/xdebug.c
+++ b/xdebug.c
@@ -81,9 +81,14 @@ static int xdebug_post_startup(void);
 #endif
 
 /* error callback replacement functions */
-void (*xdebug_old_error_cb)(int type, const char *error_filename, const unsigned int error_lineno, const char *format, va_list args) ZEND_ATTRIBUTE_PTR_FORMAT(printf, 4, 0);
-void (*xdebug_new_error_cb)(int type, const char *error_filename, const unsigned int error_lineno, const char *format, va_list args);
-void xdebug_error_cb(int type, const char *error_filename, const unsigned int error_lineno, const char *format, va_list args);
+#if PHP_VERSION_ID >= 70200
+# define XDEBUG_ERROR_LINENO_TYPE uint32_t
+#else
+# define XDEBUG_ERROR_LINENO_TYPE uint
+#endif
+void (*xdebug_old_error_cb)(int type, const char *error_filename, const XDEBUG_ERROR_LINENO_TYPE error_lineno, const char *format, va_list args) ZEND_ATTRIBUTE_PTR_FORMAT(printf, 4, 0);
+void (*xdebug_new_error_cb)(int type, const char *error_filename, const XDEBUG_ERROR_LINENO_TYPE error_lineno, const char *format, va_list args);
+void xdebug_error_cb(int type, const char *error_filename, const XDEBUG_ERROR_LINENO_TYPE error_lineno, const char *format, va_list args);
 
 static int xdebug_header_handler(sapi_header_struct *h, sapi_header_op_enum op, sapi_headers_struct *s TSRMLS_DC);
 static size_t xdebug_ub_write(const char *string, size_t length TSRMLS_DC);
@@ -2052,7 +2057,7 @@ void xdebug_execute_internal(zend_execute_data *current_execute_data, zval *retu
 	int                   function_nr = 0;
 
 	int                   restore_error_handler_situation = 0;
-	void                (*tmp_error_cb)(int type, const char *error_filename, const unsigned int error_lineno, const char *format, va_list args) ZEND_ATTRIBUTE_PTR_FORMAT(printf, 4, 0) = NULL;
+	void                (*tmp_error_cb)(int type, const char *error_filename, const XDEBUG_ERROR_LINENO_TYPE error_lineno, const char *format, va_list args) ZEND_ATTRIBUTE_PTR_FORMAT(printf, 4, 0) = NULL;
 
 	XG(level)++;
 	if ((signed long) XG(level) > XG(max_nesting_level) && (XG(max_nesting_level) != -1)) {

--- a/xdebug_handler_dbgp.c
+++ b/xdebug_handler_dbgp.c
@@ -1097,7 +1097,7 @@ DBGP_FUNC(eval)
 
 /* these functions interupt PHP's output functions, so we can
    redirect to our remote debugger! */
-static void xdebug_send_stream(const char *name, const char *str, uint str_length TSRMLS_DC)
+static void xdebug_send_stream(const char *name, const char *str, unsigned int str_length TSRMLS_DC)
 {
 	/* create an xml document to send as the stream */
 	xdebug_xml_node *message;
@@ -2439,7 +2439,7 @@ int xdebug_dbgp_deinit(xdebug_con *context)
 	return 1;
 }
 
-int xdebug_dbgp_error(xdebug_con *context, int type, char *exception_type, char *message, const char *location, const uint line, xdebug_llist *stack)
+int xdebug_dbgp_error(xdebug_con *context, int type, char *exception_type, char *message, const char *location, const unsigned int line, xdebug_llist *stack)
 {
 	char               *errortype;
 	xdebug_xml_node     *response, *error;

--- a/xdebug_handler_dbgp.h
+++ b/xdebug_handler_dbgp.h
@@ -101,7 +101,7 @@ typedef struct xdebug_dbgp_resolve_context {
 
 int xdebug_dbgp_init(xdebug_con *context, int mode);
 int xdebug_dbgp_deinit(xdebug_con *context);
-int xdebug_dbgp_error(xdebug_con *context, int type, char *exception_type, char *message, const char *location, const uint line, xdebug_llist *stack);
+int xdebug_dbgp_error(xdebug_con *context, int type, char *exception_type, char *message, const char *location, const unsigned int line, xdebug_llist *stack);
 int xdebug_dbgp_break_on_line(xdebug_con *context, xdebug_brk_info *brk, const char *file, int file_len, int lineno);
 int xdebug_dbgp_breakpoint(xdebug_con *context, xdebug_llist *stack, char *file, long lineno, int type, char *exception, char *code, char *message);
 int xdebug_dbgp_resolve_breakpoints(xdebug_con *context, int type, void *data);

--- a/xdebug_handlers.h
+++ b/xdebug_handlers.h
@@ -132,7 +132,7 @@ struct _xdebug_remote_handler {
 	int (*remote_deinit)(xdebug_con *h);
 
 	/* Stack messages */
-	int (*remote_error)(xdebug_con *h, int type, char *exception_type, char *message, const char *location, const uint line, xdebug_llist *stack);
+	int (*remote_error)(xdebug_con *h, int type, char *exception_type, char *message, const char *location, const unsigned int line, xdebug_llist *stack);
 
 	/* Breakpoints */
 	int (*break_on_line)(xdebug_con *h, xdebug_brk_info *brk, const char *file, int filename_len, int lineno);

--- a/xdebug_stack.c
+++ b/xdebug_stack.c
@@ -586,7 +586,7 @@ char *xdebug_strip_php_stack_trace(char *buffer)
 	return NULL;
 }
 
-char *xdebug_handle_stack_trace(int type, char *error_type_str, const char *error_filename, const uint error_lineno, char *buffer TSRMLS_DC)
+char *xdebug_handle_stack_trace(int type, char *error_type_str, const char *error_filename, const unsigned int error_lineno, char *buffer TSRMLS_DC)
 {
 	char *printable_stack;
 	char *tmp_buf;
@@ -614,7 +614,7 @@ char *xdebug_handle_stack_trace(int type, char *error_type_str, const char *erro
 }
 
 /* Error callback for formatting stack traces */
-void xdebug_error_cb(int type, const char *error_filename, const uint error_lineno, const char *format, va_list args)
+void xdebug_error_cb(int type, const char *error_filename, const unsigned int error_lineno, const char *format, va_list args)
 {
 	char *buffer, *error_type_str;
 	int buffer_len;

--- a/xdebug_stack.h
+++ b/xdebug_stack.h
@@ -35,6 +35,6 @@ void xdebug_append_printable_stack(xdebug_str *str, int html TSRMLS_DC);
 void xdebug_append_error_footer(xdebug_str *str, int html TSRMLS_DC);
 void xdebug_log_stack(const char *error_type_str, char *buffer, const char *error_filename, const int error_lineno TSRMLS_DC);
 char *xdebug_strip_php_stack_trace(char *buffer);
-char *xdebug_handle_stack_trace(int type, char *error_type_str, const char *error_filename, const uint error_lineno, char *buffer TSRMLS_DC);
+char *xdebug_handle_stack_trace(int type, char *error_type_str, const char *error_filename, const unsigned int error_lineno, char *buffer TSRMLS_DC);
 
 #endif

--- a/xdebug_var.c
+++ b/xdebug_var.c
@@ -1647,11 +1647,11 @@ xdebug_str* xdebug_get_zval_synopsis_text_ansi(zval *val, int mode, int debug_zv
 
 typedef struct
 {
-	char  type;
-	char *name;
-	int   name_len;
-	ulong index_key;
-	zval *zv;
+	char          type;
+	char         *name;
+	int           name_len;
+	unsigned long index_key;
+	zval         *zv;
 } xdebug_object_item;
 
 static int object_item_add_to_merged_hash(zval *zv_nptr, zend_ulong index_key, zend_string *hash_key, HashTable *merged, int object_type)


### PR DESCRIPTION
Since the `uint` and `ulong` typedefs will be removed from php.h, we
replace their usage with `unsigned int` and `unsigned long`,
respectively.  This lets us compile Xdebug for PHP 7.4 on Windows.