### PR TITLE
Reduce number of AppVeyor builds

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -41,25 +41,13 @@ environment:
       ARCHITECTURE: x86
       ZTS_STATE: enable
       PHP_BUILD_CRT: vs16
-      OPCACHE: yes
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019 Preview
-    - PHP_REL: 7.4
-      ARCHITECTURE: x86
-      ZTS_STATE: disable
-      PHP_BUILD_CRT: vs16
-      OPCACHE: yes
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019 Preview
-    - PHP_REL: 7.4
-      ARCHITECTURE: x86
-      ZTS_STATE: enable
-      PHP_BUILD_CRT: vs16
       OPCACHE: no
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019 Preview
     - PHP_REL: 7.4
       ARCHITECTURE: x86
       ZTS_STATE: disable
       PHP_BUILD_CRT: vs16
-      OPCACHE: no
+      OPCACHE: yes
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019 Preview
     - PHP_REL: 7.3
       ARCHITECTURE: x64
@@ -71,31 +59,7 @@ environment:
       ARCHITECTURE: x64
       ZTS_STATE: disable
       PHP_BUILD_CRT: vc15
-      OPCACHE: yes
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-    - PHP_REL: 7.3
-      ARCHITECTURE: x64
-      ZTS_STATE: enable
-      PHP_BUILD_CRT: vc15
       OPCACHE: no
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-    - PHP_REL: 7.3
-      ARCHITECTURE: x64
-      ZTS_STATE: disable
-      PHP_BUILD_CRT: vc15
-      OPCACHE: no
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-    - PHP_REL: 7.3
-      ARCHITECTURE: x86
-      ZTS_STATE: enable
-      PHP_BUILD_CRT: vc15
-      OPCACHE: yes
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-    - PHP_REL: 7.3
-      ARCHITECTURE: x86
-      ZTS_STATE: disable
-      PHP_BUILD_CRT: vc15
-      OPCACHE: yes
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
     - PHP_REL: 7.3
       ARCHITECTURE: x86
@@ -107,7 +71,7 @@ environment:
       ARCHITECTURE: x86
       ZTS_STATE: disable
       PHP_BUILD_CRT: vc15
-      OPCACHE: no
+      OPCACHE: yes
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
     - PHP_REL: 7.2
       ARCHITECTURE: x64


### PR DESCRIPTION
For PHP 7.4, we now only test two variants for x86 builds.
For PHP 7.3, we now only test four variants all together.