### PR TITLE
    Fixed issue #1680: Update var dumping routines to include relevant information for interned strings and immutable arrays

### DIFF
--- a/tests/bug00567-php7-nts.phpt
+++ b/tests/bug00567-php7-nts.phpt
@@ -18,5 +18,5 @@ function func(){
 func();
 ?>
 --EXPECTF--
-a: (refcount=%d, is_ref=0)='hoge'
-a: (refcount=%d, is_ref=0)='hoge'(29)
+a: (%s, is_ref=0)='hoge'
+a: (%s, is_ref=0)='hoge'(%d)

--- a/tests/bug00567-php70-nts-opcache.phpt
+++ b/tests/bug00567-php70-nts-opcache.phpt
@@ -18,5 +18,5 @@ function func(){
 func();
 ?>
 --EXPECTF--
-a: (refcount=%r(0|1)%r, is_ref=0)='hoge'
-a: (refcount=%r(0|1)%r, is_ref=0)='hoge'(29)
+a: (interned, is_ref=0)='hoge'
+a: (interned, is_ref=0)='hoge'(%d)

--- a/tests/bug00567-php70-zts.phpt
+++ b/tests/bug00567-php70-zts.phpt
@@ -18,6 +18,6 @@ function func(){
 
 func();
 ?>
---EXPECT--
-a: (refcount=1, is_ref=0)='hoge'
-a: (refcount=1, is_ref=0)='hoge'(29)
+--EXPECTF--
+a: (%s, is_ref=0)='hoge'
+a: (%s, is_ref=0)='hoge'(%d)

--- a/tests/bug00567-php71-zts-opcache.phpt
+++ b/tests/bug00567-php71-zts-opcache.phpt
@@ -19,5 +19,5 @@ function func(){
 func();
 ?>
 --EXPECTF--
-a: (refcount=%r(1|2)%r, is_ref=0)='hoge'
-a: (refcount=%r(1|2)%r, is_ref=0)='hoge'(29)
+a: (%s, is_ref=0)='hoge'
+a: (%s, is_ref=0)='hoge'(%d)

--- a/tests/bug00567-php71-zts.phpt
+++ b/tests/bug00567-php71-zts.phpt
@@ -19,5 +19,5 @@ function func(){
 func();
 ?>
 --EXPECTF--
-a: (refcount=%d, is_ref=0)='hoge'
-a: (refcount=%d, is_ref=0)='hoge'(29)
+a: (%s, is_ref=0)='hoge'
+a: (%s, is_ref=0)='hoge'(%d)

--- a/tests/bug00978-2.phpt
+++ b/tests/bug00978-2.phpt
@@ -11,7 +11,7 @@ xdebug_debug_zval('$a[1]');
 ?>
 --EXPECTF--
 4
-$a: (refcount=%d, is_ref=0)=array (0 => (refcount=1, is_ref=0)='nul', -1 => (refcount=1, is_ref=0)='minus one', -2 => (refcount=1, is_ref=0)='not two', 1 => (refcount=1, is_ref=0)='een')
-$a[-1]: (refcount=1, is_ref=0)='minus one'
+$a: (%s, is_ref=0)=array (0 => (%s, is_ref=0)='nul', -1 => (%s, is_ref=0)='minus one', -2 => (%s, is_ref=0)='not two', 1 => (%s, is_ref=0)='een')
+$a[-1]: (%s, is_ref=0)='minus one'
 $a[-]: no such symbol
-$a[1]: (refcount=1, is_ref=0)='een'
+$a[1]: (%s, is_ref=0)='een'

--- a/tests/bug01048-2.phpt
+++ b/tests/bug01048-2.phpt
@@ -8,5 +8,5 @@ xdebug_debug_zval('$GLOBALS[\'cache\']');
 xdebug_debug_zval('$GLOBALS[\'cache\']');
 ?>
 --EXPECTF--
-11$GLOBALS['cache']: (refcount=%d, is_ref=0)='cache'
-$GLOBALS['cache']: (refcount=%d, is_ref=0)='cache'
+11$GLOBALS['cache']: (%s, is_ref=0)='cache'
+$GLOBALS['cache']: (%s, is_ref=0)='cache'

--- a/tests/xdebug_debug_zval-php70-nts-opcache.phpt
+++ b/tests/xdebug_debug_zval-php70-nts-opcache.phpt
@@ -1,9 +1,9 @@
 --TEST--
-Test for xdebug_debug_zval() (< PHP 7.1, NTS, !opcache)
+Test for xdebug_debug_zval() (< PHP 7.1, NTS, opcache)
 --SKIPIF--
 <?php
 require __DIR__ . '/utils.inc';
-check_reqs('PHP < 7.1; NTS; !opcache');
+check_reqs('PHP < 7.1; NTS; opcache');
 ?>
 --INI--
 xdebug.default_enable=1
@@ -45,7 +45,7 @@ $b['b']: (refcount=2, is_ref=1)=5
 b[1]: (refcount=0, is_ref=0)=9
 c: (refcount=2, is_ref=1)=5
 d: (refcount=0, is_ref=0)=6
-e: (refcount=1, is_ref=0)=class stdClass { public $foo = (refcount=2, is_ref=1)=FALSE; public $bar = (refcount=2, is_ref=1)=FALSE; public $baz = (refcount=1, is_ref=0)=array (0 => (refcount=0, is_ref=0)=4, 'b' => (refcount=0, is_ref=0)=42) }
+e: (refcount=1, is_ref=0)=class stdClass { public $foo = (refcount=2, is_ref=1)=FALSE; public $bar = (refcount=2, is_ref=1)=FALSE; public $baz = (immutable, is_ref=0)=array (0 => (refcount=0, is_ref=0)=4, 'b' => (refcount=0, is_ref=0)=42) }
 e->bar: (refcount=2, is_ref=1)=FALSE
 e->bar['b']: no such symbol
 e->baz[0]: (refcount=0, is_ref=0)=4

--- a/tests/xdebug_debug_zval-php70-zts.phpt
+++ b/tests/xdebug_debug_zval-php70-zts.phpt
@@ -37,15 +37,15 @@ function func(){
 func();
 ?>
 --EXPECTF--
-a: (refcount=1, is_ref=0)='hoge'
-$a: (refcount=1, is_ref=0)='hoge'
+a: (%s, is_ref=0)='hoge'
+$a: (%s, is_ref=0)='hoge'
 $b: (refcount=1, is_ref=0)=array ('a' => (refcount=0, is_ref=0)=4, 'b' => (refcount=2, is_ref=1)=5, 'c' => (refcount=0, is_ref=0)=6, 0 => (refcount=0, is_ref=0)=8, 1 => (refcount=0, is_ref=0)=9)
 $b['a']: (refcount=0, is_ref=0)=4
 $b['b']: (refcount=2, is_ref=1)=5
 b[1]: (refcount=0, is_ref=0)=9
 c: (refcount=2, is_ref=1)=5
 d: (refcount=0, is_ref=0)=6
-e: (refcount=1, is_ref=0)=class stdClass { public $foo = (refcount=2, is_ref=1)=FALSE; public $bar = (refcount=2, is_ref=1)=FALSE; public $baz = (refcount=%r(1|2)%r, is_ref=0)=array (0 => (refcount=0, is_ref=0)=4, 'b' => (refcount=0, is_ref=0)=42) }
+e: (refcount=1, is_ref=0)=class stdClass { public $foo = (refcount=2, is_ref=1)=FALSE; public $bar = (refcount=2, is_ref=1)=FALSE; public $baz = (%s, is_ref=0)=array (0 => (refcount=0, is_ref=0)=4, 'b' => (refcount=0, is_ref=0)=42) }
 e->bar: (refcount=2, is_ref=1)=FALSE
 e->bar['b']: no such symbol
 e->baz[0]: (refcount=0, is_ref=0)=4

--- a/tests/xdebug_debug_zval-php71-nts-opcache.phpt
+++ b/tests/xdebug_debug_zval-php71-nts-opcache.phpt
@@ -37,15 +37,15 @@ function func(){
 func();
 ?>
 --EXPECT--
-a: (refcount=1, is_ref=0)='hoge'
-$a: (refcount=1, is_ref=0)='hoge'
+a: (interned, is_ref=0)='hoge'
+$a: (interned, is_ref=0)='hoge'
 $b: (refcount=1, is_ref=0)=array ('a' => (refcount=0, is_ref=0)=4, 'b' => (refcount=2, is_ref=1)=5, 'c' => (refcount=0, is_ref=0)=6, 0 => (refcount=0, is_ref=0)=8, 1 => (refcount=0, is_ref=0)=9)
 $b['a']: (refcount=0, is_ref=0)=4
 $b['b']: (refcount=2, is_ref=1)=5
 b[1]: (refcount=0, is_ref=0)=9
 c: (refcount=2, is_ref=1)=5
 d: (refcount=0, is_ref=0)=6
-e: (refcount=1, is_ref=0)=class stdClass { public $foo = (refcount=2, is_ref=1)=FALSE; public $bar = (refcount=2, is_ref=1)=FALSE; public $baz = (refcount=2, is_ref=0)=array (0 => (refcount=0, is_ref=0)=4, 'b' => (refcount=0, is_ref=0)=42) }
+e: (refcount=1, is_ref=0)=class stdClass { public $foo = (refcount=2, is_ref=1)=FALSE; public $bar = (refcount=2, is_ref=1)=FALSE; public $baz = (immutable, is_ref=0)=array (0 => (refcount=0, is_ref=0)=4, 'b' => (refcount=0, is_ref=0)=42) }
 e->bar: (refcount=2, is_ref=1)=FALSE
 e->bar['b']: no such symbol
 e->baz[0]: (refcount=0, is_ref=0)=4

--- a/tests/xdebug_debug_zval-php71-nts.phpt
+++ b/tests/xdebug_debug_zval-php71-nts.phpt
@@ -37,8 +37,8 @@ function func(){
 func();
 ?>
 --EXPECTF--
-a: (refcount=%d, is_ref=0)='hoge'
-$a: (refcount=%d, is_ref=0)='hoge'
+a: (%s, is_ref=0)='hoge'
+$a: (%s, is_ref=0)='hoge'
 $b: (refcount=1, is_ref=0)=array ('a' => (refcount=0, is_ref=0)=4, 'b' => (refcount=2, is_ref=1)=5, 'c' => (refcount=0, is_ref=0)=6, 0 => (refcount=0, is_ref=0)=8, 1 => (refcount=0, is_ref=0)=9)
 $b['a']: (refcount=0, is_ref=0)=4
 $b['b']: (refcount=2, is_ref=1)=5

--- a/tests/xdebug_debug_zval-php71-zts-opcache.phpt
+++ b/tests/xdebug_debug_zval-php71-zts-opcache.phpt
@@ -37,15 +37,15 @@ function func(){
 func();
 ?>
 --EXPECTF--
-a: (refcount=%r(0|1|2)%r, is_ref=0)='hoge'
-$a: (refcount=%r(0|1|2)%r, is_ref=0)='hoge'
+a: (%s, is_ref=0)='hoge'
+$a: (%s, is_ref=0)='hoge'
 $b: (refcount=1, is_ref=0)=array ('a' => (refcount=0, is_ref=0)=4, 'b' => (refcount=2, is_ref=1)=5, 'c' => (refcount=0, is_ref=0)=6, 0 => (refcount=0, is_ref=0)=8, 1 => (refcount=0, is_ref=0)=9)
 $b['a']: (refcount=0, is_ref=0)=4
 $b['b']: (refcount=2, is_ref=1)=5
 b[1]: (refcount=0, is_ref=0)=9
 c: (refcount=2, is_ref=1)=5
 d: (refcount=0, is_ref=0)=6
-e: (refcount=1, is_ref=0)=class stdClass { public $foo = (refcount=2, is_ref=1)=FALSE; public $bar = (refcount=2, is_ref=1)=FALSE; public $baz = (refcount=2, is_ref=0)=array (0 => (refcount=0, is_ref=0)=4, 'b' => (refcount=0, is_ref=0)=42) }
+e: (refcount=1, is_ref=0)=class stdClass { public $foo = (refcount=2, is_ref=1)=FALSE; public $bar = (refcount=2, is_ref=1)=FALSE; public $baz = (%s, is_ref=0)=array (0 => (refcount=0, is_ref=0)=4, 'b' => (refcount=0, is_ref=0)=42) }
 e->bar: (refcount=2, is_ref=1)=FALSE
 e->bar['b']: no such symbol
 e->baz[0]: (refcount=0, is_ref=0)=4

--- a/tests/xdebug_debug_zval-php71-zts.phpt
+++ b/tests/xdebug_debug_zval-php71-zts.phpt
@@ -37,8 +37,8 @@ function func(){
 func();
 ?>
 --EXPECTF--
-a: (refcount=%d, is_ref=0)='hoge'
-$a: (refcount=%d, is_ref=0)='hoge'
+a: (%s, is_ref=0)='hoge'
+$a: (%s, is_ref=0)='hoge'
 $b: (refcount=1, is_ref=0)=array ('a' => (refcount=0, is_ref=0)=4, 'b' => (refcount=2, is_ref=1)=5, 'c' => (refcount=0, is_ref=0)=6, 0 => (refcount=0, is_ref=0)=8, 1 => (refcount=0, is_ref=0)=9)
 $b['a']: (refcount=0, is_ref=0)=4
 $b['b']: (refcount=2, is_ref=1)=5

--- a/tests/xdebug_debug_zval-php72-opcache.phpt
+++ b/tests/xdebug_debug_zval-php72-opcache.phpt
@@ -45,7 +45,7 @@ $b['b']: (refcount=2, is_ref=1)=5
 b[1]: (refcount=0, is_ref=0)=9
 c: (refcount=2, is_ref=1)=5
 d: (refcount=0, is_ref=0)=6
-e: (refcount=1, is_ref=0)=class stdClass { public $foo = (refcount=2, is_ref=1)=FALSE; public $bar = (refcount=2, is_ref=1)=FALSE; public $baz = (refcount=2, is_ref=0)=array (0 => (refcount=0, is_ref=0)=4, 'b' => (refcount=0, is_ref=0)=42) }
+e: (refcount=1, is_ref=0)=class stdClass { public $foo = (refcount=2, is_ref=1)=FALSE; public $bar = (refcount=2, is_ref=1)=FALSE; public $baz = (immutable, is_ref=0)=array (0 => (refcount=0, is_ref=0)=4, 'b' => (refcount=0, is_ref=0)=42) }
 e->bar: (refcount=2, is_ref=1)=FALSE
 e->bar['b']: no such symbol
 e->baz[0]: (refcount=0, is_ref=0)=4

--- a/tests/xdebug_debug_zval_cli_color-php70-nts-opcache.phpt
+++ b/tests/xdebug_debug_zval_cli_color-php70-nts-opcache.phpt
@@ -1,9 +1,9 @@
 --TEST--
-Test for xdebug_debug_zval() (CLI colours) (< PHP 7.1, NTS, !opcache)
+Test for xdebug_debug_zval() (CLI colours) (< PHP 7.1, NTS, opcache)
 --SKIPIF--
 <?php
 require __DIR__ . '/utils.inc';
-check_reqs('PHP <= 7.1; NTS; !opcache');
+check_reqs('PHP <= 7.1; NTS; opcache');
 ?>
 --INI--
 xdebug.default_enable=1
@@ -70,7 +70,7 @@ e: (refcount=1, is_ref=0)=[1mclass[22m [31mstdClass[0m#1 ([32m3[0m) {
   [32m[1mpublic[22m[0m $bar [0m=>[0m
   (refcount=2, is_ref=1)=[1mbool[22m([35mfalse[0m)
   [32m[1mpublic[22m[0m $baz [0m=>[0m
-  (refcount=1, is_ref=0)=[1marray[22m([32m2[0m) {
+  (immutable, is_ref=0)=[1marray[22m([32m2[0m) {
     [0] [0m=>[0m
     (refcount=0, is_ref=0)=[1mint[22m([32m4[0m)
     'b' =>

--- a/tests/xdebug_debug_zval_cli_color-php70-zts.phpt
+++ b/tests/xdebug_debug_zval_cli_color-php70-zts.phpt
@@ -37,9 +37,9 @@ function func(){
 func();
 ?>
 --EXPECTF--
-a: (refcount=1, is_ref=0)=[1mstring[22m([32m4[0m) "[31mhoge[0m"
+a: (%s, is_ref=0)=[1mstring[22m([32m4[0m) "[31mhoge[0m"
 
-$a: (refcount=1, is_ref=0)=[1mstring[22m([32m4[0m) "[31mhoge[0m"
+$a: (%s, is_ref=0)=[1mstring[22m([32m4[0m) "[31mhoge[0m"
 
 $b: (refcount=1, is_ref=0)=[1marray[22m([32m5[0m) {
   'a' =>
@@ -70,7 +70,7 @@ e: (refcount=1, is_ref=0)=[1mclass[22m [31mstdClass[0m#1 ([32m3[0m) {
   [32m[1mpublic[22m[0m $bar [0m=>[0m
   (refcount=2, is_ref=1)=[1mbool[22m([35mfalse[0m)
   [32m[1mpublic[22m[0m $baz [0m=>[0m
-  (refcount=%r(1|2)%r, is_ref=0)=[1marray[22m([32m2[0m) {
+  (%s, is_ref=0)=[1marray[22m([32m2[0m) {
     [0] [0m=>[0m
     (refcount=0, is_ref=0)=[1mint[22m([32m4[0m)
     'b' =>

--- a/tests/xdebug_debug_zval_cli_color-php71-nts-opcache.phpt
+++ b/tests/xdebug_debug_zval_cli_color-php71-nts-opcache.phpt
@@ -37,9 +37,9 @@ function func(){
 func();
 ?>
 --EXPECT--
-a: (refcount=1, is_ref=0)=[1mstring[22m([32m4[0m) "[31mhoge[0m"
+a: (interned, is_ref=0)=[1mstring[22m([32m4[0m) "[31mhoge[0m"
 
-$a: (refcount=1, is_ref=0)=[1mstring[22m([32m4[0m) "[31mhoge[0m"
+$a: (interned, is_ref=0)=[1mstring[22m([32m4[0m) "[31mhoge[0m"
 
 $b: (refcount=1, is_ref=0)=[1marray[22m([32m5[0m) {
   'a' =>
@@ -70,7 +70,7 @@ e: (refcount=1, is_ref=0)=[1mclass[22m [31mstdClass[0m#1 ([32m3[0m) {
   [32m[1mpublic[22m[0m $bar [0m=>[0m
   (refcount=2, is_ref=1)=[1mbool[22m([35mfalse[0m)
   [32m[1mpublic[22m[0m $baz [0m=>[0m
-  (refcount=2, is_ref=0)=[1marray[22m([32m2[0m) {
+  (immutable, is_ref=0)=[1marray[22m([32m2[0m) {
     [0] [0m=>[0m
     (refcount=0, is_ref=0)=[1mint[22m([32m4[0m)
     'b' =>

--- a/tests/xdebug_debug_zval_cli_color-php71-nts.phpt
+++ b/tests/xdebug_debug_zval_cli_color-php71-nts.phpt
@@ -37,9 +37,9 @@ function func(){
 func();
 ?>
 --EXPECTF--
-a: (refcount=%d, is_ref=0)=[1mstring[22m([32m4[0m) "[31mhoge[0m"
+a: (%s, is_ref=0)=[1mstring[22m([32m4[0m) "[31mhoge[0m"
 
-$a: (refcount=%d, is_ref=0)=[1mstring[22m([32m4[0m) "[31mhoge[0m"
+$a: (%s, is_ref=0)=[1mstring[22m([32m4[0m) "[31mhoge[0m"
 
 $b: (refcount=1, is_ref=0)=[1marray[22m([32m5[0m) {
   'a' =>

--- a/tests/xdebug_debug_zval_cli_color-php71-zts-opcache.phpt
+++ b/tests/xdebug_debug_zval_cli_color-php71-zts-opcache.phpt
@@ -37,9 +37,9 @@ function func(){
 func();
 ?>
 --EXPECTF--
-a: (refcount=%r(0|1|2)%r, is_ref=0)=[1mstring[22m([32m4[0m) "[31mhoge[0m"
+a: (%s, is_ref=0)=[1mstring[22m([32m4[0m) "[31mhoge[0m"
 
-$a: (refcount=%r(0|1|2)%r, is_ref=0)=[1mstring[22m([32m4[0m) "[31mhoge[0m"
+$a: (%s, is_ref=0)=[1mstring[22m([32m4[0m) "[31mhoge[0m"
 
 $b: (refcount=1, is_ref=0)=[1marray[22m([32m5[0m) {
   'a' =>
@@ -70,7 +70,7 @@ e: (refcount=1, is_ref=0)=[1mclass[22m [31mstdClass[0m#1 ([32m3[0m) {
   [32m[1mpublic[22m[0m $bar [0m=>[0m
   (refcount=2, is_ref=1)=[1mbool[22m([35mfalse[0m)
   [32m[1mpublic[22m[0m $baz [0m=>[0m
-  (refcount=2, is_ref=0)=[1marray[22m([32m2[0m) {
+  (%s, is_ref=0)=[1marray[22m([32m2[0m) {
     [0] [0m=>[0m
     (refcount=0, is_ref=0)=[1mint[22m([32m4[0m)
     'b' =>

--- a/tests/xdebug_debug_zval_cli_color-php72-opcache.phpt
+++ b/tests/xdebug_debug_zval_cli_color-php72-opcache.phpt
@@ -68,7 +68,7 @@ e: (refcount=1, is_ref=0)=[1mclass[22m [31mstdClass[0m#1 ([32m3[0m) {
   [32m[1mpublic[22m[0m $bar [0m=>[0m
   (refcount=2, is_ref=1)=[1mbool[22m([35mfalse[0m)
   [32m[1mpublic[22m[0m $baz [0m=>[0m
-  (refcount=2, is_ref=0)=[1marray[22m([32m2[0m) {
+  (immutable, is_ref=0)=[1marray[22m([32m2[0m) {
     [0] [0m=>[0m
     (refcount=0, is_ref=0)=[1mint[22m([32m4[0m)
     'b' =>

--- a/tests/xdebug_debug_zval_stdout-php70-nts-opcache.phpt
+++ b/tests/xdebug_debug_zval_stdout-php70-nts-opcache.phpt
@@ -1,9 +1,9 @@
 --TEST--
-Test for xdebug_debug_zval() (< PHP 7.1, NTS, !opcache)
+Test for xdebug_debug_zval_stdout() (< PHP 7.1, NTS; opcache)
 --SKIPIF--
 <?php
 require __DIR__ . '/utils.inc';
-check_reqs('PHP < 7.1; NTS; !opcache');
+check_reqs('PHP < 7.1; NTS; opcache');
 ?>
 --INI--
 xdebug.default_enable=1
@@ -45,7 +45,7 @@ $b['b']: (refcount=2, is_ref=1)=5
 b[1]: (refcount=0, is_ref=0)=9
 c: (refcount=2, is_ref=1)=5
 d: (refcount=0, is_ref=0)=6
-e: (refcount=1, is_ref=0)=class stdClass { public $foo = (refcount=2, is_ref=1)=FALSE; public $bar = (refcount=2, is_ref=1)=FALSE; public $baz = (refcount=1, is_ref=0)=array (0 => (refcount=0, is_ref=0)=4, 'b' => (refcount=0, is_ref=0)=42) }
+e: (refcount=1, is_ref=0)=class stdClass { public $foo = (refcount=2, is_ref=1)=FALSE; public $bar = (refcount=2, is_ref=1)=FALSE; public $baz = (immutable, is_ref=0)=array (0 => (refcount=0, is_ref=0)=4, 'b' => (refcount=0, is_ref=0)=42) }
 e->bar: (refcount=2, is_ref=1)=FALSE
 e->bar['b']: no such symbol
 e->baz[0]: (refcount=0, is_ref=0)=4

--- a/tests/xdebug_debug_zval_stdout-php70-nts.phpt
+++ b/tests/xdebug_debug_zval_stdout-php70-nts.phpt
@@ -1,9 +1,9 @@
 --TEST--
-Test for xdebug_debug_zval_stdout() (< PHP 7.1, NTS)
+Test for xdebug_debug_zval_stdout() (< PHP 7.1, NTS, !opcache)
 --SKIPIF--
 <?php
 require __DIR__ . '/utils.inc';
-check_reqs('PHP < 7.1; NTS');
+check_reqs('PHP < 7.1; NTS; !opcache');
 ?>
 --INI--
 xdebug.default_enable=1
@@ -37,15 +37,15 @@ function func(){
 func();
 ?>
 --EXPECTF--
-a: (refcount=%r(0|1)%r, is_ref=0)='hoge'
-$a: (refcount=%r(0|1)%r, is_ref=0)='hoge'
+a: (interned, is_ref=0)='hoge'
+$a: (interned, is_ref=0)='hoge'
 $b: (refcount=1, is_ref=0)=array ('a' => (refcount=0, is_ref=0)=4, 'b' => (refcount=2, is_ref=1)=5, 'c' => (refcount=0, is_ref=0)=6, 0 => (refcount=0, is_ref=0)=8, 1 => (refcount=0, is_ref=0)=9)
 $b['a']: (refcount=0, is_ref=0)=4
 $b['b']: (refcount=2, is_ref=1)=5
 b[1]: (refcount=0, is_ref=0)=9
 c: (refcount=2, is_ref=1)=5
 d: (refcount=0, is_ref=0)=6
-e: (refcount=1, is_ref=0)=class stdClass { public $foo = (refcount=2, is_ref=1)=FALSE; public $bar = (refcount=2, is_ref=1)=FALSE; public $baz = (refcount=%r(1|2)%r, is_ref=0)=array (0 => (refcount=0, is_ref=0)=4, 'b' => (refcount=0, is_ref=0)=42) }
+e: (refcount=1, is_ref=0)=class stdClass { public $foo = (refcount=2, is_ref=1)=FALSE; public $bar = (refcount=2, is_ref=1)=FALSE; public $baz = (refcount=1, is_ref=0)=array (0 => (refcount=0, is_ref=0)=4, 'b' => (refcount=0, is_ref=0)=42) }
 e->bar: (refcount=2, is_ref=1)=FALSE
 e->bar['b']: no such symbol
 e->baz[0]: (refcount=0, is_ref=0)=4

--- a/tests/xdebug_debug_zval_stdout-php70-zts.phpt
+++ b/tests/xdebug_debug_zval_stdout-php70-zts.phpt
@@ -37,15 +37,15 @@ function func(){
 func();
 ?>
 --EXPECTF--
-a: (refcount=1, is_ref=0)='hoge'
-$a: (refcount=1, is_ref=0)='hoge'
+a: (%s, is_ref=0)='hoge'
+$a: (%s, is_ref=0)='hoge'
 $b: (refcount=1, is_ref=0)=array ('a' => (refcount=0, is_ref=0)=4, 'b' => (refcount=2, is_ref=1)=5, 'c' => (refcount=0, is_ref=0)=6, 0 => (refcount=0, is_ref=0)=8, 1 => (refcount=0, is_ref=0)=9)
 $b['a']: (refcount=0, is_ref=0)=4
 $b['b']: (refcount=2, is_ref=1)=5
 b[1]: (refcount=0, is_ref=0)=9
 c: (refcount=2, is_ref=1)=5
 d: (refcount=0, is_ref=0)=6
-e: (refcount=1, is_ref=0)=class stdClass { public $foo = (refcount=2, is_ref=1)=FALSE; public $bar = (refcount=2, is_ref=1)=FALSE; public $baz = (refcount=%r(1|2)%r, is_ref=0)=array (0 => (refcount=0, is_ref=0)=4, 'b' => (refcount=0, is_ref=0)=42) }
+e: (refcount=1, is_ref=0)=class stdClass { public $foo = (refcount=2, is_ref=1)=FALSE; public $bar = (refcount=2, is_ref=1)=FALSE; public $baz = (%s, is_ref=0)=array (0 => (refcount=0, is_ref=0)=4, 'b' => (refcount=0, is_ref=0)=42) }
 e->bar: (refcount=2, is_ref=1)=FALSE
 e->bar['b']: no such symbol
 e->baz[0]: (refcount=0, is_ref=0)=4

--- a/tests/xdebug_debug_zval_stdout-php71-nts-opcache.phpt
+++ b/tests/xdebug_debug_zval_stdout-php71-nts-opcache.phpt
@@ -37,15 +37,15 @@ function func(){
 func();
 ?>
 --EXPECT--
-a: (refcount=1, is_ref=0)='hoge'
-$a: (refcount=1, is_ref=0)='hoge'
+a: (interned, is_ref=0)='hoge'
+$a: (interned, is_ref=0)='hoge'
 $b: (refcount=1, is_ref=0)=array ('a' => (refcount=0, is_ref=0)=4, 'b' => (refcount=2, is_ref=1)=5, 'c' => (refcount=0, is_ref=0)=6, 0 => (refcount=0, is_ref=0)=8, 1 => (refcount=0, is_ref=0)=9)
 $b['a']: (refcount=0, is_ref=0)=4
 $b['b']: (refcount=2, is_ref=1)=5
 b[1]: (refcount=0, is_ref=0)=9
 c: (refcount=2, is_ref=1)=5
 d: (refcount=0, is_ref=0)=6
-e: (refcount=1, is_ref=0)=class stdClass { public $foo = (refcount=2, is_ref=1)=FALSE; public $bar = (refcount=2, is_ref=1)=FALSE; public $baz = (refcount=2, is_ref=0)=array (0 => (refcount=0, is_ref=0)=4, 'b' => (refcount=0, is_ref=0)=42) }
+e: (refcount=1, is_ref=0)=class stdClass { public $foo = (refcount=2, is_ref=1)=FALSE; public $bar = (refcount=2, is_ref=1)=FALSE; public $baz = (immutable, is_ref=0)=array (0 => (refcount=0, is_ref=0)=4, 'b' => (refcount=0, is_ref=0)=42) }
 e->bar: (refcount=2, is_ref=1)=FALSE
 e->bar['b']: no such symbol
 e->baz[0]: (refcount=0, is_ref=0)=4

--- a/tests/xdebug_debug_zval_stdout-php71-nts.phpt
+++ b/tests/xdebug_debug_zval_stdout-php71-nts.phpt
@@ -37,8 +37,8 @@ function func(){
 func();
 ?>
 --EXPECTF--
-a: (refcount=%d, is_ref=0)='hoge'
-$a: (refcount=%d, is_ref=0)='hoge'
+a: (%s, is_ref=0)='hoge'
+$a: (%s, is_ref=0)='hoge'
 $b: (refcount=1, is_ref=0)=array ('a' => (refcount=0, is_ref=0)=4, 'b' => (refcount=2, is_ref=1)=5, 'c' => (refcount=0, is_ref=0)=6, 0 => (refcount=0, is_ref=0)=8, 1 => (refcount=0, is_ref=0)=9)
 $b['a']: (refcount=0, is_ref=0)=4
 $b['b']: (refcount=2, is_ref=1)=5

--- a/tests/xdebug_debug_zval_stdout-php71-zts-opcache.phpt
+++ b/tests/xdebug_debug_zval_stdout-php71-zts-opcache.phpt
@@ -37,15 +37,15 @@ function func(){
 func();
 ?>
 --EXPECTF--
-a: (refcount=%r(0|1|2)%r, is_ref=0)='hoge'
-$a: (refcount=%r(0|1|2)%r, is_ref=0)='hoge'
+a: (%s, is_ref=0)='hoge'
+$a: (%s, is_ref=0)='hoge'
 $b: (refcount=1, is_ref=0)=array ('a' => (refcount=0, is_ref=0)=4, 'b' => (refcount=2, is_ref=1)=5, 'c' => (refcount=0, is_ref=0)=6, 0 => (refcount=0, is_ref=0)=8, 1 => (refcount=0, is_ref=0)=9)
 $b['a']: (refcount=0, is_ref=0)=4
 $b['b']: (refcount=2, is_ref=1)=5
 b[1]: (refcount=0, is_ref=0)=9
 c: (refcount=2, is_ref=1)=5
 d: (refcount=0, is_ref=0)=6
-e: (refcount=1, is_ref=0)=class stdClass { public $foo = (refcount=2, is_ref=1)=FALSE; public $bar = (refcount=2, is_ref=1)=FALSE; public $baz = (refcount=2, is_ref=0)=array (0 => (refcount=0, is_ref=0)=4, 'b' => (refcount=0, is_ref=0)=42) }
+e: (refcount=1, is_ref=0)=class stdClass { public $foo = (refcount=2, is_ref=1)=FALSE; public $bar = (refcount=2, is_ref=1)=FALSE; public $baz = (%s, is_ref=0)=array (0 => (refcount=0, is_ref=0)=4, 'b' => (refcount=0, is_ref=0)=42) }
 e->bar: (refcount=2, is_ref=1)=FALSE
 e->bar['b']: no such symbol
 e->baz[0]: (refcount=0, is_ref=0)=4

--- a/tests/xdebug_debug_zval_stdout-php71-zts.phpt
+++ b/tests/xdebug_debug_zval_stdout-php71-zts.phpt
@@ -37,8 +37,8 @@ function func(){
 func();
 ?>
 --EXPECTF--
-a: (refcount=%d, is_ref=0)='hoge'
-$a: (refcount=%d, is_ref=0)='hoge'
+a: (%s, is_ref=0)='hoge'
+$a: (%s, is_ref=0)='hoge'
 $b: (refcount=1, is_ref=0)=array ('a' => (refcount=0, is_ref=0)=4, 'b' => (refcount=2, is_ref=1)=5, 'c' => (refcount=0, is_ref=0)=6, 0 => (refcount=0, is_ref=0)=8, 1 => (refcount=0, is_ref=0)=9)
 $b['a']: (refcount=0, is_ref=0)=4
 $b['b']: (refcount=2, is_ref=1)=5

--- a/tests/xdebug_debug_zval_stdout-php72-opcache.phpt
+++ b/tests/xdebug_debug_zval_stdout-php72-opcache.phpt
@@ -45,7 +45,7 @@ $b['b']: (refcount=2, is_ref=1)=5
 b[1]: (refcount=0, is_ref=0)=9
 c: (refcount=2, is_ref=1)=5
 d: (refcount=0, is_ref=0)=6
-e: (refcount=1, is_ref=0)=class stdClass { public $foo = (refcount=2, is_ref=1)=FALSE; public $bar = (refcount=2, is_ref=1)=FALSE; public $baz = (refcount=2, is_ref=0)=array (0 => (refcount=0, is_ref=0)=4, 'b' => (refcount=0, is_ref=0)=42) }
+e: (refcount=1, is_ref=0)=class stdClass { public $foo = (refcount=2, is_ref=1)=FALSE; public $bar = (refcount=2, is_ref=1)=FALSE; public $baz = (immutable, is_ref=0)=array (0 => (refcount=0, is_ref=0)=4, 'b' => (refcount=0, is_ref=0)=42) }
 e->bar: (refcount=2, is_ref=1)=FALSE
 e->bar['b']: no such symbol
 e->baz[0]: (refcount=0, is_ref=0)=4


### PR DESCRIPTION
Prompted by [this question](https://stackoverflow.com/questions/56833897/why-increasing-refcount-of-zval-not-working)

It's not really appropriate to display a refcount for values that are not refcounted, so for interned strings and immutable arrays, show something relevant maybe ?

There's no test, the immutable arrays part would be dependent on opcache, and I'm not familiar enough with CI to know how that is setup.