### PR TITLE
Fixed issue #1766: Using the DBGp detach command disables remote debugging for the whole process

### DIFF
--- a/php_xdebug.h
+++ b/php_xdebug.h
@@ -20,7 +20,7 @@
 #define PHP_XDEBUG_H
 
 #define XDEBUG_NAME       "Xdebug"
-#define XDEBUG_VERSION    "2.9.4-dev""
+#define XDEBUG_VERSION    "2.9.4-dev"
 #define XDEBUG_AUTHOR     "Derick Rethans"
 #define XDEBUG_COPYRIGHT  "Copyright (c) 2002-2020 by Derick Rethans"
 #define XDEBUG_COPYRIGHT_SHORT "Copyright (c) 2002-2020"

--- a/src/debugger/com.c
+++ b/src/debugger/com.c
@@ -566,6 +566,10 @@ static void xdebug_handle_stop_session()
 
 void xdebug_do_req(void)
 {
+	if (XG_DBG(detached)) {
+		return;
+	}
+
 	if (XINI_DBG(remote_mode) != XDEBUG_REQ) {
 		return;
 	}

--- a/src/debugger/debugger.c
+++ b/src/debugger/debugger.c
@@ -531,6 +531,7 @@ void xdebug_debugger_rinit(void)
 	xdebug_mark_debug_connection_not_active();
 
 	XG_DBG(breakpoints_allowed) = 1;
+	XG_DBG(detached) = 0;
 	XG_DBG(breakable_lines_map) = xdebug_hash_alloc(2048, (xdebug_hash_dtor_t) xdebug_line_list_dtor);
 	XG_DBG(remote_log_file) = NULL;
 

--- a/src/debugger/debugger.h
+++ b/src/debugger/debugger.h
@@ -30,6 +30,7 @@ typedef struct _xdebug_debugger_globals_t {
 	zend_bool     remote_connection_enabled;
 	zend_ulong    remote_connection_pid;
 	zend_bool     breakpoints_allowed;
+	zend_bool     detached;
 	xdebug_con    context;
 	unsigned int  breakpoint_count;
 	unsigned int  no_exec;

--- a/src/debugger/handler_dbgp.c
+++ b/src/debugger/handler_dbgp.c
@@ -1205,7 +1205,7 @@ DBGP_FUNC(detach)
 	XG_DBG(context).handler->remote_deinit(&(XG_DBG(context)));
 	xdebug_mark_debug_connection_not_active();
 	XG_DBG(stdout_mode) = 0;
-	XINI_DBG(remote_enable) = 0;
+	XG_DBG(detached) = 1;
 }
 
 
@@ -2465,6 +2465,7 @@ int xdebug_dbgp_deinit(xdebug_con *context)
 {
 	xdebug_xml_node           *response;
 	xdebug_var_export_options *options;
+	int                        detaching = (XG_DBG(status) == DBGP_STATUS_DETACHED);
 
 	if (xdebug_is_debug_connection_active_for_current_pid()) {
 		XG_DBG(status) = DBGP_STATUS_STOPPING;
@@ -2484,7 +2485,9 @@ int xdebug_dbgp_deinit(xdebug_con *context)
 		send_message(context, response);
 		xdebug_xml_node_dtor(response);
 
-		xdebug_dbgp_cmdloop(context, 0);
+		if (!detaching) {
+			xdebug_dbgp_cmdloop(context, 0);
+		}
 	}
 
 	if (xdebug_is_debug_connection_active_for_current_pid()) {


### PR DESCRIPTION
And it also does not disconnect properly