### PR TITLE
Fixed issue #1687: Use appropriate process ID for logging and "right process" tracking

### DIFF
--- a/.appveyor/build_task.cmd
+++ b/.appveyor/build_task.cmd
@@ -45,7 +45,7 @@ setlocal enableextensions enabledelayedexpansion
 	mkdir c:\tests_tmp
 	set TEST_PHP_EXECUTABLE=%APPVEYOR_BUILD_FOLDER%\build\php.exe
 	set TEST_PHP_JUNIT=c:\tests_tmp\tests-junit.xml
-	set TEST_PHP_ARGS=-n -d -foo=yes -d zend_extension=%APPVEYOR_BUILD_FOLDER%\build\ext\php_opcache.dll -d zend_extension=%APPVEYOR_BUILD_FOLDER%\build\ext\php_xdebug.dll -dxdebug.remote_enable=1
+	set TEST_PHP_ARGS=-n -d foo=yes -d zend_extension=%APPVEYOR_BUILD_FOLDER%\build\ext\php_opcache.dll -d zend_extension=%APPVEYOR_BUILD_FOLDER%\build\ext\php_xdebug.dll -dxdebug.remote_enable=1
 	rem set SKIP_DBGP_TESTS=1
 	set SKIP_IPV6_TESTS=1
 	set REPORT_EXIT_STATUS=1

--- a/php_xdebug.h
+++ b/php_xdebug.h
@@ -263,7 +263,7 @@ ZEND_BEGIN_MODULE_GLOBALS(xdebug)
 
 	/* remote debugging globals */
 	zend_bool     remote_connection_enabled;
-	pid_t         remote_connection_pid;
+	zend_ulong    remote_connection_pid;
 	zend_bool     breakpoints_allowed;
 	xdebug_con    context;
 	unsigned int  breakpoint_count;

