### PR TITLE
Issue 1752 - Use a vector instead of a linked list to manage the stack

### DIFF
--- a/php_xdebug.h
+++ b/php_xdebug.h
@@ -38,6 +38,7 @@
 #include "lib/compat.h"
 #include "lib/hash.h"
 #include "lib/llist.h"
+#include "lib/vector.h"
 
 extern zend_module_entry xdebug_module_entry;
 #define phpext_xdebug_ptr &xdebug_module_entry
@@ -140,7 +141,7 @@ PHP_FUNCTION(xdebug_set_filter);
 
 struct xdebug_base_info {
 	unsigned long level;
-	xdebug_llist *stack;
+	XDEBUG_VECTOR_OF_TYPE(function_stack_entry) stack;
 	double        start_time;
 	unsigned int  prev_memory;
 	zif_handler   orig_var_dump_func;

--- a/src/base/filter.c
+++ b/src/base/filter.c
@@ -20,6 +20,7 @@
 #include "filter.h"
 
 #include "lib/private.h"
+#include "lib/vector.h"
 
 ZEND_EXTERN_MODULE_GLOBALS(xdebug)
 
@@ -39,7 +40,7 @@ int xdebug_is_stack_frame_filtered(int filter_type, function_stack_entry *fse)
 int xdebug_is_top_stack_frame_filtered(int filter_type)
 {
 	function_stack_entry *fse;
-	fse = XDEBUG_LLIST_VALP(XDEBUG_LLIST_TAIL(XG_BASE(stack)));
+	fse = XDEBUG_VECTOR_END(XG_BASE(stack));
 	return xdebug_is_stack_frame_filtered(filter_type, fse);
 }
 

--- a/src/base/stack.c
+++ b/src/base/stack.c
@@ -1245,7 +1245,6 @@ PHP_FUNCTION(xdebug_get_function_stack)
 {
 	function_stack_entry *i;
 	unsigned int          j;
-	unsigned int          k;
 	zval                 *frame;
 	zval                 *params;
 
@@ -1336,7 +1335,6 @@ static void xdebug_attach_used_var_names(void *return_value, xdebug_hash_element
    Returns an array representing the current stack */
 PHP_FUNCTION(xdebug_get_declared_vars)
 {
-	xdebug_llist_element *le;
 	function_stack_entry *i;
 	xdebug_hash *tmp_hash;
 

--- a/src/debugger/debugger.c
+++ b/src/debugger/debugger.c
@@ -240,9 +240,8 @@ void xdebug_debugger_statement_call(char *file, int file_len, int lineno)
 		}
 
 		/* Get latest stack level and function number */
-		if (XG_BASE(stack) && XDEBUG_LLIST_TAIL(XG_BASE(stack))) {
-			le = XDEBUG_LLIST_TAIL(XG_BASE(stack));
-			fse = XDEBUG_LLIST_VALP(le);
+		if (XDEBUG_VECTOR_NOT_EMPTY(XG_BASE(stack))) {
+			fse = XDEBUG_VECTOR_END(XG_BASE(stack));
 			level = fse->level;
 			func_nr = fse->function_nr;
 		} else {

--- a/src/debugger/handler_dbgp.c
+++ b/src/debugger/handler_dbgp.c
@@ -1878,7 +1878,6 @@ DBGP_FUNC(stack_depth)
 DBGP_FUNC(stack_get)
 {
 	xdebug_xml_node      *stackframe;
-	xdebug_llist_element *le;
 	int                   counter = 0;
 	long                  depth;
 

--- a/src/debugger/handler_dbgp.c
+++ b/src/debugger/handler_dbgp.c
@@ -1892,10 +1892,9 @@ DBGP_FUNC(stack_get)
 		}
 	} else {
 		counter = 0;
-		for (le = XDEBUG_LLIST_TAIL(XG_BASE(stack)); le != NULL; le = XDEBUG_LLIST_PREV(le)) {
+		for (counter = 0; counter < XDEBUG_VECTOR_SIZE(XG_BASE(stack)); counter++) {
 			stackframe = return_stackframe(counter);
 			xdebug_xml_add_child(*retval, stackframe);
-			counter++;
 		}
 	}
 }
@@ -2572,7 +2571,7 @@ int xdebug_dbgp_break_on_line(xdebug_con *context, xdebug_brk_info *brk, const c
 	return 0;
 }
 
-int xdebug_dbgp_breakpoint(xdebug_con *context, xdebug_llist *stack, char *file, long lineno, int type, char *exception, char *code, char *message)
+int xdebug_dbgp_breakpoint(xdebug_con *context, XDEBUG_VECTOR_OF_TYPE(function_stack_entry) stack, char *file, long lineno, int type, char *exception, char *code, char *message)
 {
 	xdebug_xml_node *response, *error_container;
 

--- a/src/debugger/handler_dbgp.h
+++ b/src/debugger/handler_dbgp.h
@@ -22,6 +22,7 @@
 #include <string.h>
 #include "handlers.h"
 #include "lib/xml.h"
+#include "lib/vector.h"
 
 #define DBGP_VERSION "1.0"
 
@@ -101,7 +102,7 @@ int xdebug_dbgp_init(xdebug_con *context, int mode);
 int xdebug_dbgp_deinit(xdebug_con *context);
 int xdebug_dbgp_error(xdebug_con *context, int type, char *exception_type, char *message, const char *location, const unsigned int line, xdebug_llist *stack);
 int xdebug_dbgp_break_on_line(xdebug_con *context, xdebug_brk_info *brk, const char *file, int file_len, int lineno);
-int xdebug_dbgp_breakpoint(xdebug_con *context, xdebug_llist *stack, char *file, long lineno, int type, char *exception, char *code, char *message);
+int xdebug_dbgp_breakpoint(xdebug_con *context, XDEBUG_VECTOR_OF_TYPE(function_stack_entry) stack, char *file, long lineno, int type, char *exception, char *code, char *message);
 int xdebug_dbgp_resolve_breakpoints(xdebug_con *context, zend_string *filename);
 int xdebug_dbgp_stream_output(const char *string, unsigned int length);
 int xdebug_dbgp_notification(xdebug_con *context, const char *file, long lineno, int type, char *type_string, char *message);

--- a/src/debugger/handlers.h
+++ b/src/debugger/handlers.h
@@ -25,6 +25,7 @@
 #include "lib/hash.h"
 #include "lib/private.h"
 #include "lib/usefulstuff.h"
+#include "lib/vector.h"
 #include "debugger_private.h"
 
 typedef struct _xdebug_brk_admin            xdebug_brk_admin;
@@ -130,7 +131,7 @@ struct _xdebug_remote_handler {
 
 	/* Breakpoints */
 	int (*break_on_line)(xdebug_con *h, xdebug_brk_info *brk, const char *file, int filename_len, int lineno);
-	int (*remote_breakpoint)(xdebug_con *h, xdebug_llist *stack, char *file, long lineno, int type, char *exception, char *code, char *message);
+	int (*remote_breakpoint)(xdebug_con *h, XDEBUG_VECTOR_OF_TYPE(function_stack_entry) stack, char *file, long lineno, int type, char *exception, char *code, char *message);
 	int (*resolve_breakpoints)(xdebug_con *h, zend_string *opa);
 
 	/* Output redirection */

--- a/src/lib/private.c
+++ b/src/lib/private.c
@@ -27,58 +27,26 @@ const char *xdebug_log_prefix[11] = {
 
 function_stack_entry *xdebug_get_stack_head(void)
 {
-	xdebug_llist_element *le;
-
-	if (XG_BASE(stack)) {
-		if ((le = XDEBUG_LLIST_HEAD(XG_BASE(stack)))) {
-			return XDEBUG_LLIST_VALP(le);
-		} else {
-			return NULL;
-		}
-	} else {
-		return NULL;
+	if (XDEBUG_VECTOR_NOT_EMPTY(XG_BASE(stack))) {
+		return XDEBUG_VECTOR_START(XG_BASE(stack));
 	}
+	return NULL;
 }
 
 function_stack_entry *xdebug_get_stack_frame(int nr)
 {
-	xdebug_llist_element *le;
-
-	if (!XG_BASE(stack)) {
-		return NULL;
+	if (XDEBUG_VECTOR_NOT_EMPTY(XG_BASE(stack)) && nr >=0 && nr < XDEBUG_VECTOR_SIZE(XG_BASE(stack))) {
+		return XDEBUG_VECTOR_END(XG_BASE(stack)) - nr;
 	}
-
-	if (!(le = XDEBUG_LLIST_TAIL(XG_BASE(stack)))) {
-		return NULL;
-	}
-
-	if (nr < 0) {
-		return NULL;
-	}
-
-	while (nr) {
-		nr--;
-		le = XDEBUG_LLIST_PREV(le);
-		if (!le) {
-			return NULL;
-		}
-	}
-	return XDEBUG_LLIST_VALP(le);
+	return NULL;
 }
 
 function_stack_entry *xdebug_get_stack_tail(void)
 {
-	xdebug_llist_element *le;
-
-	if (XG_BASE(stack)) {
-		if ((le = XDEBUG_LLIST_TAIL(XG_BASE(stack)))) {
-			return XDEBUG_LLIST_VALP(le);
-		} else {
-			return NULL;
-		}
-	} else {
-		return NULL;
+	if (XDEBUG_VECTOR_NOT_EMPTY(XG_BASE(stack))) {
+		return XDEBUG_VECTOR_END(XG_BASE(stack));
 	}
+	return NULL;
 }
 
 static void xdebug_used_var_hash_from_llist_dtor(void *data)

--- a/src/lib/private.h
+++ b/src/lib/private.h
@@ -34,6 +34,7 @@
 #include "hash.h"
 #include "llist.h"
 #include "set.h"
+#include "vector.h"
 
 #define MICRO_IN_SEC 1000000.00
 
@@ -203,7 +204,6 @@ typedef struct _function_stack_entry {
 
 	/* misc properties */
 	int          refcount;
-	struct _function_stack_entry *prev;
 	zend_op_array *op_array;
 } function_stack_entry;
 

--- a/src/lib/vector.h
+++ b/src/lib/vector.h
@@ -117,8 +117,8 @@ SOFTWARE.
 	if (vec) {                                         \
 		const size_t __sz = XDEBUG_VECTOR_SIZE(vec);         \
 		if ((i) < __sz) {                              \
-			XDEBUG_VECTOR_SET_SIZE((vec), __sz - 1);         \
 			size_t __x;                                \
+			XDEBUG_VECTOR_SET_SIZE((vec), __sz - 1);         \
 			for (__x = (i); __x < (__sz - 1); ++__x) { \
 				(vec)[__x] = (vec)[__x + 1];           \
 			}                                          \
@@ -186,12 +186,15 @@ SOFTWARE.
  * @return void
  */
 #define XDEBUG_VECTOR_PUSH(vec, value)                   \
-	size_t __cap = XDEBUG_VECTOR_CAPACITY(vec);           \
-	if (__cap <= XDEBUG_VECTOR_SIZE(vec)) {               \
-		XDEBUG_VECTOR_GROW((vec), __cap + 1);             \
-	}                                               \
-	vec[XDEBUG_VECTOR_SIZE(vec)] = (value);               \
-	XDEBUG_VECTOR_SET_SIZE((vec), XDEBUG_VECTOR_SIZE(vec) + 1);
+	do {                                                \
+		size_t __cap = XDEBUG_VECTOR_CAPACITY(vec);           \
+		if (__cap <= XDEBUG_VECTOR_SIZE(vec)) {               \
+			XDEBUG_VECTOR_GROW((vec), __cap + 1);             \
+		}                                               \
+		vec[XDEBUG_VECTOR_SIZE(vec)] = (value);               \
+		XDEBUG_VECTOR_SET_SIZE((vec), XDEBUG_VECTOR_SIZE(vec) + 1); \
+	} while (0)
+
 
 /**
  * @brief XDEBUG_VECTOR_PUSH_EMPTY - adds an empty element to the end of the vector
@@ -199,10 +202,12 @@ SOFTWARE.
  * @return void
  */
 #define XDEBUG_VECTOR_PUSH_EMPTY(vec)                       \
-	size_t __cap = XDEBUG_VECTOR_CAPACITY(vec);           \
-	if (__cap <= XDEBUG_VECTOR_SIZE(vec)) {               \
-		XDEBUG_VECTOR_GROW((vec), __cap + 1);             \
-	}                                               \
-	XDEBUG_VECTOR_SET_SIZE((vec), XDEBUG_VECTOR_SIZE(vec) + 1);
+	do {                                                \
+		size_t __cap = XDEBUG_VECTOR_CAPACITY(vec);           \
+		if (__cap <= XDEBUG_VECTOR_SIZE(vec)) {               \
+			XDEBUG_VECTOR_GROW((vec), __cap + 1);             \
+		}                                               \
+		XDEBUG_VECTOR_SET_SIZE((vec), XDEBUG_VECTOR_SIZE(vec) + 1); \
+	} while (0)
 
 #endif /* vector_H_ */

--- a/src/lib/vector.h
+++ b/src/lib/vector.h
@@ -1,0 +1,208 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2015 Evan Teran
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#ifndef vector_H_
+#define vector_H_
+
+#include <stddef.h> /* for size_t */
+#include <stdlib.h> /* for malloc/realloc/free */
+
+/**
+ * @brief XDEBUG_VECTOR_OF_TYPE - The vector type used in this library
+ */
+#define XDEBUG_VECTOR_OF_TYPE(type) type *
+
+/**
+ * @brief XDEBUG_VECTOR_SET_CAPACITY - For internal use, sets the capacity variable of the vector
+ * @param vec - the vector
+ * @param size - the new capacity to set
+ * @return void
+ */
+#define XDEBUG_VECTOR_SET_CAPACITY(vec, size)     \
+	if (vec) {                          \
+		((size_t *)(vec))[-1] = (size); \
+	}
+
+/**
+ * @brief XDEBUG_VECTOR_SET_SIZE - For internal use, sets the size variable of the vector
+ * @param vec - the vector
+ * @param size - the new capacity to set
+ * @return void
+ */
+#define XDEBUG_VECTOR_SET_SIZE(vec, size)         \
+	if (vec) {                          \
+		((size_t *)(vec))[-2] = (size); \
+	}
+
+/**
+ * @brief XDEBUG_VECTOR_CAPACITY - gets the current capacity of the vector
+ * @param vec - the vector
+ * @return the capacity as a size_t
+ */
+#define XDEBUG_VECTOR_CAPACITY(vec) \
+	((vec) ? ((size_t *)(vec))[-1] : (size_t)0)
+
+/**
+ * @brief XDEBUG_VECTOR_SIZE - gets the current size of the vector
+ * @param vec - the vector
+ * @return the size as a size_t
+ */
+#define XDEBUG_VECTOR_SIZE(vec) \
+	((vec) ? ((size_t *)(vec))[-2] : (size_t)0)
+
+/**
+ * @brief XDEBUG_VECTOR_NOT_EMPTY - returns non-zero if the vector is not empty
+ * @param vec - the vector
+ * @return zero if empty, non-zero if non-empty
+ */
+#define XDEBUG_VECTOR_NOT_EMPTY(vec) \
+	(XDEBUG_VECTOR_SIZE(vec) != 0)
+
+/**
+ * @brief XDEBUG_VECTOR_GROW - For internal use, ensures that the vector is at least <count> elements big
+ * @param vec - the vector
+ * @param size - the new capacity to set
+ * @return void
+ */
+#define XDEBUG_VECTOR_GROW(vec, count)                                             \
+	const size_t __sz = (count) * sizeof(*(vec)) + (sizeof(size_t) * 2); \
+	if (!(vec)) {                                                        \
+		size_t *__p = malloc(__sz);                                      \
+		(vec) = (void *)(&__p[2]);                                       \
+		XDEBUG_VECTOR_SET_CAPACITY((vec), (count));                            \
+		XDEBUG_VECTOR_SET_SIZE((vec), 0);                                      \
+	} else {                                                             \
+		size_t *__p1 = &((size_t *)(vec))[-2];                           \
+		size_t *__p2 = realloc(__p1, (__sz));                            \
+		(vec) = (void *)(&__p2[2]);                                      \
+		XDEBUG_VECTOR_SET_CAPACITY((vec), (count));                            \
+	}
+
+/**
+ * @brief XDEBUG_VECTOR_POP - removes the last element from the vector
+ * @param vec - the vector
+ * @return void
+ */
+#define XDEBUG_VECTOR_POP(vec)                           \
+	XDEBUG_VECTOR_SET_SIZE((vec), XDEBUG_VECTOR_SIZE(vec) - 1);
+
+/**
+ * @brief XDEBUG_VECTOR_REMOVE - removes the element at index i from the vector
+ * @param vec - the vector
+ * @param i - index of element to remove
+ * @return void
+ */
+#define XDEBUG_VECTOR_REMOVE(vec, i)                              \
+	if (vec) {                                         \
+		const size_t __sz = XDEBUG_VECTOR_SIZE(vec);         \
+		if ((i) < __sz) {                              \
+			XDEBUG_VECTOR_SET_SIZE((vec), __sz - 1);         \
+			size_t __x;                                \
+			for (__x = (i); __x < (__sz - 1); ++__x) { \
+				(vec)[__x] = (vec)[__x + 1];           \
+			}                                          \
+		}                                              \
+	}
+
+/**
+ * @brief XDEBUG_VECTOR_FREE - frees all memory associated with the vector
+ * @param vec - the vector
+ * @return void
+ */
+#define XDEBUG_VECTOR_FREE(vec)                        \
+	if (vec) {                               \
+		size_t *p1 = &((size_t *)(vec))[-2]; \
+		free(p1);                            \
+	}
+
+/**
+ * @brief XDEBUG_VECTOR_START - returns an iterator to first element of the vector
+ * @param vec - the vector
+ * @return a pointer to the first element (or NULL)
+ */
+#define XDEBUG_VECTOR_START(vec) \
+	(vec)
+
+/**
+ * @brief XDEBUG_VECTOR_END - returns an iterator to the last element of the vector
+ * @param vec - the vector
+ * @return a pointer to the last element (or NULL)
+ */
+#define XDEBUG_VECTOR_END(vec) \
+	((vec) ? &((vec)[XDEBUG_VECTOR_SIZE(vec) - 1]) : NULL)
+
+/**
+ * @brief XDEBUG_VECTOR_PREV - returns a pointer to the previous element of a given element if it exists
+ * @param vec - the vector
+ * @param elem - pointer to the element
+ * @return a pointer to the previous element (or NULL)
+ */
+#define XDEBUG_VECTOR_PREV(vec, elem) \
+	((vec && elem != vec) ? elem - 1 : NULL)
+
+/**
+ * @brief XDEBUG_VECTOR_NEXT - returns a pointer to the next element of a given element if it exists
+ * @param vec - the vector
+ * @param elem - pointer to the element
+ * @return a pointer to the previous element (or NULL)
+ */
+#define XDEBUG_VECTOR_NEXT(vec, elem) \
+	((vec && elem != XDEBUG_VECTOR_END(vec)) ? elem + 1 : NULL)
+
+/**
+ * @brief XDEBUG_VECTOR_ELEMENT_AT - returns a pointer to the element at a certain position
+ * @param vec - the vector
+ * @param position - the position
+ * @return a pointer to the element at position (or NULL)
+ */
+#define XDEBUG_VECTOR_ELEMENT_AT(vec, position) \
+	((vec) ? &((vec)[position]) : NULL)
+
+/**
+ * @brief XDEBUG_VECTOR_PUSH - adds an element to the end of the vector
+ * @param vec - the vector
+ * @param value - the value to add
+ * @return void
+ */
+#define XDEBUG_VECTOR_PUSH(vec, value)                   \
+	size_t __cap = XDEBUG_VECTOR_CAPACITY(vec);           \
+	if (__cap <= XDEBUG_VECTOR_SIZE(vec)) {               \
+		XDEBUG_VECTOR_GROW((vec), __cap + 1);             \
+	}                                               \
+	vec[XDEBUG_VECTOR_SIZE(vec)] = (value);               \
+	XDEBUG_VECTOR_SET_SIZE((vec), XDEBUG_VECTOR_SIZE(vec) + 1);
+
+/**
+ * @brief XDEBUG_VECTOR_PUSH_EMPTY - adds an empty element to the end of the vector
+ * @param vec - the vector
+ * @return void
+ */
+#define XDEBUG_VECTOR_PUSH_EMPTY(vec)                       \
+	size_t __cap = XDEBUG_VECTOR_CAPACITY(vec);           \
+	if (__cap <= XDEBUG_VECTOR_SIZE(vec)) {               \
+		XDEBUG_VECTOR_GROW((vec), __cap + 1);             \
+	}                                               \
+	XDEBUG_VECTOR_SET_SIZE((vec), XDEBUG_VECTOR_SIZE(vec) + 1);
+
+#endif /* vector_H_ */

--- a/src/tracing/tracing.c
+++ b/src/tracing/tracing.c
@@ -597,7 +597,7 @@ static int xdebug_common_assign_dim_handler(const char *op, int do_cc, zend_exec
 			val = xdebug_get_zval(execute_data, cur_opcode->op2_type, &cur_opcode->op2, &is_var);
 		}
 
-		fse = XDEBUG_LLIST_VALP(XDEBUG_LLIST_TAIL(XG_BASE(stack)));
+		fse = XDEBUG_VECTOR_END(XG_BASE(stack));
 		if (XG_TRACE(trace_context) && XINI_BASE(collect_assignments) && XG_TRACE(trace_handler)->assignment) {
 			XG_TRACE(trace_handler)->assignment(XG_TRACE(trace_context), fse, full_varname, val, right_full_varname, op, file, lineno);
 		}

--- a/src/tracing/tracing.h
+++ b/src/tracing/tracing.h
@@ -19,6 +19,7 @@
 #define XDEBUG_TRACING_H
 
 #include "php.h"
+#include "lib/vector.h"
 
 typedef struct
 {


### PR DESCRIPTION
The current implementation of the stack uses a linked list of stack entries. This is inefficient because we are allocating and freeing memory every time that we enter or leave a function. This can be implemented in a more efficient way using a vector (an array of objects whose size can grow dynamically at run time)

I implemented this using the code found here for implementing a vector in C as a basis:

https://github.com/eteran/c-vector

I modified the code a little bit to add some extra functionality, adapt it to our needs and adapt it to the XDEBUG terminology

I have benchmarked this by running this PHP function (Calculates the Fibonacci number using a recursive algorithm):

```
<?php
function fib($n) {
    if ($n <= 1) { return 1; }
    return fib($n - 1) + fib($n - 2);
}

echo fib(35);
?>
```
with XDebug enabled, connected to a debug client, no code coverage, profiling or tracing. With the current master, the average run time (taken over 10 runs) is 2m15s. With my branch the average run time is 2m08s. So, not a big improvement (5%), specially taking into account that this code probably overstates the importance of function calls in php code, but points in the good direction as I believe we may be able to do something similar for many other data used by XDebug