### PR TITLE
Issue 1752 - Use a pool to manage stack entries

### DIFF
--- a/php_xdebug.h
+++ b/php_xdebug.h
@@ -141,7 +141,8 @@ PHP_FUNCTION(xdebug_set_filter);
 struct xdebug_base_info {
 	unsigned long level;
 	xdebug_llist *stack;
-	function_stack_entry *stackPool;
+	function_stack_entry *stack_pool;
+	unsigned int  stack_pool_size;
 	double        start_time;
 	unsigned int  prev_memory;
 	zif_handler   orig_var_dump_func;

--- a/php_xdebug.h
+++ b/php_xdebug.h
@@ -141,6 +141,7 @@ PHP_FUNCTION(xdebug_set_filter);
 struct xdebug_base_info {
 	unsigned long level;
 	xdebug_llist *stack;
+	function_stack_entry *stackPool;
 	double        start_time;
 	unsigned int  prev_memory;
 	zif_handler   orig_var_dump_func;

--- a/src/base/stack.c
+++ b/src/base/stack.c
@@ -1041,7 +1041,7 @@ normal_after_all:
 	}
 }
 
-function_stack_entry *xdebug_add_stack_frame(zend_execute_data *zdata, zend_op_array *op_array, int type)
+function_stack_entry *xdebug_add_stack_frame(zend_execute_data *zdata, zend_op_array *op_array, int type, int level)
 {
 	zend_execute_data    *edata;
 	zend_op             **opline_ptr = NULL;
@@ -1061,7 +1061,11 @@ function_stack_entry *xdebug_add_stack_frame(zend_execute_data *zdata, zend_op_a
 	}
 	zdata = EG(current_execute_data);
 
-	tmp = xdmalloc (sizeof (function_stack_entry));
+	if (XG_BASE(stackPool)) {
+		tmp = XG_BASE(stackPool) + level;
+	} else {
+		tmp = xdmalloc (sizeof (function_stack_entry));
+	}
 	tmp->var           = NULL;
 	tmp->varc          = 0;
 	tmp->refcount      = 1;

--- a/src/base/stack.c
+++ b/src/base/stack.c
@@ -1041,7 +1041,7 @@ normal_after_all:
 	}
 }
 
-function_stack_entry *xdebug_add_stack_frame(zend_execute_data *zdata, zend_op_array *op_array, int type, int level)
+function_stack_entry *xdebug_add_stack_frame(zend_execute_data *zdata, zend_op_array *op_array, int type)
 {
 	zend_execute_data    *edata;
 	zend_op             **opline_ptr = NULL;
@@ -1049,6 +1049,7 @@ function_stack_entry *xdebug_add_stack_frame(zend_execute_data *zdata, zend_op_a
 	zend_op              *cur_opcode;
 	int                   i = 0;
 	int                   hit_variadic = 0;
+	unsigned int          stack_level;
 
 	if (type == XDEBUG_USER_DEFINED) {
 		edata = EG(current_execute_data)->prev_execute_data;
@@ -1061,8 +1062,9 @@ function_stack_entry *xdebug_add_stack_frame(zend_execute_data *zdata, zend_op_a
 	}
 	zdata = EG(current_execute_data);
 
-	if (XG_BASE(stackPool)) {
-		tmp = XG_BASE(stackPool) + level;
+	stack_level = XG_BASE(level) - 1;
+	if (stack_level < XG_BASE(stack_pool_size)) {
+		tmp = XG_BASE(stack_pool) + stack_level;
 	} else {
 		tmp = xdmalloc (sizeof (function_stack_entry));
 	}

--- a/src/base/stack.h
+++ b/src/base/stack.h
@@ -28,7 +28,7 @@ void xdebug_func_dtor_by_ref(xdebug_func *elem); /* TODO: Remove this API */
 void xdebug_func_dtor(xdebug_func *elem);
 void xdebug_build_fname(xdebug_func *tmp, zend_execute_data *edata);
 void xdebug_build_fname_from_oparray(xdebug_func *tmp, zend_op_array *opa);
-function_stack_entry *xdebug_add_stack_frame(zend_execute_data *zdata, zend_op_array *op_array, int type);
+function_stack_entry *xdebug_add_stack_frame(zend_execute_data *zdata, zend_op_array *op_array, int type, int level);
 void xdebug_append_error_head(xdebug_str *str, int html, const char *error_type_str);
 void xdebug_append_error_description(xdebug_str *str, int html, const char *error_type_str, const char *buffer, const char *error_filename, const int error_lineno);
 void xdebug_append_printable_stack(xdebug_str *str, int html);

--- a/src/base/stack.h
+++ b/src/base/stack.h
@@ -28,7 +28,7 @@ void xdebug_func_dtor_by_ref(xdebug_func *elem); /* TODO: Remove this API */
 void xdebug_func_dtor(xdebug_func *elem);
 void xdebug_build_fname(xdebug_func *tmp, zend_execute_data *edata);
 void xdebug_build_fname_from_oparray(xdebug_func *tmp, zend_op_array *opa);
-function_stack_entry *xdebug_add_stack_frame(zend_execute_data *zdata, zend_op_array *op_array, int type, int level);
+function_stack_entry *xdebug_add_stack_frame(zend_execute_data *zdata, zend_op_array *op_array, int type);
 void xdebug_append_error_head(xdebug_str *str, int html, const char *error_type_str);
 void xdebug_append_error_description(xdebug_str *str, int html, const char *error_type_str, const char *buffer, const char *error_filename, const int error_lineno);
 void xdebug_append_printable_stack(xdebug_str *str, int html);


### PR DESCRIPTION
The maximum number of stack entries is known as this will be equal to max_nesting_level. And the use of these entries follows a very logical path depending on the stack level. So instead of allocating and deallocating memory every time we enter or leave a function we could allocate a global pool of stack entries and use that. This should improve the performance of Xdebug

Obviously this is only possible if max_nesting_level is not set to -1 or a very large value. If that is the case, we default to the previous behaviour