--- a/run-xdebug-tests.php
+++ b/run-xdebug-tests.php
@@ -2412,7 +2412,7 @@ function settings2params(&$ini_settings)
 				$settings .= " -d \"$name=$val\"";
 			}
 		} else {
-			if (substr(PHP_OS, 0, 3) == "WIN" && !empty($value) && $value{0} == '"') {
+			if (substr(PHP_OS, 0, 3) == "WIN" && !empty($value) && is_string($value) && $value{0} == '"') {
 				$len = strlen($value);
 
 				if ($value{$len - 1} == '"') {

--- a/usefulstuff.c
+++ b/usefulstuff.c
@@ -561,7 +561,7 @@ int xdebug_format_output_filename(char **filename, char *format, char *script_na
 					break;
 
 				case 'p': /* pid */
-					xdebug_str_add(&fname, xdebug_sprintf("%ld", getpid()), 1);
+					xdebug_str_add(&fname, xdebug_sprintf(ZEND_ULONG_FMT, xdebug_get_pid()), 1);
 					break;
 
 				case 'r': /* random number */

--- a/xdebug_com.c
+++ b/xdebug_com.c
@@ -347,7 +347,7 @@ int xdebug_handle_hit_value(xdebug_brk_info *brk_info)
 /* Log related functions */
 static void xdebug_open_log(void)
 {
-	long pid = getpid();
+	zend_ulong pid = xdebug_get_pid();
 
 	/* initialize remote log file */
 	XG(remote_log_file) = NULL;
@@ -356,7 +356,7 @@ static void xdebug_open_log(void)
 	}
 	if (XG(remote_log_file)) {
 		char *timestr = xdebug_get_time();
-		fprintf(XG(remote_log_file), "[%ld] Log opened at %s\n", pid, timestr);
+		fprintf(XG(remote_log_file), "[" ZEND_ULONG_FMT "] Log opened at %s\n", pid, timestr);
 		fflush(XG(remote_log_file));
 		xdfree(timestr);
 	} else if (strlen(XG(remote_log))) {
@@ -368,10 +368,10 @@ static void xdebug_close_log()
 {
 
 	if (XG(remote_log_file)) {
-		long pid = getpid();
+		zend_ulong pid = xdebug_get_pid();
 		char *timestr = xdebug_get_time();
 
-		fprintf(XG(remote_log_file), "[%ld] Log closed at %s\n\n", pid, timestr);
+		fprintf(XG(remote_log_file), "[" ZEND_ULONG_FMT "] Log closed at %s\n\n", pid, timestr);
 		fflush(XG(remote_log_file));
 		xdfree(timestr);
 		fclose(XG(remote_log_file));
@@ -496,19 +496,19 @@ int xdebug_is_debug_connection_active_for_current_pid()
 {
 	/* Start debugger if previously a connection was established and this
 	 * process no longer has the same PID */
-	if ((xdebug_is_debug_connection_active() && (XG(remote_connection_pid) != getpid()))) {
+	if ((xdebug_is_debug_connection_active() && (XG(remote_connection_pid) != xdebug_get_pid()))) {
 		xdebug_restart_debugger();
 	}
 
 	return (
-		XG(remote_connection_enabled) && (XG(remote_connection_pid) == getpid())
+		XG(remote_connection_enabled) && (XG(remote_connection_pid) == xdebug_get_pid())
 	);
 }
 
 void xdebug_mark_debug_connection_active()
 {
 	XG(remote_connection_enabled) = 1;
-	XG(remote_connection_pid) = getpid();
+	XG(remote_connection_pid) = xdebug_get_pid();
 }
 
 void xdebug_mark_debug_connection_pending()

--- a/xdebug_compat.c
+++ b/xdebug_compat.c
@@ -355,6 +355,19 @@ void xdebug_stripcslashes(char *str, int *len)
 	*len = nlen;
 }
 
+zend_ulong xdebug_get_pid(void)
+{
+#ifndef ZTS
+	return (zend_ulong) getpid();
+#else
+# ifdef _WIN32
+	return (zend_ulong) GetCurrentThreadId();
+# else
+	return (zend_ulong) pthread_self();
+# endif
+#endif
+}
+
 zend_class_entry *xdebug_fetch_class(char *classname, int classname_len, int flags TSRMLS_DC)
 {
 	zend_class_entry *tmp_ce;

--- a/xdebug_compat.h
+++ b/xdebug_compat.h
@@ -36,6 +36,8 @@ unsigned char *xdebug_base64_decode(unsigned char *data, size_t data_len, size_t
 zend_string *xdebug_addslashes(zend_string *str);
 void xdebug_stripcslashes(char *string, int *new_len);
 
+zend_ulong xdebug_get_pid(void);
+
 zend_class_entry *xdebug_fetch_class(char *classname, int classname_len, int flags TSRMLS_DC);
 int xdebug_get_constant(xdebug_str *val, zval *const_val TSRMLS_DC);
 void xdebug_setcookie(const char *name, int name_len, char *value, int value_len, time_t expires, const char *path, int path_len, const char *domain, int domain_len, int secure, int url_encode, int httponly TSRMLS_DC);

--- a/xdebug_handler_dbgp.c
+++ b/xdebug_handler_dbgp.c
@@ -261,10 +261,10 @@ static xdebug_dbgp_cmd* lookup_cmd(char *cmd)
 void XDEBUG_ATTRIBUTE_FORMAT(printf, 2, 3) xdebug_dbgp_log(int log_level, const char *fmt, ...)
 {
 	if (XG(remote_log_file) && XG(remote_log_level) >= log_level) {
-		va_list argv;
-		long    pid = getpid();
+		va_list    argv;
+		zend_ulong pid = xdebug_get_pid();
 
-		fprintf(XG(remote_log_file), "[%ld] %s", pid, xdebug_log_prefix[log_level]);
+		fprintf(XG(remote_log_file), "[" ZEND_ULONG_FMT "] %s", pid, xdebug_log_prefix[log_level]);
 		va_start(argv, fmt);
 		vfprintf(XG(remote_log_file), fmt, argv);
 		va_end(argv);
@@ -522,7 +522,7 @@ static int breakpoint_admin_add(xdebug_con *context, int type, char *key)
 	TSRMLS_FETCH();
 
 	XG(breakpoint_count)++;
-	admin->id   = ((getpid() & 0x1ffff) * 10000) + XG(breakpoint_count);
+	admin->id   = ((xdebug_get_pid() & 0x1ffff) * 10000) + XG(breakpoint_count);
 	admin->type = type;
 	admin->key  = xdstrdup(key);
 
@@ -2344,7 +2344,7 @@ int xdebug_dbgp_init(xdebug_con *context, int mode)
 	xdebug_xml_add_attribute_ex(response, "language", "PHP", 0, 0);
 	xdebug_xml_add_attribute_ex(response, "xdebug:language_version", PHP_VERSION, 0, 0);
 	xdebug_xml_add_attribute_ex(response, "protocol_version", DBGP_VERSION, 0, 0);
-	xdebug_xml_add_attribute_ex(response, "appid", xdebug_sprintf("%d", getpid()), 0, 1);
+	xdebug_xml_add_attribute_ex(response, "appid", xdebug_sprintf(ZEND_ULONG_FMT, xdebug_get_pid()), 0, 1);
 
 	if (getenv("DBGP_COOKIE")) {
 		xdebug_xml_add_attribute_ex(response, "session", xdstrdup(getenv("DBGP_COOKIE")), 0, 1);

--- a/xdebug_profiler.c
+++ b/xdebug_profiler.c
@@ -379,9 +379,9 @@ int xdebug_profiler_output_aggr_data(const char *prefix TSRMLS_DC)
 	if (zend_hash_num_elements(&XG(aggr_calls)) == 0) return SUCCESS;
 
 	if (prefix) {
-		filename = xdebug_sprintf("%s/cachegrind.out.aggregate.%s.%ld", XG(profiler_output_dir), prefix, getpid());
+		filename = xdebug_sprintf("%s/cachegrind.out.aggregate.%s." ZEND_ULONG_FMT, XG(profiler_output_dir), prefix, (zend_ulong) xdebug_get_pid());
 	} else {
-		filename = xdebug_sprintf("%s/cachegrind.out.aggregate.%ld", XG(profiler_output_dir), getpid());
+		filename = xdebug_sprintf("%s/cachegrind.out.aggregate." ZEND_ULONG_FMT, XG(profiler_output_dir), (zend_ulong) xdebug_get_pid());
 	}
 
 	fprintf(stderr, "opening %s\n", filename);


### PR DESCRIPTION
Based on @krakjoe's #487 