### PR TITLE
Properly sanitize dbgpclient commands on Windows as well

### DIFF
--- a/.appveyor/build_task.cmd
+++ b/.appveyor/build_task.cmd
@@ -46,7 +46,7 @@ setlocal enableextensions enabledelayedexpansion
 	set TEST_PHP_EXECUTABLE=%APPVEYOR_BUILD_FOLDER%\build\php.exe
 	set TEST_PHP_JUNIT=c:\tests_tmp\tests-junit.xml
 	set TEST_PHP_ARGS=-n -d -foo=1 -d zend_extension=%APPVEYOR_BUILD_FOLDER%\build\ext\php_opcache.dll -d zend_extension=%APPVEYOR_BUILD_FOLDER%\build\ext\php_xdebug.dll -dxdebug.remote_enable=1
-	set SKIP_DBGP_TESTS=1
+	rem set SKIP_DBGP_TESTS=1
 	set SKIP_IPV6_TESTS=1
 	set REPORT_EXIT_STATUS=1
 	set OPCACHE=%OPCACHE%

--- a/tests/bug00714.phpt
+++ b/tests/bug00714.phpt
@@ -1,5 +1,10 @@
 --TEST--
 Test for bug #714: Cachegrind files have huge (wrong) numbers in some lines
+--SKIPIF--
+<?php
+require __DIR__ . '/utils.inc';
+check_reqs('slow');
+?>
 --INI--
 xdebug.profiler_enable=1
 --FILE--

--- a/tests/bug00998-ipv4.phpt
+++ b/tests/bug00998-ipv4.phpt
@@ -8,8 +8,10 @@ check_reqs('dbgp');
 --FILE--
 <?php
 require 'dbgp/dbgpclient.php';
-dbgpRunFile("", array(), null, XDEBUG_DBGP_IPV4);
+$filename = dirname(__FILE__) . '/bug00998.inc';
+
+dbgpRunFile( $filename, [], null, XDEBUG_DBGP_IPV4 );
 ?>
 --EXPECT--
 <?xml version="1.0" encoding="iso-8859-1"?>
-<init xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" fileuri="file://" language="PHP" xdebug:language_version="" protocol_version="1.0" appid="" idekey=""><engine version=""><![CDATA[Xdebug]]></engine><author><![CDATA[Derick Rethans]]></author><url><![CDATA[https://xdebug.org]]></url><copyright><![CDATA[Copyright (c) 2002-2099 by Derick Rethans]]></copyright></init>
+<init xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" fileuri="file://bug00998.inc" language="PHP" xdebug:language_version="" protocol_version="1.0" appid="" idekey=""><engine version=""><![CDATA[Xdebug]]></engine><author><![CDATA[Derick Rethans]]></author><url><![CDATA[https://xdebug.org]]></url><copyright><![CDATA[Copyright (c) 2002-2099 by Derick Rethans]]></copyright></init>

--- a/tests/bug00998-ipv4_localhost.phpt
+++ b/tests/bug00998-ipv4_localhost.phpt
@@ -8,8 +8,10 @@ check_reqs('dbgp');
 --FILE--
 <?php
 require 'dbgp/dbgpclient.php';
-dbgpRunFile("", array(), array("xdebug.remote_host" => "localhost"), XDEBUG_DBGP_IPV4);
+$filename = dirname(__FILE__) . '/bug00998.inc';
+
+dbgpRunFile( $filename, [], [ 'xdebug.remote_host' => 'localhost' ], XDEBUG_DBGP_IPV4 );
 ?>
 --EXPECT--
 <?xml version="1.0" encoding="iso-8859-1"?>
-<init xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" fileuri="file://" language="PHP" xdebug:language_version="" protocol_version="1.0" appid="" idekey=""><engine version=""><![CDATA[Xdebug]]></engine><author><![CDATA[Derick Rethans]]></author><url><![CDATA[https://xdebug.org]]></url><copyright><![CDATA[Copyright (c) 2002-2099 by Derick Rethans]]></copyright></init>
+<init xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" fileuri="file://bug00998.inc" language="PHP" xdebug:language_version="" protocol_version="1.0" appid="" idekey=""><engine version=""><![CDATA[Xdebug]]></engine><author><![CDATA[Derick Rethans]]></author><url><![CDATA[https://xdebug.org]]></url><copyright><![CDATA[Copyright (c) 2002-2099 by Derick Rethans]]></copyright></init>

