### PR TITLE
Use latest PHP 7.4 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
-  - 7.4snapshot
+  - 7.4
   - nightly
 
 matrix:


### PR DESCRIPTION
Their so called snapshot build is older than 7.4.0, actually.