### PR TITLE
Fix segmentation fault when other extensions run PHP in RINIT

### DIFF
--- a/src/debugger/debugger.c
+++ b/src/debugger/debugger.c
@@ -662,7 +662,7 @@ void xdebug_debugger_compile_file(zend_op_array *op_array)
 	zend_class_entry *class_entry;
 	xdebug_lines_list *file_function_lines_list;
 
-	if (!XINI_DBG(remote_enable)) {
+	if (!XINI_DBG(remote_enable) || !XG_DBG(breakable_lines_map)) {
 		return;
 	}
 

--- a/src/debugger/handler_dbgp.c
+++ b/src/debugger/handler_dbgp.c
@@ -2870,7 +2870,7 @@ int xdebug_dbgp_resolve_breakpoints(xdebug_con *context, zend_string *filename)
 	xdebug_lines_list *lines_list;
 
 	/* Get the lines list for the current file */
-	if (!xdebug_hash_find(XG_DBG(breakable_lines_map), ZSTR_VAL(filename), ZSTR_LEN(filename), (void *) &lines_list)) {
+	if (!XG_DBG(breakable_lines_map) || !xdebug_hash_find(XG_DBG(breakable_lines_map), ZSTR_VAL(filename), ZSTR_LEN(filename), (void *) &lines_list)) {
 		context->handler->log(XDEBUG_LOG_DEBUG, "E: Lines list for '%s' does not exist\n", ZSTR_VAL(filename));
 		return 0;
 	}


### PR DESCRIPTION
Starting in Xdebug 2.9.1, when `xdebug.remote_enable=1`, Xdebug can cause a segmentation fault when another extension makes a [call to `zend_compile_file()`](https://github.com/DataDog/dd-trace-php/blob/2025ef3aa38c0ba490b2379ac9dcc214549d1876/src/ext/request_hooks.c#L179) in [RINIT](https://github.com/DataDog/dd-trace-php/blob/2025ef3aa38c0ba490b2379ac9dcc214549d1876/src/ext/ddtrace.c#L183).

In the case of the [Datadog PHP tracer extension](https://github.com/DataDog/dd-trace-php), when ddtrace's RINIT is run before Xdebug's RINIT, `XG_DBG(breakable_lines_map)` is not yet allocated so the segmentation fault occurs when trying to execute a PHP file set via the `ddtrace.request_init_hook` INI setting.

I'm not sure that this PR contains the best patch, but I can confirm that it prevents the segfault from occurring when running alongside `ddtrace` when `ddtrace.request_init_hook=/some/file.php`.

Related: DataDog/dd-trace-php#725