--- a/tests/bug01202.phpt
+++ b/tests/bug01202.phpt
@@ -35,11 +35,11 @@ dbgpRunFile( $filename, $commands );
 
 -> context_get -i 3
 <?xml version="1.0" encoding="iso-8859-1"?>
-<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="context_get" transaction_id="3" context="0"><property name="$a" fullname="$a" type="object" classname="class@anonymous&#0;%s0x%s" children="1" numchildren="1" page="0" pagesize="32"><property name="a" fullname="$a-&gt;a" facet="public" type="int"><![CDATA[42]]></property></property></response>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="context_get" transaction_id="3" context="0"><property name="$a" fullname="$a" type="object" classname="class@anonymous&#0;%s" children="1" numchildren="1" page="0" pagesize="32"><property name="a" fullname="$a-&gt;a" facet="public" type="int"><![CDATA[42]]></property></property></response>
 
 -> property_get -i 4 -n $a
 <?xml version="1.0" encoding="iso-8859-1"?>
-<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="property_get" transaction_id="4"><property name="$a" fullname="$a" type="object" classname="class@anonymous&#0;%s0x%s" children="1" numchildren="1" page="0" pagesize="32"><property name="a" fullname="$a-&gt;a" facet="public" type="int"><![CDATA[42]]></property></property></response>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="property_get" transaction_id="4"><property name="$a" fullname="$a" type="object" classname="class@anonymous&#0;%s" children="1" numchildren="1" page="0" pagesize="32"><property name="a" fullname="$a-&gt;a" facet="public" type="int"><![CDATA[42]]></property></property></response>
 
 -> property_get -i 5 -n $a->a
 <?xml version="1.0" encoding="iso-8859-1"?>

--- a/tests/bug01203.phpt
+++ b/tests/bug01203.phpt
@@ -35,11 +35,11 @@ dbgpRunFile( $filename, $commands );
 
 -> context_get -i 3
 <?xml version="1.0" encoding="iso-8859-1"?>
-<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="context_get" transaction_id="3" context="0"><property name="$a" fullname="$a" type="object" classname="class@anonymous&#0;%s0x%s" children="1" numchildren="1" page="0" pagesize="32"><property name="a" fullname="$a-&gt;a" facet="public" type="int"><![CDATA[42]]></property></property></response>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="context_get" transaction_id="3" context="0"><property name="$a" fullname="$a" type="object" classname="class@anonymous&#0;%s" children="1" numchildren="1" page="0" pagesize="32"><property name="a" fullname="$a-&gt;a" facet="public" type="int"><![CDATA[42]]></property></property></response>
 
 -> property_get -i 4 -n $a
 <?xml version="1.0" encoding="iso-8859-1"?>
-<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="property_get" transaction_id="4"><property name="$a" fullname="$a" type="object" classname="class@anonymous&#0;%s0x%s" children="1" numchildren="1" page="0" pagesize="32"><property name="a" fullname="$a-&gt;a" facet="public" type="int"><![CDATA[42]]></property></property></response>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="property_get" transaction_id="4"><property name="$a" fullname="$a" type="object" classname="class@anonymous&#0;%s" children="1" numchildren="1" page="0" pagesize="32"><property name="a" fullname="$a-&gt;a" facet="public" type="int"><![CDATA[42]]></property></property></response>
 
 -> property_get -i 5 -n $a::a
 <?xml version="1.0" encoding="iso-8859-1"?>

--- a/tests/dbgp/dbgpclient.php
+++ b/tests/dbgp/dbgpclient.php
@@ -168,7 +168,7 @@ class DebugClient
 			}
 
 			$sanitised = $command;
-			$sanitised = preg_replace( '@\sfile://.*/(.*\.inc)\s@', ' file://\\1 ', $sanitised );
+			$sanitised = preg_replace( '@\sfile://.*[/\\\\](.*\.inc)\s@', ' file://\\1 ', $sanitised );
 
 			echo "-> ", $sanitised, "\n";
 			fwrite( $conn, $command . "\0" );


### PR DESCRIPTION
This fixes ~40 test failures for me.