### PR TITLE
Fixed issue #1755: Overload pcntl_fork() to prevent performance degradation by calling xdebug_get_pid often

### DIFF
--- a/php_xdebug.h
+++ b/php_xdebug.h
@@ -87,6 +87,7 @@ PHP_FUNCTION(xdebug_call_line);
 PHP_FUNCTION(xdebug_set_time_limit);
 PHP_FUNCTION(xdebug_error_reporting);
 PHP_FUNCTION(xdebug_pcntl_exec);
+PHP_FUNCTION(xdebug_pcntl_fork);
 
 PHP_FUNCTION(xdebug_var_dump);
 PHP_FUNCTION(xdebug_debug_zval);
@@ -147,6 +148,7 @@ struct xdebug_base_info {
 	zif_handler   orig_set_time_limit_func;
 	zif_handler   orig_error_reporting_func;
 	zif_handler   orig_pcntl_exec_func;
+	zif_handler   orig_pcntl_fork_func;
 	int           output_is_tty;
 	zend_bool     in_debug_info;
 	char         *last_exception_trace;

--- a/src/base/base.c
+++ b/src/base/base.c
@@ -507,7 +507,8 @@ static void xdebug_overloaded_functions_setup(void)
 		XG_BASE(orig_pcntl_exec_func) = NULL;
 	}
 
-	/* Override pcntl_fork with our own function to be able to start the debugger for the forked process */
+	/* Override pcntl_fork with our own function to be able
+	 * to start the debugger for the forked process */
 	orig = zend_hash_str_find_ptr(EG(function_table), "pcntl_fork", sizeof("pcntl_fork") - 1);
 	if (orig) {
 		XG_BASE(orig_pcntl_fork_func) = orig->internal_function.handler;
@@ -644,7 +645,6 @@ void xdebug_base_rinit()
 	XG_BASE(filters_tracing)           = xdebug_llist_alloc(xdebug_llist_string_dtor);
 	XG_BASE(filters_code_coverage)     = xdebug_llist_alloc(xdebug_llist_string_dtor);
 
-	/* Overload var_dump, set_time_limit, error_reporting, pcntl_exec and pcntl_fork */
 	xdebug_overloaded_functions_setup();
 }
 

