### PR TITLE
Improve/update AppVeyor CI integration

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,6 +12,42 @@ cache:
 environment:
     BIN_SDK_VER: 2.2.0
     matrix:
+        - PHP_VER: master
+          ARCH: x64
+          TS: 1
+          VC: vs16
+          OPCACHE: yes
+          APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+        - PHP_VER: master
+          ARCH: x64
+          TS: 0
+          VC: vs16
+          OPCACHE: yes
+          APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+        - PHP_VER: master
+          ARCH: x64
+          TS: 1
+          VC: vs16
+          OPCACHE: no
+          APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+        - PHP_VER: master
+          ARCH: x64
+          TS: 0
+          VC: vs16
+          OPCACHE: no
+          APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+        - PHP_VER: master
+          ARCH: x86
+          TS: 1
+          VC: vs16
+          OPCACHE: no
+          APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+        - PHP_VER: master
+          ARCH: x86
+          TS: 0
+          VC: vs16
+          OPCACHE: yes
+          APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
         - PHP_VER: 7.4
           ARCH: x64
           TS: 1

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,26 +1,13 @@
 image: Visual Studio 2015
 version: '{branch}.{build}'
 
-clone_folder: c:\projects\xdebug
+clone_folder: C:\projects\xdebug
 
 install:
-    ps: |
-        if (-not (Test-Path c:\build-cache)) {
-            mkdir c:\build-cache
-        }
-        $bname = 'php-sdk-' + $env:BIN_SDK_VER + '.zip'
-        if (-not (Test-Path c:\build-cache\$bname)) {
-            Invoke-WebRequest "https://github.com/OSTC/php-sdk-binary-tools/archive/$bname" -OutFile "c:\build-cache\$bname"
-        }
-        $dname0 = 'php-sdk-binary-tools-php-sdk-' + $env:BIN_SDK_VER
-        $dname1 = 'php-sdk-' + $env:BIN_SDK_VER
-        if (-not (Test-Path c:\build-cache\$dname1)) {
-            7z x c:\build-cache\$bname -oc:\build-cache
-            move c:\build-cache\$dname0 c:\build-cache\$dname1
-        }
+    ps: .appveyor\install.ps1
 
 cache:
-  - c:\build-cache -> .appveyor.yml
+  - C:\build-cache -> .appveyor.yml, .appveyor\install.ps1
 
 environment:
     BIN_SDK_VER: 2.2.0
@@ -111,105 +98,10 @@ environment:
           APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
 
 build_script:
-    ps: |
-        $ts_part = ''
-        if ('0' -eq $env:TS) { $ts_part = '-nts' }
-        $bname = 'php-devel-pack-' + $env:PHP_VER + $ts_part + '-Win32-' + $env:VC.toUpper() + '-' + $env:ARCH + '.zip'
-        if (-not (Test-Path c:\build-cache\$bname)) {
-            Invoke-WebRequest "http://windows.php.net/downloads/releases/archives/$bname" -OutFile "c:\build-cache\$bname"
-            if (-not (Test-Path c:\build-cache\$bname)) {
-                Invoke-WebRequest "http://windows.php.net/downloads/releases/$bname" -OutFile "c:\build-cache\$bname"
-            }
-        }
-        $dname0 = 'php-' + $env:PHP_VER + '-devel-' + $env:VC.toUpper() + '-' + $env:ARCH
-        $dname1 = 'php-' + $env:PHP_VER + $ts_part + '-devel-' + $env:VC.toUpper() + '-' + $env:ARCH
-        if (-not (Test-Path c:\build-cache\$dname1)) {
-            7z x c:\build-cache\$bname -oc:\build-cache
-            if ($dname0 -ne $dname1) {
-                move c:\build-cache\$dname0 c:\build-cache\$dname1
-            }
-        }
-        cd c:\projects\xdebug
-        $env:PATH = 'c:\build-cache\' + $dname1 + ';' + $env:PATH
-        #echo "@echo off" | Out-File -Encoding "ASCII" task.bat
-        #echo "" | Out-File -Encoding "ASCII" -Append task.bat
-        echo "" | Out-File -Encoding "ASCII" task.bat
-        echo "call phpize 2>&1" | Out-File -Encoding "ASCII" -Append task.bat
-        echo "call configure --with-xdebug --enable-debug-pack 2>&1" | Out-File -Encoding "ASCII" -Append task.bat
-        echo "nmake /nologo 2>&1" | Out-File -Encoding "ASCII" -Append task.bat
-        echo "exit %errorlevel%" | Out-File -Encoding "ASCII" -Append task.bat
-        $here = (Get-Item -Path "." -Verbose).FullName
-        $runner = 'c:\build-cache\php-sdk-' + $env:BIN_SDK_VER + '\phpsdk' + '-' + $env:VC + '-' + $env:ARCH + '.bat'
-        $task = $here + '\task.bat'
-        & $runner -t $task
+    ps: .appveyor\build.ps1
 
 after_build:
