### PR TITLE
Use better time souces for Linux, Windows and Mac platforms

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -78,7 +78,7 @@ if test "$PHP_XDEBUG" != "no"; then
   PHP_XDEBUG_CFLAGS="$STD_CFLAGS $MAINTAINER_CFLAGS"
 
   XDEBUG_BASE_SOURCES="src/base/base.c src/base/filter.c"
-  XDEBUG_LIB_SOURCES="src/lib/usefulstuff.c src/lib/compat.c src/lib/crc32.c src/lib/hash.c src/lib/headers.c src/lib/lib.c src/lib/llist.c src/lib/set.c src/lib/str.c src/lib/var.c src/lib/var_export_html.c src/lib/var_export_line.c src/lib/var_export_serialized.c src/lib/var_export_text.c src/lib/var_export_xml.c src/lib/xml.c"
+  XDEBUG_LIB_SOURCES="src/lib/usefulstuff.c src/lib/compat.c src/lib/crc32.c src/lib/hash.c src/lib/headers.c src/lib/lib.c src/lib/llist.c src/lib/set.c src/lib/str.c src/lib/timing.c src/lib/var.c src/lib/var_export_html.c src/lib/var_export_line.c src/lib/var_export_serialized.c src/lib/var_export_text.c src/lib/var_export_xml.c src/lib/xml.c"
 
   XDEBUG_COVERAGE_SOURCES="src/coverage/branch_info.c src/coverage/code_coverage.c"
   XDEBUG_DEBUGGER_SOURCES="src/debugger/com.c src/debugger/debugger.c src/debugger/handler_dbgp.c src/debugger/handlers.c"

