### PR TITLE
Fixed issue #1783: Stacktrace needs vertical scrolling on small screens.

### DIFF
--- a/src/tracing/trace_html.c
+++ b/src/tracing/trace_html.c
@@ -52,7 +52,7 @@ void xdebug_trace_html_write_header(void *ctxt)
 {
 	xdebug_trace_html_context *context = (xdebug_trace_html_context*) ctxt;
 
-	fprintf(context->trace_file, "<table class='xdebug-trace' dir='ltr' border='1' cellspacing='0'>\n");
+	fprintf(context->trace_file, "<table style='hyphens: auto; -webkit-hyphens: auto; -ms-hyphens: auto;' class='xdebug-trace' dir='ltr' border='1' cellspacing='0'>\n");
 	fprintf(context->trace_file, "\t<tr><th>#</th><th>Time</th>");
 	fprintf(context->trace_file, "<th>Mem</th>");
 	if (XINI_BASE(show_mem_delta)) {

--- a/tests/tracing/bug01232.phpt
+++ b/tests/tracing/bug01232.phpt
@@ -34,7 +34,7 @@ unlink($tf);
 ?>
 --EXPECTF--
 bar
-<table class='xdebug-trace' dir='ltr' border='1' cellspacing='0'>
+<table style='hyphens: auto; -webkit-hyphens: auto; -ms-hyphens: auto;' class='xdebug-trace' dir='ltr' border='1' cellspacing='0'>
 	<tr><th>#</th><th>Time</th><th>Mem</th><th>&#948; Mem</th><th colspan='2'>Function</th><th>Location</th></tr>
 	<tr><td>4</td><td>%f</td><td align='right'>%d</td><td align='right'>%d</td><td align='left'>&nbsp; &nbsp;-&gt;</td><td>foo()</td><td>%sbug01232.php:14</td></tr>
 	<tr><td>5</td><td>%f</td><td align='right'>%d</td><td align='right'>%d</td><td align='left'>&nbsp; &nbsp;&nbsp; &nbsp;-&gt;</td><td>bar()</td><td>%sbug01232.php:11</td></tr>

--- a/tests/tracing/test18b.phpt
+++ b/tests/tracing/test18b.phpt
@@ -34,7 +34,7 @@ unlink($tf);
 ?>
 --EXPECTF--
 bar
-<table class='xdebug-trace' dir='ltr' border='1' cellspacing='0'>
+<table style='hyphens: auto; -webkit-hyphens: auto; -ms-hyphens: auto;' class='xdebug-trace' dir='ltr' border='1' cellspacing='0'>
 	<tr><th>#</th><th>Time</th><th>Mem</th><th colspan='2'>Function</th><th>Location</th></tr>
 	<tr><td>4</td><td>%f</td><td align='right'>%d</td><td align='left'>&nbsp; &nbsp;-&gt;</td><td>foo()</td><td>%stest18b.php:14</td></tr>
 	<tr><td>5</td><td>%f</td><td align='right'>%d</td><td align='left'>&nbsp; &nbsp;&nbsp; &nbsp;-&gt;</td><td>bar()</td><td>%stest18b.php:11</td></tr>

--- a/tests/tracing/trace-002.phpt
+++ b/tests/tracing/trace-002.phpt
@@ -38,7 +38,7 @@ xdebug.trace_format=0
 	unlink($tf);
 ?>
 --EXPECTF--
-<table class='xdebug-trace' dir='ltr' border='1' cellspacing='0'>
+<table style='hyphens: auto; -webkit-hyphens: auto; -ms-hyphens: auto;' class='xdebug-trace' dir='ltr' border='1' cellspacing='0'>
 	<tr><th>#</th><th>Time</th><th>Mem</th><th colspan='2'>Function</th><th>Location</th></tr>
 	<tr><td>4</td><td>%f</td><td align='right'>%d</td><td align='left'>&nbsp; &nbsp;-&gt;</td><td>fibonacci_cache()</td><td>%strace-002.php:22</td></tr>
 	<tr><td>5</td><td>%f</td><td align='right'>%d</td><td align='left'>&nbsp; &nbsp;&nbsp; &nbsp;-&gt;</td><td>fibonacci_cache()</td><td>%strace-002.php:16</td></tr>


### PR DESCRIPTION
Use CSS Hyphenation to break long paths apart.