### PR TITLE
Fixed issue #1717: Code coverage turned slow after update from 2.7.2 to 2.8.0

### DIFF
--- a/php_xdebug.h
+++ b/php_xdebug.h
@@ -216,6 +216,8 @@ ZEND_BEGIN_MODULE_GLOBALS(xdebug)
 		unsigned int  size;
 		int *last_branch_nr;
 	} branches;
+	size_t        coverage_prefill_function_count;
+	size_t        coverage_prefill_class_count;
 
 	/* used for collection errors */
 	zend_bool     do_collect_errors;

--- a/xdebug.c
+++ b/xdebug.c
@@ -1319,6 +1319,8 @@ PHP_RINIT_FUNCTION(xdebug)
 	XG(code_coverage_filter_offset) = zend_xdebug_filter_offset;
 	XG(previous_filename) = NULL;
 	XG(previous_file) = NULL;
+	XG(coverage_prefill_function_count) = 0;
+	XG(coverage_prefill_class_count) = 0;
 	XG(gc_stats_file) = NULL;
 	XG(gc_stats_filename) = NULL;
 	XG(gc_stats_enabled) = 0;


### PR DESCRIPTION
New algorithm that does less work to speed this up *a lot*. With thanks to @nikic for the idea.