-    ps: |
-        $ts_part = ''
-        if ('0' -eq $env:TS) { $ts_part = '-nts' }
-        $arch_part = ''
-        if ('x64' -eq $env:ARCH) { $arch_part = '-x86_64' }
-        if ($env:APPVEYOR_REPO_TAG -eq "true") {
-            $bname = 'php_xdebug-' + $env:APPVEYOR_REPO_TAG_NAME + '-' + $env:PHP_VER.substring(0, 3) + '-' + $env:VC + $ts_part + $arch_part
-        } else {
-            $bname = 'php_xdebug-' + $env:APPVEYOR_REPO_COMMIT.substring(0, 8) + '-' + $env:PHP_VER.substring(0, 3) + '-' + $env:VC + $ts_part + $arch_part
-        }
-        $zip_bname = $bname + '.zip'
-        $dll_bname = $bname + '.dll'
-
-        $dir = 'c:\projects\xdebug\';
-        if ('x64' -eq $env:ARCH) { $dir = $dir + 'x64\' }
-        $dir = $dir + 'Release'
-        if ('1' -eq $env:TS) { $dir = $dir + '_TS' }
-
-        cp $dir\php_xdebug.dll $dir\$dll_bname
-        & 7z a c:\$zip_bname $dir\$dll_bname $dir\php_xdebug.pdb c:\projects\xdebug\LICENSE
-        Push-AppveyorArtifact c:\$zip_bname
+    ps: .appveyor\package.ps1
 
 test_script:
-    ps: |
-        $ts_part = ''
-        if ('0' -eq $env:TS) { $ts_part = '-nts' }
-        $bname = 'php-' + $env:PHP_VER + $ts_part + '-Win32-' + $env:VC.toUpper() + '-' + $env:ARCH + '.zip'
-        if (-not (Test-Path c:\build-cache\$bname)) {
-            Invoke-WebRequest "http://windows.php.net/downloads/releases/archives/$bname" -OutFile "c:\build-cache\$bname"
-            if (-not (Test-Path c:\build-cache\$bname)) {
-                Invoke-WebRequest "http://windows.php.net/downloads/releases/$bname" -OutFile "c:\build-cache\$bname"
-            }
-        }
-        $dname = 'php-' + $env:PHP_VER + $ts_part + '-' + $env:VC.toUpper() + '-' + $env:ARCH
-        if (-not (Test-Path c:\build-cache\$dname)) {
-            7z x c:\build-cache\$bname -oc:\build-cache\$dname
-        }
-        
-        $dir = 'c:\projects\xdebug\';
-        if ('x64' -eq $env:ARCH) { $dir = $dir + 'x64\' }
-        $dir = $dir + 'Release'
-        if ('1' -eq $env:TS) { $dir = $dir + '_TS' }
-
-        $xdebug_dll_opt = '-d zend_extension=' + $dir + '\php_xdebug.dll'
-
-
-        cd c:\projects\xdebug
-        mkdir c:\tests_tmp
-        echo "" | Out-File -Encoding "ASCII" task.bat
-        echo "set REPORT_EXIT_STATUS=1" | Out-File -Encoding "ASCII" -Append task.bat
-        $cmd = 'call configure --with-xdebug --with-prefix=c:\build-cache\' + $dname + " 2>&1"
-        echo $cmd | Out-File -Encoding "ASCII" -Append task.bat
-
-        $opts = 'set TEST_PHP_ARGS=-n -d foo=yes'
-        if ('yes' -eq $env:OPCACHE) { $opts = $opts + ' -d zend_extension=c:\build-cache\' + $dname + '\ext\php_opcache.dll -d opcache.enabled=1 -d opcache.enable_cli=1' }
-        $opts = $opts + ' ' + $xdebug_dll_opt
-        echo $opts | Out-File -Encoding "ASCII" -Append task.bat
-
-        $php = "c:\\build-cache\\" + $dname + '\php.exe'
-        $test_php_exec = "set TEST_PHP_EXECUTABLE=" + $php
-        echo $test_php_exec | Out-File -Encoding "ASCII" -Append task.bat
-        $tcmd = $php + ' run-xdebug-tests.php -q --offline --show-diff --show-slow 1000 --set-timeout 120 -g FAIL,XFAIL,BORK,WARN,LEAK,SKIP --temp-source c:\tests_tmp --temp-target c:\tests_tmp -p c:\build-cache\' + $dname + '\php.exe'
-        echo $tcmd | Out-File -Encoding "ASCII" -Append task.bat
-        echo "exit %errorlevel%" | Out-File -Encoding "ASCII" -Append task.bat
-
-        $here = (Get-Item -Path "." -Verbose).FullName
-        $runner = 'c:\build-cache\php-sdk-' + $env:BIN_SDK_VER + '\phpsdk' + '-' + $env:VC + '-' + $env:ARCH + '.bat'
-        $task = $here + '\task.bat'
-        & $runner -t $task
+    ps: .appveyor\test.ps1

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,85 +12,85 @@ cache:
 environment:
     BIN_SDK_VER: 2.2.0
     matrix:
-        - PHP_VER: 7.4.0
+        - PHP_VER: 7.4
           ARCH: x64
           TS: 1
           VC: vc15
           OPCACHE: yes
           APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-        - PHP_VER: 7.4.0
+        - PHP_VER: 7.4
           ARCH: x64
           TS: 0
           VC: vc15
           OPCACHE: yes
           APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-        - PHP_VER: 7.4.0
+        - PHP_VER: 7.4
           ARCH: x64
           TS: 1
           VC: vc15
           OPCACHE: no
           APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-        - PHP_VER: 7.4.0
+        - PHP_VER: 7.4
           ARCH: x64
           TS: 0
           VC: vc15
           OPCACHE: no
           APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-        - PHP_VER: 7.4.0
+        - PHP_VER: 7.4
           ARCH: x86
           TS: 1
           VC: vc15
           OPCACHE: no
           APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-        - PHP_VER: 7.4.0
+        - PHP_VER: 7.4
           ARCH: x86
           TS: 0
           VC: vc15
           OPCACHE: yes
           APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-        - PHP_VER: 7.3.13
+        - PHP_VER: 7.3
           ARCH: x64
           TS: 1
           VC: vc15
           OPCACHE: yes
           APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-        - PHP_VER: 7.3.13
+        - PHP_VER: 7.3
           ARCH: x64
           TS: 0
           VC: vc15
           OPCACHE: no
           APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-        - PHP_VER: 7.3.13
+        - PHP_VER: 7.3
           ARCH: x86
           TS: 1
           VC: vc15
           OPCACHE: no
           APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-        - PHP_VER: 7.3.13
+        - PHP_VER: 7.3
           ARCH: x86
           TS: 0
           VC: vc15
           OPCACHE: yes
           APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-        - PHP_VER: 7.2.26
+        - PHP_VER: 7.2
           ARCH: x64
           TS: 1
           VC: vc15
           OPCACHE: yes
           APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-        - PHP_VER: 7.2.26
+        - PHP_VER: 7.2
           ARCH: x64
           TS: 0
           VC: vc15
           OPCACHE: no
           APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-        - PHP_VER: 7.2.26
+        - PHP_VER: 7.2
           ARCH: x86
           TS: 1
           VC: vc15
           OPCACHE: no
           APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-        - PHP_VER: 7.2.26
+        - PHP_VER: 7.2
           ARCH: x86
           TS: 0
           VC: vc15

--- a/.appveyor/build.ps1
+++ b/.appveyor/build.ps1
@@ -1,3 +1,5 @@
+$ErrorActionPreference = "Stop"
+
 Set-Location 'C:\projects\xdebug'
 
 $task = New-Item 'task.bat' -Force
@@ -6,3 +8,6 @@ Add-Content $task "call configure --with-xdebug --enable-debug-pack 2>&1"
 Add-Content $task "nmake /nologo 2>&1"
 Add-Content $task "exit %errorlevel%"
 & "C:\build-cache\php-sdk-$env:BIN_SDK_VER\phpsdk-$env:VC-$env:ARCH.bat" -t $task
+if (-not $?) {
+    throw "build failed with errorlevel $LastExitCode"
+}

--- a/.appveyor/build.ps1
+++ b/.appveyor/build.ps1
@@ -1,0 +1,8 @@
+Set-Location 'C:\projects\xdebug'
+
+$task = New-Item 'task.bat' -Force
+Add-Content $task "call phpize 2>&1"
+Add-Content $task "call configure --with-xdebug --enable-debug-pack 2>&1"
+Add-Content $task "nmake /nologo 2>&1"
+Add-Content $task "exit %errorlevel%"
+& "C:\build-cache\php-sdk-$env:BIN_SDK_VER\phpsdk-$env:VC-$env:ARCH.bat" -t $task

--- a/.appveyor/install.ps1
+++ b/.appveyor/install.ps1
@@ -14,41 +14,75 @@ if (-not (Test-Path "C:\build-cache\$dname1")) {
     Move-Item "C:\build-cache\$dname0" "C:\build-cache\$dname1"
 }
 
-$releases = Invoke-WebRequest https://windows.php.net/downloads/releases/releases.json | ConvertFrom-Json
-$phpversion = $releases.$env:PHP_VER.version
+if ($env:PHP_VER -eq 'master') {
+    $snaps = Invoke-WebRequest 'https://windows.php.net/downloads/snaps/master/master.json' | ConvertFrom-Json
+    $revision = $snaps.revision_last_exported
 
-$ts_part = ''
-if ($env:TS -eq '0') {
-    $ts_part += '-nts'
-}
-$bname = "php-devel-pack-$phpversion$ts_part-Win32-$env:VC-$env:ARCH.zip"
-if (-not (Test-Path "C:\build-cache\$bname")) {
-    try {
-        Invoke-WebRequest "https://windows.php.net/downloads/releases/archives/$bname" -OutFile "C:\build-cache\$bname"
-    } catch [System.Net.WebException] { 
-        Invoke-WebRequest "https://windows.php.net/downloads/releases/$bname" -OutFile "C:\build-cache\$bname"
+    if ($env:TS -eq '0') {
+        $ts_part = '-nts'
+    } else {
+        $ts_part = '-ts'
     }
-}
-$dname0 = "php-$phpversion-devel-$env:VC-$env:ARCH"
-$dname1 = "php-$phpversion$ts_part-devel-$env:VC-$env:ARCH"
-if (-not (Test-Path "C:\build-cache\$dname1")) {
-    Expand-Archive "C:\build-cache\$bname" 'C:\build-cache'
-    if ($dname0 -ne $dname1) {
+
+    $bname = "php-devel-pack-master$ts_part-windows-$env:VC-$env:ARCH-r$revision.zip"
+    if (-not (Test-Path "C:\build-cache\$bname")) {
+        Invoke-WebRequest "https://windows.php.net/downloads/snaps/master/r$revision/$bname" -OutFile "C:\build-cache\$bname"
+    }
+    $dname0 = "php-8.0.0-dev-devel-$env:VC-$env:ARCH"
+    $dname1 = "php-$revision$ts_part-devel-$env:VC-$env:ARCH"
+    if (-not (Test-Path "C:\build-cache\$dname1")) {
+        Expand-Archive "C:\build-cache\$bname" 'C:\build-cache'
         Move-Item "C:\build-cache\$dname0" "C:\build-cache\$dname1"
     }
-}
-$env:PATH = "C:\build-cache\$dname1;$env:PATH"
+    $env:PATH = "C:\build-cache\$dname1;$env:PATH"
 
-$bname = "php-$phpversion$ts_part-Win32-$env:VC-$env:ARCH.zip"
-if (-not (Test-Path "C:\build-cache\$bname")) {
-    try {
-        Invoke-WebRequest "https://windows.php.net/downloads/releases/archives/$bname" -OutFile "C:\build-cache\$bname"
-    } catch [System.Net.WebException] { 
-        Invoke-WebRequest "https://windows.php.net/downloads/releases/$bname" -OutFile "C:\build-cache\$bname"
+    $bname = "php-master$ts_part-windows-$env:VC-$env:ARCH-r$revision.zip"
+    if (-not (Test-Path "C:\build-cache\$bname")) {
+        Invoke-WebRequest "https://windows.php.net/downloads/snaps/master/r$revision/$bname" -OutFile "C:\build-cache\$bname"
     }
+    $dname = "php-$revision$ts_part-$env:VC-$env:ARCH"
+    if (-not (Test-Path "C:\build-cache\$dname")) {
+        Expand-Archive "C:\build-cache\$bname" "C:\build-cache\$dname"
+    }
+    $env:PATH = "c:\build-cache\$dname;$env:PATH"
+} else {
+    $releases = Invoke-WebRequest 'https://windows.php.net/downloads/releases/releases.json' | ConvertFrom-Json
+    $phpversion = $releases.$env:PHP_VER.version
+
+    $ts_part = ''
+    if ($env:TS -eq '0') {
+        $ts_part += '-nts'
+    }
+
+    $bname = "php-devel-pack-$phpversion$ts_part-Win32-$env:VC-$env:ARCH.zip"
+    if (-not (Test-Path "C:\build-cache\$bname")) {
+        try {
+            Invoke-WebRequest "https://windows.php.net/downloads/releases/archives/$bname" -OutFile "C:\build-cache\$bname"
+        } catch [System.Net.WebException] {
+            Invoke-WebRequest "https://windows.php.net/downloads/releases/$bname" -OutFile "C:\build-cache\$bname"
+        }
+    }
+    $dname0 = "php-$phpversion-devel-$env:VC-$env:ARCH"
+    $dname1 = "php-$phpversion$ts_part-devel-$env:VC-$env:ARCH"
+    if (-not (Test-Path "C:\build-cache\$dname1")) {
+        Expand-Archive "C:\build-cache\$bname" 'C:\build-cache'
+        if ($dname0 -ne $dname1) {
+            Move-Item "C:\build-cache\$dname0" "C:\build-cache\$dname1"
+        }
+    }
+    $env:PATH = "C:\build-cache\$dname1;$env:PATH"
+
+    $bname = "php-$phpversion$ts_part-Win32-$env:VC-$env:ARCH.zip"
+    if (-not (Test-Path "C:\build-cache\$bname")) {
+        try {
+            Invoke-WebRequest "https://windows.php.net/downloads/releases/archives/$bname" -OutFile "C:\build-cache\$bname"
+        } catch [System.Net.WebException] {
+            Invoke-WebRequest "https://windows.php.net/downloads/releases/$bname" -OutFile "C:\build-cache\$bname"
+        }
+    }
+    $dname = "php-$phpversion$ts_part-$env:VC-$env:ARCH"
+    if (-not (Test-Path "C:\build-cache\$dname")) {
+        Expand-Archive "C:\build-cache\$bname" "C:\build-cache\$dname"
+    }
+    $env:PATH = "c:\build-cache\$dname;$env:PATH"
 }
-$dname = "php-$phpversion$ts_part-$env:VC-$env:ARCH"
-if (-not (Test-Path "C:\build-cache\$dname")) {
-    Expand-Archive "C:\build-cache\$bname" "C:\build-cache\$dname"
-}
-$env:PATH = "c:\build-cache\$dname;$env:PATH"

--- a/.appveyor/install.ps1
+++ b/.appveyor/install.ps1
@@ -1,3 +1,5 @@
+$ErrorActionPreference = "Stop"
+
 if (-not (Test-Path 'C:\build-cache')) {
     [void](New-Item 'C:\build-cache' -ItemType 'directory')
 }
@@ -18,8 +20,9 @@ if ($env:TS -eq '0') {
 }
 $bname = "php-devel-pack-$env:PHP_VER$ts_part-Win32-$env:VC-$env:ARCH.zip"
 if (-not (Test-Path "C:\build-cache\$bname")) {
-    Invoke-WebRequest "https://windows.php.net/downloads/releases/archives/$bname" -OutFile "C:\build-cache\$bname"
-    if (-not (Test-Path "C:\build-cache\$bname")) {
+    try {
+        Invoke-WebRequest "https://windows.php.net/downloads/releases/archives/$bname" -OutFile "C:\build-cache\$bname"
+    } catch [System.Net.WebException] { 
         Invoke-WebRequest "https://windows.php.net/downloads/releases/$bname" -OutFile "C:\build-cache\$bname"
     }
 }
@@ -35,8 +38,9 @@ $env:PATH = "C:\build-cache\$dname1;$env:PATH"
 
 $bname = "php-$env:PHP_VER$ts_part-Win32-$env:VC-$env:ARCH.zip"
 if (-not (Test-Path "C:\build-cache\$bname")) {
-    Invoke-WebRequest "https://windows.php.net/downloads/releases/archives/$bname" -OutFile "C:\build-cache\$bname"
-    if (-not (Test-Path "C:\build-cache\$bname")) {
+    try {
+        Invoke-WebRequest "https://windows.php.net/downloads/releases/archives/$bname" -OutFile "C:\build-cache\$bname"
+    } catch [System.Net.WebException] { 
         Invoke-WebRequest "https://windows.php.net/downloads/releases/$bname" -OutFile "C:\build-cache\$bname"
     }
 }

--- a/.appveyor/install.ps1
+++ b/.appveyor/install.ps1
@@ -14,11 +14,14 @@ if (-not (Test-Path "C:\build-cache\$dname1")) {
     Move-Item "C:\build-cache\$dname0" "C:\build-cache\$dname1"
 }
 
+$releases = Invoke-WebRequest https://windows.php.net/downloads/releases/releases.json | ConvertFrom-Json
+$phpversion = $releases.$env:PHP_VER.version
+
 $ts_part = ''
 if ($env:TS -eq '0') {
     $ts_part += '-nts'
 }
-$bname = "php-devel-pack-$env:PHP_VER$ts_part-Win32-$env:VC-$env:ARCH.zip"
+$bname = "php-devel-pack-$phpversion$ts_part-Win32-$env:VC-$env:ARCH.zip"
 if (-not (Test-Path "C:\build-cache\$bname")) {
     try {
         Invoke-WebRequest "https://windows.php.net/downloads/releases/archives/$bname" -OutFile "C:\build-cache\$bname"
@@ -26,8 +29,8 @@ if (-not (Test-Path "C:\build-cache\$bname")) {
         Invoke-WebRequest "https://windows.php.net/downloads/releases/$bname" -OutFile "C:\build-cache\$bname"
     }
 }
-$dname0 = "php-$env:PHP_VER-devel-$env:VC-$env:ARCH"
-$dname1 = "php-$env:PHP_VER$ts_part-devel-$env:VC-$env:ARCH"
+$dname0 = "php-$phpversion-devel-$env:VC-$env:ARCH"
+$dname1 = "php-$phpversion$ts_part-devel-$env:VC-$env:ARCH"
 if (-not (Test-Path "C:\build-cache\$dname1")) {
     Expand-Archive "C:\build-cache\$bname" 'C:\build-cache'
     if ($dname0 -ne $dname1) {
@@ -36,7 +39,7 @@ if (-not (Test-Path "C:\build-cache\$dname1")) {
 }
 $env:PATH = "C:\build-cache\$dname1;$env:PATH"
 
-$bname = "php-$env:PHP_VER$ts_part-Win32-$env:VC-$env:ARCH.zip"
+$bname = "php-$phpversion$ts_part-Win32-$env:VC-$env:ARCH.zip"
 if (-not (Test-Path "C:\build-cache\$bname")) {
     try {
         Invoke-WebRequest "https://windows.php.net/downloads/releases/archives/$bname" -OutFile "C:\build-cache\$bname"
@@ -44,7 +47,7 @@ if (-not (Test-Path "C:\build-cache\$bname")) {
         Invoke-WebRequest "https://windows.php.net/downloads/releases/$bname" -OutFile "C:\build-cache\$bname"
     }
 }
-$dname = "php-$env:PHP_VER$ts_part-$env:VC-$env:ARCH"
+$dname = "php-$phpversion$ts_part-$env:VC-$env:ARCH"
 if (-not (Test-Path "C:\build-cache\$dname")) {
     Expand-Archive "C:\build-cache\$bname" "C:\build-cache\$dname"
 }

--- a/.appveyor/install.ps1
+++ b/.appveyor/install.ps1
@@ -1,0 +1,47 @@
+if (-not (Test-Path 'C:\build-cache')) {
+    [void](New-Item 'C:\build-cache' -ItemType 'directory')
+}
+$bname = "php-sdk-$env:BIN_SDK_VER.zip"
+if (-not (Test-Path "C:\build-cache\$bname")) {
+    Invoke-WebRequest "https://github.com/OSTC/php-sdk-binary-tools/archive/$bname" -OutFile "C:\build-cache\$bname"
+}
+$dname0 = "php-sdk-binary-tools-php-sdk-$env:BIN_SDK_VER"
+$dname1 = "php-sdk-$env:BIN_SDK_VER"
+if (-not (Test-Path "C:\build-cache\$dname1")) {
+    Expand-Archive "C:\build-cache\$bname" 'C:\build-cache'
+    Move-Item "C:\build-cache\$dname0" "C:\build-cache\$dname1"
+}
+
+$ts_part = ''
+if ($env:TS -eq '0') {
+    $ts_part += '-nts'
+}
+$bname = "php-devel-pack-$env:PHP_VER$ts_part-Win32-$env:VC-$env:ARCH.zip"
+if (-not (Test-Path "C:\build-cache\$bname")) {
+    Invoke-WebRequest "https://windows.php.net/downloads/releases/archives/$bname" -OutFile "C:\build-cache\$bname"
+    if (-not (Test-Path "C:\build-cache\$bname")) {
+        Invoke-WebRequest "https://windows.php.net/downloads/releases/$bname" -OutFile "C:\build-cache\$bname"
+    }
+}
+$dname0 = "php-$env:PHP_VER-devel-$env:VC-$env:ARCH"
+$dname1 = "php-$env:PHP_VER$ts_part-devel-$env:VC-$env:ARCH"
+if (-not (Test-Path "C:\build-cache\$dname1")) {
+    Expand-Archive "C:\build-cache\$bname" 'C:\build-cache'
+    if ($dname0 -ne $dname1) {
+        Move-Item "C:\build-cache\$dname0" "C:\build-cache\$dname1"
+    }
+}
+$env:PATH = "C:\build-cache\$dname1;$env:PATH"
+
+$bname = "php-$env:PHP_VER$ts_part-Win32-$env:VC-$env:ARCH.zip"
+if (-not (Test-Path "C:\build-cache\$bname")) {
+    Invoke-WebRequest "https://windows.php.net/downloads/releases/archives/$bname" -OutFile "C:\build-cache\$bname"
+    if (-not (Test-Path "C:\build-cache\$bname")) {
+        Invoke-WebRequest "https://windows.php.net/downloads/releases/$bname" -OutFile "C:\build-cache\$bname"
+    }
+}
+$dname = "php-$env:PHP_VER$ts_part-$env:VC-$env:ARCH"
+if (-not (Test-Path "C:\build-cache\$dname")) {
+    Expand-Archive "C:\build-cache\$bname" "C:\build-cache\$dname"
+}
+$env:PATH = "c:\build-cache\$dname;$env:PATH"

--- a/.appveyor/package.ps1
+++ b/.appveyor/package.ps1
@@ -1,0 +1,28 @@
+$ts_part = ''
+if ($env:TS -eq '0') {
+    $ts_part += '-nts'
+}
+$arch_part = ''
+if ($env:ARCH -eq 'x64') {
+    $arch_part += '-x86_64'
+}
+if ($env:APPVEYOR_REPO_TAG -eq "true") {
+    $bname = "php_xdebug-$env:APPVEYOR_REPO_TAG_NAME-" + $env:PHP_VER.substring(0, 3) + "-$env:VC$ts_part$arch_part"
+} else {
+    $bname = 'php_xdebug-' + $env:APPVEYOR_REPO_COMMIT.substring(0, 8) + '-' + $env:PHP_VER.substring(0, 3) + "-$env:VC$ts_part$arch_part"
+}
+$zip_bname = "$bname.zip"
+$dll_bname = "$bname.dll"
+
+$dir = 'C:\projects\xdebug\'
+if ($env:ARCH -eq 'x64') {
+    $dir += 'x64\'
+}
+$dir += 'Release'
+if ($env:TS -eq '1') {
+    $dir += '_TS'
+}
+
+Copy-Item "$dir\php_xdebug.dll" "$dir\$dll_bname"
+Compress-Archive @("$dir\$dll_bname", "$dir\php_xdebug.pdb", 'C:\projects\xdebug\LICENSE') "C:\$zip_bname"
+Push-AppveyorArtifact "C:\$zip_bname"

--- a/.appveyor/package.ps1
+++ b/.appveyor/package.ps1
@@ -9,9 +9,9 @@ if ($env:ARCH -eq 'x64') {
     $arch_part += '-x86_64'
 }
 if ($env:APPVEYOR_REPO_TAG -eq "true") {
-    $bname = "php_xdebug-$env:APPVEYOR_REPO_TAG_NAME-" + $env:PHP_VER.substring(0, 3) + "-$env:VC$ts_part$arch_part"
+    $bname = "php_xdebug-$env:APPVEYOR_REPO_TAG_NAME-" + "$env:PHP_VER-$env:VC$ts_part$arch_part"
 } else {
-    $bname = 'php_xdebug-' + $env:APPVEYOR_REPO_COMMIT.substring(0, 8) + '-' + $env:PHP_VER.substring(0, 3) + "-$env:VC$ts_part$arch_part"
+    $bname = 'php_xdebug-' + $env:APPVEYOR_REPO_COMMIT.substring(0, 8) + "-$env:PHP_VER-$env:VC$ts_part$arch_part"
 }
 $zip_bname = "$bname.zip"
 $dll_bname = "$bname.dll"

--- a/.appveyor/package.ps1
+++ b/.appveyor/package.ps1
@@ -1,3 +1,5 @@
+$ErrorActionPreference = "Stop"
+
 $ts_part = ''
 if ($env:TS -eq '0') {
     $ts_part += '-nts'

--- a/.appveyor/test.ps1
+++ b/.appveyor/test.ps1
@@ -1,3 +1,5 @@
+$ErrorActionPreference = "Stop"
+
 $dir = 'C:\projects\xdebug\'
 if ($env:ARCH -eq 'x64') {
     $dir += 'x64\'
@@ -24,3 +26,6 @@ $env:TEST_PHP_ARGS = $opts
 
 $env:TEST_PHP_EXECUTABLE = $php
 & $php run-xdebug-tests.php -q --offline --show-diff --show-slow 1000 --set-timeout 120 -g FAIL,XFAIL,BORK,WARN,LEAK,SKIP --temp-source C:\tests_tmp --temp-target C:\tests_tmp
+if (-not $?) {
+    throw "tests failed with errorlevel $LastExitCode"
+}

--- a/.appveyor/test.ps1
+++ b/.appveyor/test.ps1
@@ -1,0 +1,26 @@
+$dir = 'C:\projects\xdebug\'
+if ($env:ARCH -eq 'x64') {
+    $dir += 'x64\'
+}
+$dir += 'Release'
+if ($env:TS -eq '1') {
+    $dir += '_TS'
+}
+
+$xdebug_dll_opt = "-d zend_extension=$dir\php_xdebug.dll"
+
+Set-Location "C:\projects\xdebug"
+[void](New-Item "C:\tests_tmp" -ItemType 'directory')
+
+$php = Get-Command 'php' | Select-Object -ExpandProperty 'Definition'
+$dname = (Get-Item $php).Directory.FullName
+
+$opts = '-n -d foo=yes'
+if ($env:OPCACHE -eq 'yes') {
+    $opts += " -d zend_extension=$dname\ext\php_opcache.dll -d opcache.enabled=1 -d opcache.enable_cli=1"
+}
+$opts += " $xdebug_dll_opt"
+$env:TEST_PHP_ARGS = $opts
+
+$env:TEST_PHP_EXECUTABLE = $php
+& $php run-xdebug-tests.php -q --offline --show-diff --show-slow 1000 --set-timeout 120 -g FAIL,XFAIL,BORK,WARN,LEAK,SKIP --temp-source C:\tests_tmp --temp-target C:\tests_tmp

--- a/src/base/stack.c
+++ b/src/base/stack.c
@@ -710,7 +710,7 @@ void xdebug_error_cb(int orig_type, const char *error_filename, const unsigned i
 #ifdef PHP_WIN32
 			if (type==E_CORE_ERROR || type==E_CORE_WARNING) {
 #if PHP_VERSION_ID >= 80000
-				syslog(LOG_ALERT, "PHP %s: %s (%s)", error_type_str, ZSTR_VAL(message), GetCommandLine());
+				php_syslog(LOG_ALERT, "PHP %s: %s (%s)", error_type_str, ZSTR_VAL(message), GetCommandLine());
 #else
 				MessageBox(NULL, buffer, error_type_str, MB_OK);
 #endif


### PR DESCRIPTION
This PR improves the existing AppVeyor CI integration by refactoring and better error handling (formerly, some relevant errors could still let CI pass), updates to always use the latest PHP revisions, and adds  php-src/master build jobs.

It also fixes a bug, where `syslog()` is called on Windows for PHP 8, although that symbol is not exported.

The php-src/master builds might not work if snapshot builds are in progress; not sure about that. Also, at least in the long run, the build-cache needs some clean-up, because as it is now, new PHP builds and devel packages will be just added to the cache.