### PR TITLE
Fixed issue #1731: var_dump with DateTime does not output properties

### DIFF
--- a/src/lib/var.h
+++ b/src/lib/var.h
@@ -69,8 +69,13 @@ xdebug_var_export_options* xdebug_var_get_nolimit_options(void);
 xdebug_str* xdebug_get_property_type(zval* object, zval *val);
 #endif
 xdebug_str* xdebug_get_property_info(char *mangled_property, int mangled_len, const char **modifier, char **class_name);
+#if PHP_VERSION_ID >= 70400
+HashTable *xdebug_objdebug_pp(zval **zval_pp);
+#else
 HashTable *xdebug_objdebug_pp(zval **zval_pp, int *is_tmp);
 void xdebug_var_maybe_destroy_ht(HashTable *ht, int is_temp);
+#endif
+
 
 #define XDEBUG_VAR_ATTR_TEXT 0
 #define XDEBUG_VAR_ATTR_HTML 1

--- a/src/lib/var_export_xml.c
+++ b/src/lib/var_export_xml.c
@@ -567,7 +567,9 @@ void xdebug_var_export_xml_node(zval **struc, xdebug_str *name, xdebug_xml_node 
 			HashTable          *merged_hash;
 			xdebug_str         *class_name;
 			zend_class_entry   *ce;
+#if PHP_VERSION_ID < 70400 
 			int                 is_temp;
+#endif
 			zend_property_info *zpi_val;
 
 			ALLOC_HASHTABLE(merged_hash);
@@ -592,7 +594,11 @@ void xdebug_var_export_xml_node(zval **struc, xdebug_str *name, xdebug_xml_node 
 			xdebug_zend_hash_apply_protection_end(&ce->properties_info);
 
 			/* Adding normal properties */
+#if PHP_VERSION_ID >= 70400
+			myht = xdebug_objdebug_pp(struc);
+#else
 			myht = xdebug_objdebug_pp(struc, &is_temp);
+#endif
 			if (myht) {
 				zval *tmp_val;
 
@@ -637,8 +643,11 @@ void xdebug_var_export_xml_node(zval **struc, xdebug_str *name, xdebug_xml_node 
 			zend_hash_destroy(merged_hash);
 			FREE_HASHTABLE(merged_hash);
 			xdebug_str_free(class_name);
-
+#if PHP_VERSION_ID >= 70400
+			zend_release_properties(myht);
+#else
 			xdebug_var_maybe_destroy_ht(myht, is_temp);
+#endif
 			break;
 		}
 

--- a/tests/base/bug01272-002.phpt
+++ b/tests/base/bug01272-002.phpt
@@ -19,7 +19,7 @@ xdebug_debug_zval('e->b[1]->@attributes["attb"]');
 attb-1
 attb-2
 e: (refcount=1, is_ref=0)=class SimpleXMLElement { public $@attributes = (refcount=1, is_ref=0)=array ('att1' => (refcount=1, is_ref=0)='att-a'); public $b = (refcount=1, is_ref=0)=array (0 => (refcount=1, is_ref=0)=class SimpleXMLElement { ... }, 1 => (refcount=1, is_ref=0)=class SimpleXMLElement { ... }) }
-e->@attributes: (refcount=0, is_ref=0)=array ('att1' => (refcount=1, is_ref=0)='att-a')
-e->@attributes["att1"]: (refcount=0, is_ref=0)='att-a'
-e->b[0]->@attributes: (refcount=0, is_ref=0)=array ('attb' => (refcount=1, is_ref=0)='attb-1')
-e->b[1]->@attributes["attb"]: (refcount=0, is_ref=0)='attb-2'
+e->@attributes: (refcount=%d, is_ref=0)=array ('att1' => (refcount=1, is_ref=0)='att-a')
+e->@attributes["att1"]: (refcount=%d, is_ref=0)='att-a'
+e->b[0]->@attributes: (refcount=%d, is_ref=0)=array ('attb' => (refcount=1, is_ref=0)='attb-1')
+e->b[1]->@attributes["attb"]: (refcount=%d, is_ref=0)='attb-2'

--- a/tests/base/xdebug_var_dump_datetime_php74.phpt
+++ b/tests/base/xdebug_var_dump_datetime_php74.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Test output from xdebug_var_dump() with DateTimeImmutable
+--SKIPIF--
+<?php
+require __DIR__ . '/../utils.inc';
+check_reqs('PHP >= 7.4');
+?>
+--INI--
+xdebug.default_enable=1
+xdebug.auto_trace=0
+xdebug.profiler_enable=0
+html_errors=0
+date.timezone=Europe/Oslo
+xdebug.var_display_max_children=11
+xdebug.overload_var_dump=2
+xdebug.file_link_format=xdebug://%f@%l
+xdebug.filename_format=
+--FILE--
+<?php
+var_dump(new DateTimeImmutable('2019-12-20 13:00:00+0000'));
+--EXPECTF--
+%sxdebug_var_dump_datetime_php74.php:%d:
+class DateTimeImmutable#1 (3) {
+  public $date =>
+  string(26) "2019-12-20 13:00:00.000000"
+  public $timezone_type =>
+  int(1)
+  public $timezone =>
+  string(6) "+00:00"
+}

--- a/tests/base/xdebug_var_dump_typed_properties-ansi.phpt
+++ b/tests/base/xdebug_var_dump_typed_properties-ansi.phpt
@@ -46,7 +46,13 @@ var_dump(new class{public string $x;});
   [32m[1mpublic[22m ?Fibble[0m $z [0m=>[0m
   [34m*uninitialized*[0m
   [32m[1mpublic[22m DateTime[0m $a [0m=>[0m
-  [1mclass[22m [31mDateTime[0m#2 ([32m0[0m) {
+  [1mclass[22m [31mDateTime[0m#%d ([32m3[0m) {
+    [32m[1mpublic[22m[0m $date [0m=>[0m
+    [1mstring[22m([32m26[0m) "[31m%s[0m"
+    [32m[1mpublic[22m[0m $timezone_type [0m=>[0m
+    [1mint[22m([32m3[0m)
+    [32m[1mpublic[22m[0m $timezone [0m=>[0m
+    [1mstring[22m([32m3[0m) "[31mUTC[0m"
   }
 }
 [1m%sxdebug_var_dump_typed_properties-ansi.php[22m:[1m15[22m:

--- a/tests/base/xdebug_var_dump_typed_properties-html.phpt
+++ b/tests/base/xdebug_var_dump_typed_properties-html.phpt
@@ -42,6 +42,9 @@ var_dump(new class{public string $x;});
   <i>public</i> <i>?Fibble</i> 'z' <font color='#888a85'>=&gt;</font> <font color='#3465a4'>*uninitialized*</font>
   <i>public</i> <i>DateTime</i> 'a' <font color='#888a85'>=&gt;</font> 
     <b>object</b>(<i>DateTime</i>)[<i>2</i>]
+      <i>public</i> 'date' <font color='#888a85'>=&gt;</font> <small>string</small> <font color='#cc0000'>'%s'</font> <i>(length=26)</i>
+      <i>public</i> 'timezone_type' <font color='#888a85'>=&gt;</font> <small>int</small> <font color='#4e9a06'>3</font>
+      <i>public</i> 'timezone' <font color='#888a85'>=&gt;</font> <small>string</small> <font color='#cc0000'>'UTC'</font> <i>(length=3)</i>
 </pre><pre class='xdebug-var-dump' dir='ltr'>
 <small>%sxdebug_var_dump_typed_properties-html.php:15:</small>
 <b>object</b>(<i>class@anonymous</i>)[<i>3</i>]

--- a/tests/base/xdebug_var_dump_typed_properties-text.phpt
+++ b/tests/base/xdebug_var_dump_typed_properties-text.phpt
@@ -46,7 +46,13 @@ class foo#1 (6) {
   public ?Fibble $z =>
   *uninitialized*
   public DateTime $a =>
-  class DateTime#2 (0) {
+  class DateTime#%d (%d) {
+    public $date =>
+    string(26) "%s"
+    public $timezone_type =>
+    int(3)
+    public $timezone =>
+    string(3) "UTC"
   }
 }
 %sxdebug_var_dump_typed_properties-text.php:15:

--- a/tests/tracing/functrace_typed_properties_3.phpt
+++ b/tests/tracing/functrace_typed_properties_3.phpt
@@ -45,7 +45,7 @@ unlink($tf);
 --EXPECTF--
 TRACE START [%d-%d-%d %d:%d:%d]
 %w%f %w%d     -> DateTime->__construct() %sfunctrace_typed_properties_3.php:16
-%w%f %w%d     -> test(class foo { public $v = 3.1415926535898; public $w = NULL; private string $x = *uninitialized*; protected int $y = 42; public ?Fibble $z = *uninitialized*; public DateTime $a = class DateTime {  } }) %sfunctrace_typed_properties_3.php:18
+%w%f %w%d     -> test(class foo { public $v = 3.1415926535898; public $w = NULL; private string $x = *uninitialized*; protected int $y = 42; public ?Fibble $z = *uninitialized*; public DateTime $a = class DateTime { public $date = '%s'; public $timezone_type = 3; public $timezone = 'UTC' } }) %sfunctrace_typed_properties_3.php:18
 %w%f %w%d     -> test(class class@anonymous { public string $x = *uninitialized* }) %sfunctrace_typed_properties_3.php:19
 %w%f %w%d     -> xdebug_stop_trace() %sfunctrace_typed_properties_3.php:21
 %w%f %w%d

--- a/tests/tracing/functrace_typed_properties_4.phpt
+++ b/tests/tracing/functrace_typed_properties_4.phpt
@@ -45,7 +45,7 @@ unlink($tf);
 --EXPECTF--
 TRACE START [%d-%d-%d %d:%d:%d]
 %w%f %w%d     -> DateTime->__construct() %sfunctrace_typed_properties_4.php:16
-%w%f %w%d     -> test($value = class foo { public $v = 3.1415926535898; public $w = NULL; private string $x = *uninitialized*; protected int $y = 42; public ?Fibble $z = *uninitialized*; public DateTime $a = class DateTime {  } }) %sfunctrace_typed_properties_4.php:18
+%w%f %w%d     -> test($value = class foo { public $v = 3.1415926535898; public $w = NULL; private string $x = *uninitialized*; protected int $y = 42; public ?Fibble $z = *uninitialized*; public DateTime $a = class DateTime { public $date = '%s'; public $timezone_type = 3; public $timezone = 'UTC' } }) %sfunctrace_typed_properties_4.php:18
 %w%f %w%d     -> test($value = class class@anonymous { public string $x = *uninitialized* }) %sfunctrace_typed_properties_4.php:19
 %w%f %w%d     -> xdebug_stop_trace() %sfunctrace_typed_properties_4.php:21
 %w%f %w%d


### PR DESCRIPTION
Changed xdebug_objdebug_pp to use zend_get_properties_for instead of Z_OBJ_HANDLER in php >= 7.4