--- a/src/base/stack.c
+++ b/src/base/stack.c
@@ -1140,7 +1140,7 @@ function_stack_entry *xdebug_add_stack_frame(zend_execute_data *zdata, zend_op_a
 		tmp->lineno = find_line_number_for_current_execute_point(edata);
 		tmp->is_variadic = !!(zdata->func->common.fn_flags & ZEND_ACC_VARIADIC);
 
-		if (XINI_BASE(collect_params) || XINI_BASE(collect_vars) || xdebug_is_debug_connection_active_for_current_pid()) {
+		if (XINI_BASE(collect_params) || XINI_BASE(collect_vars) || xdebug_is_debug_connection_active()) {
 			int    arguments_sent = 0, arguments_wanted = 0, arguments_storage = 0;
 
 			/* This calculates how many arguments where sent to a function. It

--- a/src/debugger/com.c
+++ b/src/debugger/com.c
@@ -453,24 +453,6 @@ int xdebug_is_debug_connection_active()
 	);
 }
 
-void xdebug_activate_connection_for_current_pid()
-{
-	zend_ulong pid;
-
-	/* Early return to save some getpid() calls */
-	if (!xdebug_is_debug_connection_active()) {
-		return;
-	}
-
-	pid = xdebug_get_pid();
-
-	/* Start debugger if previously a connection was established and this
-	 * process no longer has the same PID */
-	if (XG_DBG(remote_connection_pid) != pid) {
-		xdebug_restart_debugger();
-	}
-}
-
 void xdebug_mark_debug_connection_active()
 {
 	XG_DBG(remote_connection_enabled) = 1;

--- a/src/debugger/com.c
+++ b/src/debugger/com.c
@@ -453,13 +453,13 @@ int xdebug_is_debug_connection_active()
 	);
 }
 
-int xdebug_is_debug_connection_active_for_current_pid()
+void xdebug_activate_connection_for_current_pid()
 {
 	zend_ulong pid;
 
 	/* Early return to save some getpid() calls */
 	if (!xdebug_is_debug_connection_active()) {
-		return 0;
+		return;
 	}
 
 	pid = xdebug_get_pid();
@@ -469,10 +469,6 @@ int xdebug_is_debug_connection_active_for_current_pid()
 	if (XG_DBG(remote_connection_pid) != pid) {
 		xdebug_restart_debugger();
 	}
-
-	return (
-		XG_DBG(remote_connection_enabled) && (XG_DBG(remote_connection_pid) == pid)
-	);
 }
 
 void xdebug_mark_debug_connection_active()
@@ -502,7 +498,7 @@ void xdebug_do_jit()
 {
 	if (
 		(XINI_DBG(remote_mode) == XDEBUG_JIT) &&
-		!xdebug_is_debug_connection_active_for_current_pid() &&
+		!xdebug_is_debug_connection_active() &&
 		XINI_DBG(remote_enable)
 	) {
 		xdebug_init_debugger();
@@ -576,7 +572,7 @@ void xdebug_do_req(void)
 
 	if (
 		XINI_DBG(remote_enable) &&
-		!xdebug_is_debug_connection_active_for_current_pid() &&
+		!xdebug_is_debug_connection_active() &&
 		(XINI_DBG(remote_autostart) || xdebug_handle_start_session())
 	) {
 		xdebug_init_debugger();

--- a/src/debugger/com.h
+++ b/src/debugger/com.h
@@ -59,8 +59,8 @@ void xdebug_close_socket(int socket);
 
 /* Remote connection activation and house keeping */
 int xdebug_is_debug_connection_active(void);
-void xdebug_activate_connection_for_current_pid(void);
 void xdebug_stop_debugger(void);
+void xdebug_restart_debugger(void);
 void xdebug_mark_debug_connection_active(void);
 void xdebug_mark_debug_connection_not_active(void);
 void xdebug_mark_debug_connection_pending(void);

--- a/src/debugger/com.h
+++ b/src/debugger/com.h
@@ -59,7 +59,7 @@ void xdebug_close_socket(int socket);
 
 /* Remote connection activation and house keeping */
 int xdebug_is_debug_connection_active(void);
-int xdebug_is_debug_connection_active_for_current_pid(void);
+void xdebug_activate_connection_for_current_pid(void);
 void xdebug_stop_debugger(void);
 void xdebug_mark_debug_connection_active(void);
 void xdebug_mark_debug_connection_not_active(void);

--- a/src/debugger/debugger.c
+++ b/src/debugger/debugger.c
@@ -229,7 +229,7 @@ void xdebug_debugger_statement_call(char *file, int file_len, int lineno)
 	int                   func_nr = 0;
 	int                   block = XDEBUG_CMDLOOP_NONBLOCK;
 
-	if (xdebug_is_debug_connection_active_for_current_pid()) {
+	if (xdebug_is_debug_connection_active()) {
 
 		if (XG_DBG(context).do_break) {
 			block = XDEBUG_CMDLOOP_BLOCK;
@@ -238,14 +238,14 @@ void xdebug_debugger_statement_call(char *file, int file_len, int lineno)
 			if (!XG_DBG(context).handler->remote_breakpoint(&(XG_DBG(context)), XG_BASE(stack), file, lineno, XDEBUG_BREAK, NULL, 0, NULL)) {
 				xdebug_mark_debug_connection_not_active();
 			}
-			if (xdebug_is_debug_connection_active_for_current_pid()) {
+			if (xdebug_is_debug_connection_active()) {
 				XG_DBG(context).handler->cmdloop(&(XG_DBG(context)), block, XDEBUG_CMDLOOP_BAIL);
 			}
 			block = XDEBUG_CMDLOOP_NONBLOCK;
 		}
 	}
 
-	if (xdebug_is_debug_connection_active_for_current_pid()) {
+	if (xdebug_is_debug_connection_active()) {
 		/* Get latest stack level and function number */
 		if (XG_BASE(stack) && XDEBUG_LLIST_TAIL(XG_BASE(stack))) {
 			le = XDEBUG_LLIST_TAIL(XG_BASE(stack));
@@ -334,7 +334,7 @@ void xdebug_debugger_statement_call(char *file, int file_len, int lineno)
 	}
 
 loop:
-	if (xdebug_is_debug_connection_active_for_current_pid()) {
+	if (xdebug_is_debug_connection_active()) {
 		XG_DBG(context).handler->cmdloop(&(XG_DBG(context)), block, XDEBUG_CMDLOOP_BAIL);
 	}
 }
@@ -347,7 +347,7 @@ void xdebug_debugger_throw_exception_hook(zend_class_entry * exception_ce, zval 
 	/* Start JIT if requested and not yet enabled */
 	xdebug_do_jit();
 
-	if (xdebug_is_debug_connection_active_for_current_pid() && XG_DBG(breakpoints_allowed)) {
+	if (xdebug_is_debug_connection_active() && XG_DBG(breakpoints_allowed)) {
 		int exception_breakpoint_found = 0;
 
 		/* Check if we have a wild card exception breakpoint */
@@ -384,7 +384,7 @@ void xdebug_debugger_throw_exception_hook(zend_class_entry * exception_ce, zval 
 		}
 	}
 
-	if (xdebug_is_debug_connection_active_for_current_pid()) {
+	if (xdebug_is_debug_connection_active()) {
 		XG_DBG(context).handler->cmdloop(&(XG_DBG(context)), block, XDEBUG_CMDLOOP_BAIL);
 	}
 }
@@ -397,7 +397,7 @@ void xdebug_debugger_error_cb(const char *error_filename, int error_lineno, int 
 	/* Start JIT if requested and not yet enabled */
 	xdebug_do_jit();
 
-	if (xdebug_is_debug_connection_active_for_current_pid() && XG_DBG(breakpoints_allowed)) {
+	if (xdebug_is_debug_connection_active() && XG_DBG(breakpoints_allowed)) {
 		/* Send notification with warning/notice/error information */
 		if (XG_DBG(context).send_notifications && !XG_DBG(context).inhibit_notifications) {
 			if (!XG_DBG(context).handler->remote_notification(&(XG_DBG(context)), error_filename, error_lineno, type, error_type_str, buffer)) {
@@ -423,7 +423,7 @@ void xdebug_debugger_error_cb(const char *error_filename, int error_lineno, int 
 		}
 	}
 
-	if (xdebug_is_debug_connection_active_for_current_pid() && XG_DBG(breakpoints_allowed)) {
+	if (xdebug_is_debug_connection_active() && XG_DBG(breakpoints_allowed)) {
 		XG_DBG(context).handler->cmdloop(&(XG_DBG(context)), block, XDEBUG_CMDLOOP_BAIL);
 	}
 }
@@ -486,12 +486,12 @@ void xdebug_debugger_handle_breakpoints(function_stack_entry *fse, int breakpoin
 {
 	int block = XDEBUG_CMDLOOP_NONBLOCK;
 	if (XG_DBG(breakpoints_allowed)) {
-		if (xdebug_is_debug_connection_active_for_current_pid()) {
+		if (xdebug_is_debug_connection_active()) {
 			if (!handle_breakpoints(fse, breakpoint_type, &block)) {
 				xdebug_mark_debug_connection_not_active();
 			}
 		}
-		if (xdebug_is_debug_connection_active_for_current_pid()) {
+		if (xdebug_is_debug_connection_active()) {
 			XG_DBG(context).handler->cmdloop(&(XG_DBG(context)), block, XDEBUG_CMDLOOP_BAIL);
 		}
 	}
@@ -499,7 +499,7 @@ void xdebug_debugger_handle_breakpoints(function_stack_entry *fse, int breakpoin
 
 static size_t xdebug_ub_write(const char *string, size_t length)
 {
-	if (xdebug_is_debug_connection_active_for_current_pid()) {
+	if (xdebug_is_debug_connection_active()) {
 		if (-1 == XG_DBG(context).handler->remote_stream_output(string, length)) {
 			return 0;
 		}
@@ -763,7 +763,7 @@ void xdebug_debugger_compile_file(zend_op_array *op_array)
 
 	add_function_to_lines_list(file_function_lines_list, op_array);
 
-	if (!xdebug_is_debug_connection_active_for_current_pid()) {
+	if (!xdebug_is_debug_connection_active()) {
 		return;
 	}
 
@@ -784,7 +784,7 @@ static void resolve_breakpoints_for_eval(int eval_id, zend_op_array *opa)
 
 	resolve_breakpoints_for_function(lines_list, opa);
 
-	if (!xdebug_is_debug_connection_active_for_current_pid()) {
+	if (!xdebug_is_debug_connection_active()) {
 		zend_string_release(eval_string);
 		xdfree(eval_filename);
 		return;
@@ -801,7 +801,7 @@ static void resolve_breakpoints_for_eval(int eval_id, zend_op_array *opa)
 
 void xdebug_debugger_register_eval(function_stack_entry *fse)
 {
-	if (xdebug_is_debug_connection_active_for_current_pid() && XG_DBG(context).handler->register_eval_id) {
+	if (xdebug_is_debug_connection_active() && XG_DBG(context).handler->register_eval_id) {
 		int eval_id = XG_DBG(context).handler->register_eval_id(&(XG_DBG(context)), fse);
 
 		resolve_breakpoints_for_eval(eval_id, fse->op_array);

--- a/src/debugger/debugger.c
+++ b/src/debugger/debugger.c
@@ -808,6 +808,23 @@ void xdebug_debugger_register_eval(function_stack_entry *fse)
 	}
 }
 
+void xdebug_debugger_restart_if_pid_changed()
+{
+	zend_ulong pid;
+
+	if (!xdebug_is_debug_connection_active()) {
+		return;
+	}
+
+	pid = xdebug_get_pid();
+
+	/* Start debugger if previously a connection was established and this
+	 * process no longer has the same PID */
+	if (XG_DBG(remote_connection_pid) != pid) {
+		xdebug_restart_debugger();
+	}
+}
+
 
 PHP_FUNCTION(xdebug_break)
 {

--- a/src/debugger/debugger.h
+++ b/src/debugger/debugger.h
@@ -70,6 +70,7 @@ void xdebug_debugger_reset_ide_key(char *envval);
 int xdebug_debugger_bailout_if_no_exec_requested(void);
 void xdebug_debugger_set_program_name(zend_string *filename);
 void xdebug_debugger_register_eval(function_stack_entry *fse);
+void xdebug_debugger_restart_if_pid_changed(void);
 
 xdebug_set *xdebug_debugger_get_breakable_lines_from_oparray(zend_op_array *opa);
 int xdebug_do_eval(char *eval_string, zval *ret_zval);

--- a/src/debugger/handler_dbgp.c
+++ b/src/debugger/handler_dbgp.c
@@ -2507,7 +2507,7 @@ int xdebug_dbgp_deinit(xdebug_con *context)
 	xdebug_xml_node           *response;
 	xdebug_var_export_options *options;
 
-	if (xdebug_is_debug_connection_active_for_current_pid()) {
+	if (xdebug_is_debug_connection_active()) {
 		XG_DBG(status) = DBGP_STATUS_STOPPING;
 		XG_DBG(reason) = DBGP_REASON_OK;
 		response = xdebug_xml_node_init("response");
@@ -2528,7 +2528,7 @@ int xdebug_dbgp_deinit(xdebug_con *context)
 		xdebug_dbgp_cmdloop(context, XDEBUG_CMDLOOP_BLOCK, XDEBUG_CMDLOOP_NONBAIL);
 	}
 
-	if (xdebug_is_debug_connection_active_for_current_pid()) {
+	if (xdebug_is_debug_connection_active()) {
 		options = (xdebug_var_export_options*) context->options;
 		xdfree(options->runtime);
 		xdfree(context->options);
@@ -2708,7 +2708,7 @@ int xdebug_dbgp_breakpoint(xdebug_con *context, xdebug_llist *stack, char *file,
 		XG_DBG(lasttransid) = NULL;
 	}
 
-	return xdebug_is_debug_connection_active_for_current_pid();
+	return xdebug_is_debug_connection_active();
 }
 
 static int xdebug_dbgp_resolved_breakpoint_notification(xdebug_con *context, xdebug_brk_info *brk_info)

--- a/xdebug.c
+++ b/xdebug.c
@@ -796,7 +796,7 @@ static int xdebug_header_handler(sapi_header_struct *h, sapi_header_op_enum op, 
    Dummy function to prevent time limit from being set within the script */
 PHP_FUNCTION(xdebug_set_time_limit)
 {
-	if (!xdebug_is_debug_connection_active_for_current_pid()) {
+	if (!xdebug_is_debug_connection_active()) {
 		XG_BASE(orig_set_time_limit_func)(INTERNAL_FUNCTION_PARAM_PASSTHRU);
 	}
 }
@@ -807,7 +807,7 @@ PHP_FUNCTION(xdebug_set_time_limit)
    Dummy function to return original error reporting level when 'eval' has turned it into 0 */
 PHP_FUNCTION(xdebug_error_reporting)
 {
-	if (ZEND_NUM_ARGS() == 0 && XG_BASE(error_reporting_overridden) && xdebug_is_debug_connection_active_for_current_pid()) {
+	if (ZEND_NUM_ARGS() == 0 && XG_BASE(error_reporting_overridden) && xdebug_is_debug_connection_active()) {
 		RETURN_LONG(XG_BASE(error_reporting_override));
 	}
 	XG_BASE(orig_error_reporting_func)(INTERNAL_FUNCTION_PARAM_PASSTHRU);
@@ -822,6 +822,16 @@ PHP_FUNCTION(xdebug_pcntl_exec)
 	xdebug_profiler_pcntl_exec_handler();
 
 	XG_BASE(orig_pcntl_exec_func)(INTERNAL_FUNCTION_PARAM_PASSTHRU);
+}
+/* }}} */
+
+/* {{{ proto int xdebug_pcntl_fork(void)
+   Dummy function to set a new connection when forking a process */
+PHP_FUNCTION(xdebug_pcntl_fork)
+{
+	XG_BASE(orig_pcntl_fork_func)(INTERNAL_FUNCTION_PARAM_PASSTHRU);
+
+	xdebug_activate_connection_for_current_pid();
 }
 /* }}} */
 
@@ -1001,7 +1011,7 @@ PHP_FUNCTION(xdebug_debug_zval_stdout)
 
 PHP_FUNCTION(xdebug_is_debugger_active)
 {
-	RETURN_BOOL(xdebug_is_debug_connection_active_for_current_pid());
+	RETURN_BOOL(xdebug_is_debug_connection_active());
 }
 
 PHP_FUNCTION(xdebug_start_error_collection)

--- a/xdebug.c
+++ b/xdebug.c
@@ -831,7 +831,7 @@ PHP_FUNCTION(xdebug_pcntl_fork)
 {
 	XG_BASE(orig_pcntl_fork_func)(INTERNAL_FUNCTION_PARAM_PASSTHRU);
 
-	xdebug_activate_connection_for_current_pid();
+	xdebug_debugger_restart_if_pid_changed();
 }
 /* }}} */
 

--- a/xdebug.c
+++ b/xdebug.c
@@ -815,7 +815,7 @@ PHP_FUNCTION(xdebug_error_reporting)
 /* }}} */
 
 /* {{{ proto void xdebug_pcntl_exec(void)
-   Dummy function to prevent time limit from being set within the script */
+   Dummy function to stop profiling when we run pcntl_exec */
 PHP_FUNCTION(xdebug_pcntl_exec)
 {
 	/* We need to stop the profiler and trace files here */


### PR DESCRIPTION
In version 2.7 a change was introduced to restart the debugger if the process id changed. This was added to fix issue # 938 which stopped you from correctly debugging forked processes after using pnctl_fork() . The problem is that now we are calling xdebug_get_pid in a lot of places and this slows down the debugger a lot. It is not actually necessary to be calling xdebug_get_pid continually as we can just do that when the process is forked and restart the debugger at that point if needed. We do this by overriding the pnctl_fork() php function and checking the process id and restarting the debugger if needed there

By doing this, the measured time to run this php code when connected to a debugging client
```
<?php
function fib($n)
{
    if ($n <= 1) {
        return 1;
    }
    return fib($n - 1) + fib($n - 2);
}

echo fib(35);
```
decreased from 2:16 min to 0:59min