--- a/config.w32
+++ b/config.w32
@@ -4,7 +4,7 @@ ARG_WITH("xdebug", "Xdebug support", "no");
 
 if (PHP_XDEBUG != 'no') {
 	var XDEBUG_BASE_SOURCES="base.c filter.c"
-	var XDEBUG_LIB_SOURCES="usefulstuff.c compat.c crc32.c hash.c headers.c lib.c llist.c set.c str.c var.c var_export_html.c var_export_line.c var_export_serialized.c var_export_text.c var_export_xml.c xml.c"
+	var XDEBUG_LIB_SOURCES="usefulstuff.c compat.c crc32.c hash.c headers.c lib.c llist.c set.c str.c timing.c var.c var_export_html.c var_export_line.c var_export_serialized.c var_export_text.c var_export_xml.c xml.c"
 
 	var XDEBUG_COVERAGE_SOURCES="branch_info.c code_coverage.c"
 	var XDEBUG_DEBUGGER_SOURCES="com.c debugger.c handler_dbgp.c handlers.c"

--- a/package.xml
+++ b/package.xml
@@ -105,6 +105,8 @@ Thu, Jul 25, 2019 - xdebug 2.8.0beta1
      <file name="set.h" role="src" />
      <file name="str.c" role="src" />
      <file name="str.h" role="src" />
+     <file name="timing.c" role="src" />
+     <file name="timing.h" role="src" />
      <file name="var.c" role="src" />
      <file name="var.h" role="src" />
      <file name="var_export_html.c" role="src" />

--- a/php_xdebug.h
+++ b/php_xdebug.h
@@ -77,7 +77,7 @@ int xdebug_is_output_tty();
 struct xdebug_base_info {
 	unsigned long level;
 	xdebug_llist *stack;
-	xdebug_nanotime_init nanotime_init;
+	xdebug_nanotime_context nanotime_context;
 	double        start_time;
 	unsigned int  prev_memory;
 	zif_handler   orig_set_time_limit_func;
@@ -104,7 +104,7 @@ struct xdebug_base_info {
 	xdebug_llist *filters_code_coverage;
 
 	struct {
-		zend_long max_nesting_level;
+		zend_long     max_nesting_level;
 	} settings;
 };
 

--- a/php_xdebug.h
+++ b/php_xdebug.h
@@ -44,8 +44,6 @@
 extern zend_module_entry xdebug_module_entry;
 #define phpext_xdebug_ptr &xdebug_module_entry
 
-#define MICRO_IN_SEC 1000000.00
-
 #define OUTPUT_NOT_CHECKED -1
 #define OUTPUT_IS_TTY       1
 #define OUTPUT_NOT_TTY      0

--- a/php_xdebug.h
+++ b/php_xdebug.h
@@ -76,6 +76,11 @@ int xdebug_is_output_tty();
 struct xdebug_base_info {
 	unsigned long level;
 	xdebug_llist *stack;
+	uint64_t nanotime_start_abs;
+	uint64_t nanotime_start_rel;
+#if PHP_WIN32
+	uint64_t nanotime_win_freq;
+#endif
 	double        start_time;
 	unsigned int  prev_memory;
 	zif_handler   orig_set_time_limit_func;
@@ -102,7 +107,7 @@ struct xdebug_base_info {
 	xdebug_llist *filters_code_coverage;
 
 	struct {
-		zend_long     max_nesting_level;
+		zend_long max_nesting_level;
 	} settings;
 };
 

--- a/php_xdebug.h
+++ b/php_xdebug.h
@@ -40,6 +40,7 @@
 #include "lib/compat.h"
 #include "lib/hash.h"
 #include "lib/llist.h"
+#include "lib/timing.h"
 
 extern zend_module_entry xdebug_module_entry;
 #define phpext_xdebug_ptr &xdebug_module_entry
@@ -76,11 +77,7 @@ int xdebug_is_output_tty();
 struct xdebug_base_info {
 	unsigned long level;
 	xdebug_llist *stack;
-	uint64_t nanotime_start_abs;
-	uint64_t nanotime_start_rel;
-#if PHP_WIN32
-	uint64_t nanotime_win_freq;
-#endif
+	xdebug_nanotime_init nanotime_init;
 	double        start_time;
 	unsigned int  prev_memory;
 	zif_handler   orig_set_time_limit_func;

--- a/src/base/base.c
+++ b/src/base/base.c
@@ -896,6 +896,7 @@ void xdebug_base_minit(INIT_FUNC_ARGS)
 	xdebug_old_execute_internal = zend_execute_internal;
 	zend_execute_internal = xdebug_execute_internal;
 
+	XG_BASE(nanotime_init) = xdebug_get_nanotime_init();
 	XG_BASE(error_reporting_override) = 0;
 	XG_BASE(error_reporting_overridden) = 0;
 	XG_BASE(output_is_tty) = OUTPUT_NOT_CHECKED;
@@ -938,11 +939,6 @@ void xdebug_base_rinit()
 	XG_BASE(last_exception_trace) = NULL;
 
 	/* Initialize start time */
-	XG_BASE(nanotime_start_abs) = xdebug_get_nanotime_abs_internal();
-	XG_BASE(nanotime_start_rel) = xdebug_get_nanotime_rel_internal();
-#if PHP_WIN32
-	XG_BASE(nanotime_win_freq)  = xdebug_get_nanotime_win_freq_internal();
-#endif
 	XG_BASE(start_time) = xdebug_get_utime();
 
 	XG_BASE(in_var_serialisation) = 0;

--- a/src/base/base.c
+++ b/src/base/base.c
@@ -896,7 +896,7 @@ void xdebug_base_minit(INIT_FUNC_ARGS)
 	xdebug_old_execute_internal = zend_execute_internal;
 	zend_execute_internal = xdebug_execute_internal;
 
-	XG_BASE(nanotime_context) = xdebug_nanotime_init();
+	xdebug_nanotime_init();
 	XG_BASE(error_reporting_override) = 0;
 	XG_BASE(error_reporting_overridden) = 0;
 	XG_BASE(output_is_tty) = OUTPUT_NOT_CHECKED;

--- a/src/base/base.c
+++ b/src/base/base.c
@@ -938,6 +938,11 @@ void xdebug_base_rinit()
 	XG_BASE(last_exception_trace) = NULL;
 
 	/* Initialize start time */
+	XG_BASE(nanotime_start_abs) = xdebug_get_nanotime_abs_internal();
+	XG_BASE(nanotime_start_rel) = xdebug_get_nanotime_rel_internal();
+#if PHP_WIN32
+	XG_BASE(nanotime_win_freq)  = xdebug_get_nanotime_win_freq_internal();
+#endif
 	XG_BASE(start_time) = xdebug_get_utime();
 
 	XG_BASE(in_var_serialisation) = 0;

--- a/src/base/base.c
+++ b/src/base/base.c
@@ -896,7 +896,7 @@ void xdebug_base_minit(INIT_FUNC_ARGS)
 	xdebug_old_execute_internal = zend_execute_internal;
 	zend_execute_internal = xdebug_execute_internal;
 
-	XG_BASE(nanotime_init) = xdebug_get_nanotime_init();
+	XG_BASE(nanotime_context) = xdebug_nanotime_init();
 	XG_BASE(error_reporting_override) = 0;
 	XG_BASE(error_reporting_overridden) = 0;
 	XG_BASE(output_is_tty) = OUTPUT_NOT_CHECKED;

--- a/src/lib/lib.h
+++ b/src/lib/lib.h
@@ -27,8 +27,6 @@
 #include "zend_API.h"
 #include "compat.h"
 
-#define XDEBUG_NANOS_IN_SEC 1000000000
-
 typedef struct xdebug_var_name {
 	zend_string *name;
 	zval         data;

--- a/src/lib/lib.h
+++ b/src/lib/lib.h
@@ -27,8 +27,7 @@
 #include "zend_API.h"
 #include "compat.h"
 
-#define XDEBUG_MICRO_IN_SEC 1000000 // 1e6, must be integer
-#define XDEBUG_NANO_IN_SEC 1000000000 // 1e9, must be integer
+#define XDEBUG_NANOS_IN_SEC 1000000000
 
 typedef struct xdebug_var_name {
 	zend_string *name;

--- a/src/lib/lib.h
+++ b/src/lib/lib.h
@@ -27,7 +27,8 @@
 #include "zend_API.h"
 #include "compat.h"
 
-#define MICRO_IN_SEC 1000000.00
+#define XDEBUG_MICRO_IN_SEC 1000000 // 1e6, must be integer
+#define XDEBUG_NANO_IN_SEC 1000000000 // 1e9, must be integer
 
 typedef struct xdebug_var_name {
 	zend_string *name;

--- a/src/lib/lib_private.h
+++ b/src/lib/lib_private.h
@@ -24,4 +24,6 @@
 #define XG_LIB(v)      (XG(globals.library.v))
 #define XINI_LIB(v)    (XG(settings.library.v))
 
+#define NANOS_IN_MICROSEC 1000
+
 #endif

--- a/src/lib/timing.c
+++ b/src/lib/timing.c
@@ -140,15 +140,32 @@ double xdebug_get_utime(void)
 	return xdebug_get_nanotime() / (double)NANOS_IN_SEC;
 }
 
+char* xdebug_nanotime_to_chars(uint64_t nanotime, unsigned char precision)
+{
+	char *res;
+	time_t secs;
+	unsigned char i;
+
+	secs = (time_t)(nanotime / NANOS_IN_SEC);
+	if (precision > 0) {
+		res = xdmalloc(30);
+	} else {
+		res = xdmalloc(20);
+	}
+	strftime(res, 20, "%Y-%m-%d %H:%M:%S", gmtime(&secs));
+	if (precision > 0) {
+		sprintf(res + 19, ".%09u", (uint32_t)(nanotime % NANOS_IN_SEC));
+		if (precision < 9) {
+			*(res + 20 + precision) = '\0';
+		}
+	}
+	return res;
+}
+
 char* xdebug_get_time(void)
 {
 	uint64_t nanotime;
-	time_t time_secs;
-	char  *res;
-
+	
 	nanotime = xdebug_get_nanotime_abs(XG_BASE(nanotime_init));
-	time_secs = (time_t)(nanotime / NANOS_IN_SEC);
-	res = xdmalloc(24);
-	strftime(res, 24, "%Y-%m-%d %H:%M:%S", gmtime(&time_secs));
-	return res;
+	return xdebug_nanotime_to_chars(nanotime, 0);
 }

--- a/src/lib/timing.c
+++ b/src/lib/timing.c
@@ -62,21 +62,23 @@ static uint64_t xdebug_get_nanotime_abs(xdebug_nanotime_init nanotime_init)
 	return 0;
 }
 
-static uint64_t xdebug_counter_and_freq_to_nanotime(uint64_t counter, uint64_t freq)
-{
-	uint32_t mul = 1, freq32;
-	uint64_t q, r;
+#if PHP_WIN32
+	static uint64_t xdebug_counter_and_freq_to_nanotime(uint64_t counter, uint64_t freq)
+	{
+		uint32_t mul = 1, freq32;
+		uint64_t q, r;
 
-	while (freq >= (1ULL << 32)) {
-		freq /= 2;
-		mul *= 2;
+		while (freq >= (1ULL << 32)) {
+			freq /= 2;
+			mul *= 2;
+		}
+		freq32 = (uint32_t)freq;
+
+		q = counter / freq32;
+		r = counter % freq32;
+		return (q * NANOS_IN_SEC + (r * NANOS_IN_SEC) / freq32) * mul;
 	}
-	freq32 = (uint32_t)freq;
-
-	q = counter / freq32;
-	r = counter % freq32;
-	return (q * NANOS_IN_SEC + (r * NANOS_IN_SEC) / freq32) * mul;
-}
+#endif
 
 static uint64_t xdebug_get_nanotime_rel(xdebug_nanotime_init nanotime_init)
 {

--- a/src/lib/timing.c
+++ b/src/lib/timing.c
@@ -164,7 +164,7 @@ char* xdebug_nanotime_to_chars(uint64_t nanotime, unsigned char precision)
 char* xdebug_get_time(void)
 {
 	uint64_t nanotime;
-	
+
 	nanotime = xdebug_get_nanotime_abs(XG_BASE(nanotime_init));
 	return xdebug_nanotime_to_chars(nanotime, 0);
 }

--- a/src/lib/timing.c
+++ b/src/lib/timing.c
@@ -1,0 +1,125 @@
+/*
+   +----------------------------------------------------------------------+
+   | Xdebug                                                               |
+   +----------------------------------------------------------------------+
+   | Copyright (c) 2002-2020 Derick Rethans                               |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 1.01 of the Xdebug license,   |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available at through the world-wide-web at                           |
+   | https://xdebug.org/license.php                                       |
+   | If you did not receive a copy of the Xdebug license and are unable   |
+   | to obtain it through the world-wide-web, please send a note to       |
+   | derick@xdebug.org so we can mail you a copy immediately.             |
+   +----------------------------------------------------------------------+
+   | Authors: Derick Rethans <derick@xdebug.org>                          |
+   |          Michael Voříšek <mvorisek@mvorisek.cz>                      |
+   +----------------------------------------------------------------------+
+ */
+
+#include "php_xdebug.h"
+#if PHP_WIN32
+	#include "win32/time.h"
+	// for MFllMulDiv()
+	#include <mfapi.h>
+	#pragma comment(lib, "mfplat.lib")
+#else
+	#include <sys/time.h>
+#endif
+#ifdef __APPLE__
+	#include <mach/mach_time.h>
+#endif
+
+#include "timing.h"
+
+ZEND_EXTERN_MODULE_GLOBALS(xdebug)
+
+static uint64_t xdebug_get_nanotime_abs(void)
+{
+	#ifdef HAVE_GETTIMEOFDAY
+		struct timeval tp;
+
+		if (gettimeofday(&tp, NULL) == 0) {
+			return (uint64_t)tp.tv_sec * NANOS_IN_SEC + (uint64_t)tp.tv_usec * NANOS_IN_MICROSEC;
+		}
+	#endif
+
+	return 0;
+}
+
+static uint64_t xdebug_get_nanotime_rel(xdebug_nanotime_init nanotime_init)
+{
+	#ifdef _SC_MONOTONIC_CLOCK
+		struct timespec ts;
+	#elif PHP_WIN32
+		LARGE_INTEGER tcounter;
+	#endif
+
+	// Linux/Unix
+	#ifdef _SC_MONOTONIC_CLOCK
+		if (clock_gettime(CLOCK_MONOTONIC, &ts) == 0) {
+			return (uint64_t)ts.tv_sec * NANOS_IN_SEC + (uint64_t)ts.tv_nsec;
+		}
+
+		return 0;
+	#endif
+
+	// Windows
+	#if PHP_WIN32
+		QueryPerformanceCounter(&tcounter);
+		return (uint64_t)MFllMulDiv(
+			tcounter.QuadPart,
+			NANOS_IN_SEC,
+			nanotime_init.win_freq,
+			(nanotime_init.win_freq / 2)
+		);
+	#endif
+
+	// Mac
+	#ifdef __APPLE__
+		return = clock_gettime_nsec_np(CLOCK_UPTIME_RAW);
+	#endif
+
+	// fallback if better platform specific relative time library is not available
+	return xdebug_get_nanotime_abs();
+}
+
+uint64_t xdebug_get_nanotime(void)
+{
+	return XG_BASE(nanotime_init).start_abs + (xdebug_get_nanotime_rel(XG_BASE(nanotime_init)) - XG_BASE(nanotime_init).start_rel);
+}
+
+xdebug_nanotime_init xdebug_get_nanotime_init(void)
+{
+	xdebug_nanotime_init res;
+	#if PHP_WIN32
+		LARGE_INTEGER tcounter;
+	#endif
+
+	res.start_abs = xdebug_get_nanotime_abs();
+	#if PHP_WIN32
+		QueryPerformanceFrequency(&tcounter);
+		res.win_freq = (uint64_t)tcounter.QuadPart;
+	#endif
+	res.start_rel = xdebug_get_nanotime_rel(res);
+
+	return res;
+}
+
+double xdebug_get_utime(void)
+{
+	return xdebug_get_nanotime() / (double)NANOS_IN_SEC;
+}
+
+char* xdebug_get_time(void)
+{
+	uint64_t nanotime;
+	time_t time_secs;
+	char  *res;
+
+	nanotime = xdebug_get_nanotime_abs();
+	time_secs = (time_t)(nanotime / NANOS_IN_SEC);
+	res = xdmalloc(24);
+	strftime(res, 24, "%Y-%m-%d %H:%M:%S", gmtime(&time_secs));
+	return res;
+}

--- a/src/lib/timing.h
+++ b/src/lib/timing.h
@@ -23,12 +23,17 @@
 #define NANOS_IN_SEC 1000000000
 #define NANOS_IN_MICROSEC 1000
 
+#if PHP_WIN32
+	typedef void (WINAPI *WIN_PRECISE_TIME_FUNC)(LPFILETIME);
+#endif
+
 typedef struct _xdebug_nanotime_init {
 	uint64_t start_abs;
-#if PHP_WIN32
-	uint64_t win_freq;
-#endif
 	uint64_t start_rel;
+	#if PHP_WIN32
+		WIN_PRECISE_TIME_FUNC win_precise_time_func;
+		uint64_t win_freq;
+	#endif
 } xdebug_nanotime_init;
 
 uint64_t xdebug_get_nanotime(void);

--- a/src/lib/timing.h
+++ b/src/lib/timing.h
@@ -38,7 +38,7 @@ typedef struct _xdebug_nanotime_context {
 #endif
 } xdebug_nanotime_context;
 
-xdebug_nanotime_context xdebug_nanotime_init(void);
+void xdebug_nanotime_init(void);
 
 uint64_t xdebug_get_nanotime(void);
 double xdebug_get_utime(void);

--- a/src/lib/timing.h
+++ b/src/lib/timing.h
@@ -39,6 +39,7 @@ typedef struct _xdebug_nanotime_init {
 uint64_t xdebug_get_nanotime(void);
 xdebug_nanotime_init xdebug_get_nanotime_init(void);
 double xdebug_get_utime(void);
+char* xdebug_nanotime_to_chars(uint64_t nanotime, unsigned char precision);
 char* xdebug_get_time(void);
 
 #endif

--- a/src/lib/timing.h
+++ b/src/lib/timing.h
@@ -20,28 +20,30 @@
 #ifndef __XDEBUG_TIMING_H__
 #define __XDEBUG_TIMING_H__
 
-#define NANOS_IN_SEC 1000000000
+#define NANOS_IN_SEC      1000000000
 #define NANOS_IN_MICROSEC 1000
 
 #if PHP_WIN32
-	typedef void (WINAPI *WIN_PRECISE_TIME_FUNC)(LPFILETIME);
+typedef void (WINAPI *WIN_PRECISE_TIME_FUNC)(LPFILETIME);
 #endif
 
-typedef struct _xdebug_nanotime_init {
+typedef struct _xdebug_nanotime_context {
 	uint64_t start_abs;
 	uint64_t start_rel;
 	uint64_t last_abs;
 	uint64_t last_rel;
-	#if PHP_WIN32
-		WIN_PRECISE_TIME_FUNC win_precise_time_func;
-		uint64_t win_freq;
-	#endif
-} xdebug_nanotime_init;
+#if PHP_WIN32
+	WIN_PRECISE_TIME_FUNC win_precise_time_func;
+	uint64_t win_freq;
+#endif
+} xdebug_nanotime_context;
+
+xdebug_nanotime_context xdebug_nanotime_init(void);
 
 uint64_t xdebug_get_nanotime(void);
-xdebug_nanotime_init xdebug_get_nanotime_init(void);
 double xdebug_get_utime(void);
-char* xdebug_nanotime_to_chars(uint64_t nanotime, unsigned char precision);
 char* xdebug_get_time(void);
+
+char* xdebug_nanotime_to_chars(uint64_t nanotime, unsigned char precision);
 
 #endif

--- a/src/lib/timing.h
+++ b/src/lib/timing.h
@@ -13,15 +13,27 @@
    | derick@xdebug.org so we can mail you a copy immediately.             |
    +----------------------------------------------------------------------+
    | Authors: Derick Rethans <derick@xdebug.org>                          |
+   |          Michael Voříšek <mvorisek@mvorisek.cz>                      |
    +----------------------------------------------------------------------+
  */
 
-#ifndef __XDEBUG_LIBRARY_PRIVATE_H__
-#define __XDEBUG_LIBRARY_PRIVATE_H__
+#ifndef __XDEBUG_TIMING_H__
+#define __XDEBUG_TIMING_H__
 
-#include "lib.h"
+#define NANOS_IN_SEC 1000000000
+#define NANOS_IN_MICROSEC 1000
 
-#define XG_LIB(v)      (XG(globals.library.v))
-#define XINI_LIB(v)    (XG(settings.library.v))
+typedef struct _xdebug_nanotime_init {
+	uint64_t start_abs;
+#if PHP_WIN32
+	uint64_t win_freq;
+#endif
+	uint64_t start_rel;
+} xdebug_nanotime_init;
+
+uint64_t xdebug_get_nanotime(void);
+xdebug_nanotime_init xdebug_get_nanotime_init(void);
+double xdebug_get_utime(void);
+char* xdebug_get_time(void);
 
 #endif

--- a/src/lib/timing.h
+++ b/src/lib/timing.h
@@ -34,6 +34,7 @@ typedef struct _xdebug_nanotime_init {
 	uint64_t last_rel;
 	#if PHP_WIN32
 		WIN_PRECISE_TIME_FUNC win_precise_time_func;
+		uint64_t win_freq;
 	#endif
 } xdebug_nanotime_init;
 

--- a/src/lib/timing.h
+++ b/src/lib/timing.h
@@ -30,9 +30,10 @@
 typedef struct _xdebug_nanotime_init {
 	uint64_t start_abs;
 	uint64_t start_rel;
+	uint64_t last_abs;
+	uint64_t last_rel;
 	#if PHP_WIN32
 		WIN_PRECISE_TIME_FUNC win_precise_time_func;
-		uint64_t win_freq;
 	#endif
 } xdebug_nanotime_init;
 

--- a/src/lib/usefulstuff.c
+++ b/src/lib/usefulstuff.c
@@ -148,16 +148,16 @@ double xdebug_get_utime(void)
 #ifdef HAVE_GETTIMEOFDAY
 	struct timeval tp;
 	long sec = 0L;
-	double msec = 0.0;
+	double secf = 0.0;
 
 	if (gettimeofday((struct timeval *) &tp, NULL) == 0) {
 		sec = tp.tv_sec;
-		msec = (double) (tp.tv_usec / MICRO_IN_SEC);
+		secf = (double) (tp.tv_usec / MICRO_IN_SEC);
 
-		if (msec >= 1.0) {
-			msec -= (long) msec;
+		if (secf >= 1.0) {
+			secf -= (long) secf;
 		}
-		return msec + sec;
+		return sec + secf;
 	}
 #endif
 	return 0;

--- a/src/lib/usefulstuff.c
+++ b/src/lib/usefulstuff.c
@@ -32,6 +32,9 @@
 #include "win32/time.h"
 #include <process.h>
 #endif
+#ifdef __APPLE__
+#include <mach/mach_time.h>
+#endif
 #include "php_xdebug.h"
 
 #include "mm.h"
@@ -143,35 +146,132 @@ char* xdebug_strrstr(const char* haystack, const char* needle)
 	return loc;
 }
 
+// this function is intended to be removed once this PR is complete
 double xdebug_get_utime(void)
 {
+    return xdebug_nanotime_to_ts(xdebug_get_nanotime());
+}
+
+// do not export this function, only for xdebug_get_nanotime()
+uint64_t xdebug_get_nanotime_abs_internal(void)
+{
+    uint64_t nanotime_abs;
 #ifdef HAVE_GETTIMEOFDAY
-	struct timeval tp;
-	long sec = 0L;
-	double secf = 0.0;
-
-	if (gettimeofday((struct timeval *) &tp, NULL) == 0) {
-		sec = tp.tv_sec;
-		secf = (double) (tp.tv_usec / MICRO_IN_SEC);
-
-		if (secf >= 1.0) {
-			secf -= (long) secf;
-		}
-		return sec + secf;
-	}
+    struct timeval tp;
 #endif
-	return 0;
+
+    // gettimeofday() is defined almost on every platform usually with microsecond local precision
+#ifdef HAVE_GETTIMEOFDAY
+    if (gettimeofday(&tp, NULL) == 0) {
+        nanotime_abs = (uint64_t)tp.tv_sec * XDEBUG_NANO_IN_SEC + (uint64_t)tp.tv_usec * 1000; // 1000 us in ns
+
+        return nanotime_abs;
+    }
+#endif
+
+    nanotime_abs = 0;
+
+    return nanotime_abs;
+}
+
+static uint64_t xdebug_get_nanotime_first_rel = 2;
+static uint64_t xdebug_get_nanotime_first_abs = 2;
+#if PHP_WIN32
+static uint64_t xdebug_get_nanotime_win_freq = 2;
+#endif
+
+uint64_t xdebug_get_nanotime(void)
+{
+    uint64_t nanotime_rel;
+#ifdef _SC_MONOTONIC_CLOCK
+    struct timespec ts;
+#endif
+#if PHP_WIN32
+    LARGE_INTEGER tcounter;
+#endif
+
+    // 1. query absolute time with at least microsecond local precision
+    // only once and store it
+    if (xdebug_get_nanotime_first_abs == 2) {
+        xdebug_get_nanotime_first_abs = xdebug_get_nanotime_abs_internal();
+        if (xdebug_get_nanotime_first_abs == 2) {
+            // code should be never reached
+            // make sure it is never called twice
+            xdebug_get_nanotime_first_abs = 0;
+        }
+    }
+
+    // 2. query relative/monotonic time with good precision (<100 ns) and reasonable query speed (<30 ns)
+
+    // Linux/Unix
+#ifdef _SC_MONOTONIC_CLOCK
+    if (clock_gettime(CLOCK_MONOTONIC, &ts) == 0) {
+        nanotime_rel = (uint64_t)ts.tv_sec * XDEBUG_NANO_IN_SEC + (uint64_t)ts.tv_nsec;
+
+        goto xdebug_get_nanotime_end;
+    }
+#endif
+
+    // Windows
+#if PHP_WIN32
+    if (xdebug_get_nanotime_win_freq == 2) {
+        QueryPerformanceFrequency(&tcounter);
+        xdebug_get_nanotime_win_freq = (uint64_t)tcounter.QuadPart;
+        if (xdebug_get_nanotime_win_freq == 2) {
+            // code should be never reached
+            // make sure it is never called twice
+            xdebug_get_nanotime_win_freq = 1;
+        }
+    }
+
+    QueryPerformanceCounter(&tcounter);
+    nanotime_rel = (uint64_t)tcounter.QuadPart * (XDEBUG_NANO_IN_SEC / xdebug_get_nanotime_win_freq);
+
+    goto xdebug_get_nanotime_end;
+#endif
+
+    // Mac
+#ifdef __APPLE__
+    nanotime_rel = clock_gettime_nsec_np(CLOCK_UPTIME_RAW);
+
+    goto xdebug_get_nanotime_end;
+#endif
+
+    // fallback if better platform specific relative time library is not available
+    nanotime_rel = xdebug_get_nanotime_abs_internal();
+
+xdebug_get_nanotime_end:
+
+    if (xdebug_get_nanotime_first_rel == 2) {
+        xdebug_get_nanotime_first_rel = nanotime_rel;
+        if (xdebug_get_nanotime_first_rel == 2) {
+            // code should be never reached
+            // make sure it is never called twice
+            xdebug_get_nanotime_first_rel = 0;
+        }
+    }
+
+    return (nanotime_rel - xdebug_get_nanotime_first_rel) + xdebug_get_nanotime_first_abs;
+}
+
+// result may be inaccurate because large value (seconds since epoch stored)
+// stored as double has limited resolution of about 1 microsecond
+double xdebug_nanotime_to_ts(uint64_t nanotime)
+{
+    return nanotime / (double)XDEBUG_NANO_IN_SEC;
 }
 
 char* xdebug_get_time(void)
 {
-	time_t cur_time;
-	char  *str_time;
+    uint64_t nanotime;
+    time_t time_secs;
+	char  *res;
 
-	str_time = xdmalloc(24);
-	cur_time = time(NULL);
-	strftime(str_time, 24, "%Y-%m-%d %H:%M:%S", gmtime (&cur_time));
-	return str_time;
+    nanotime = xdebug_get_nanotime_abs_internal();
+    time_secs = (time_t)(nanotime / XDEBUG_NANO_IN_SEC);
+    res = xdmalloc(24);
+	strftime(res, 24, "%Y-%m-%d %H:%M:%S", gmtime(&time_secs));
+	return res;
 }
 
 /* not all versions of php export this */

--- a/src/lib/usefulstuff.h
+++ b/src/lib/usefulstuff.h
@@ -44,9 +44,11 @@ xdebug_str* xdebug_join(const char *delim, xdebug_arg *args, int begin, int end)
 void xdebug_explode(const char *delim, const char *str, xdebug_arg *args, int limit);
 const char* xdebug_memnstr(const char *haystack, const char *needle, int needle_len, const char *end);
 char* xdebug_strrstr(const char* haystack, const char* needle);
-double xdebug_get_utime(void); // this function is intended to be removed once this PR is complete
+uint64_t xdebug_get_nanotime_abs_internal(void);      // fix before merge: move to timing.c, never export, should be called only once per request in rinit
+uint64_t xdebug_get_nanotime_rel_internal(void);      // fix before merge: move to timing.c, never export
+uint64_t xdebug_get_nanotime_win_freq_internal(void); // fix before merge: move to timing.c, never export, should be called only once in request in rinit
 uint64_t xdebug_get_nanotime(void);
-double xdebug_nanotime_to_ts(uint64_t nanotime);
+double xdebug_get_utime(void);
 char* xdebug_get_time(void);
 char *xdebug_path_to_url(zend_string *fileurl);
 char *xdebug_path_from_url(zend_string *fileurl);

--- a/src/lib/usefulstuff.h
+++ b/src/lib/usefulstuff.h
@@ -44,7 +44,9 @@ xdebug_str* xdebug_join(const char *delim, xdebug_arg *args, int begin, int end)
 void xdebug_explode(const char *delim, const char *str, xdebug_arg *args, int limit);
 const char* xdebug_memnstr(const char *haystack, const char *needle, int needle_len, const char *end);
 char* xdebug_strrstr(const char* haystack, const char* needle);
-double xdebug_get_utime(void);
+double xdebug_get_utime(void); // this function is intended to be removed once this PR is complete
+uint64_t xdebug_get_nanotime(void);
+double xdebug_nanotime_to_ts(uint64_t nanotime);
 char* xdebug_get_time(void);
 char *xdebug_path_to_url(zend_string *fileurl);
 char *xdebug_path_from_url(zend_string *fileurl);

--- a/src/lib/usefulstuff.h
+++ b/src/lib/usefulstuff.h
@@ -44,12 +44,6 @@ xdebug_str* xdebug_join(const char *delim, xdebug_arg *args, int begin, int end)
 void xdebug_explode(const char *delim, const char *str, xdebug_arg *args, int limit);
 const char* xdebug_memnstr(const char *haystack, const char *needle, int needle_len, const char *end);
 char* xdebug_strrstr(const char* haystack, const char* needle);
-uint64_t xdebug_get_nanotime_abs_internal(void);      // fix before merge: move to timing.c, never export, should be called only once per request in rinit
-uint64_t xdebug_get_nanotime_rel_internal(void);      // fix before merge: move to timing.c, never export
-uint64_t xdebug_get_nanotime_win_freq_internal(void); // fix before merge: move to timing.c, never export, should be called only once in request in rinit
-uint64_t xdebug_get_nanotime(void);
-double xdebug_get_utime(void);
-char* xdebug_get_time(void);
 char *xdebug_path_to_url(zend_string *fileurl);
 char *xdebug_path_from_url(zend_string *fileurl);
 FILE *xdebug_fopen(char *fname, const char *mode, const char *extension, char **new_fname);


### PR DESCRIPTION
related with https://bugs.xdebug.org/view.php?id=1820

draft for now, these questions must be cleared first:

- [x] bacause of limited double precision, is it ok to capture/save time always relative to the script (first get time call)? Should the time function stay named like `xdebug_get_utime()` or should we rename it to `xdebug_get_nanotime()` to make sure noone uses it like before/eopch time?
- [x] `gettimeofday` is inaccurate, ok to replace with https://stackoverflow.com/questions/361363/how-to-measure-time-in-milliseconds-using-ansi-c#37920181 , ie. multiple solutions for different platforms - which one - linux, Windows and other?