### PR TITLE
Use latest available revision for AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -26,91 +26,91 @@ cache:
 environment:
     BIN_SDK_VER: 2.2.0
     matrix:
-        - PHP_VER: 8.0.0alpha1
+        - PHP_VER: 8.0
           ARCH: x64
           TS: 1
           VC: vs16
           OPCACHE: yes
           APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-        - PHP_VER: 7.4.0
+        - PHP_VER: 7.4
           ARCH: x64
           TS: 1
           VC: vc15
           OPCACHE: yes
           APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-        - PHP_VER: 7.4.0
+        - PHP_VER: 7.4
           ARCH: x64
           TS: 0
           VC: vc15
           OPCACHE: yes
           APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-        - PHP_VER: 7.4.0
+        - PHP_VER: 7.4
           ARCH: x64
           TS: 1
           VC: vc15
           OPCACHE: no
           APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-        - PHP_VER: 7.4.0
+        - PHP_VER: 7.4
           ARCH: x64
           TS: 0
           VC: vc15
           OPCACHE: no
           APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-        - PHP_VER: 7.4.0
+        - PHP_VER: 7.4
           ARCH: x86
           TS: 1
           VC: vc15
           OPCACHE: no
           APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-        - PHP_VER: 7.4.0
+        - PHP_VER: 7.4
           ARCH: x86
           TS: 0
           VC: vc15
           OPCACHE: yes
           APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-        - PHP_VER: 7.3.13
+        - PHP_VER: 7.3
           ARCH: x64
           TS: 1
           VC: vc15
           OPCACHE: yes
           APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-        - PHP_VER: 7.3.13
+        - PHP_VER: 7.3
           ARCH: x64
           TS: 0
           VC: vc15
           OPCACHE: no
           APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-        - PHP_VER: 7.3.13
+        - PHP_VER: 7.3
           ARCH: x86
           TS: 1
           VC: vc15
           OPCACHE: no
           APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-        - PHP_VER: 7.3.13
+        - PHP_VER: 7.3
           ARCH: x86
           TS: 0
           VC: vc15
           OPCACHE: yes
           APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-        - PHP_VER: 7.2.26
+        - PHP_VER: 7.2
           ARCH: x64
           TS: 1
           VC: vc15
           OPCACHE: yes
           APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-        - PHP_VER: 7.2.26
+        - PHP_VER: 7.2
           ARCH: x64
           TS: 0
           VC: vc15
           OPCACHE: no
           APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-        - PHP_VER: 7.2.26
+        - PHP_VER: 7.2
           ARCH: x86
           TS: 1
           VC: vc15
           OPCACHE: no
           APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-        - PHP_VER: 7.2.26
+        - PHP_VER: 7.2
           ARCH: x86
           TS: 0
           VC: vc15
@@ -120,26 +120,29 @@ environment:
 build_script:
     ps: |
         $ErrorActionPreference = "Stop"
+        $gareleases = Invoke-WebRequest https://windows.php.net/downloads/releases/releases.json | ConvertFrom-Json
+        $qareleases = Invoke-WebRequest https://windows.php.net/downloads/qa/releases.json | ConvertFrom-Json
+        $garev = [regex]::split($gareleases.$env:PHP_VER.version, '[^\d]')[2]
+        $qarev = [regex]::split($qareleases.$env:PHP_VER.version, '[^\d]')[2]
+        if ($qarev -gt $garev) {
+            $env:PHP_VERSION = $qareleases.$env:PHP_VER.version
+            $env:PHP_RELEASE = 'QA'
+        } else {
+            $env:PHP_VERSION = $gareleases.$env:PHP_VER.version
+            $env:PHP_RELEASE = 'GA'
+        }
         $ts_part = ''
         if ('0' -eq $env:TS) { $ts_part = '-nts' }
-        $bname = 'php-devel-pack-' + $env:PHP_VER + $ts_part + '-Win32-' + $env:VC.toUpper() + '-' + $env:ARCH + '.zip'
+        $bname = 'php-devel-pack-' + $env:PHP_VERSION + $ts_part + '-Win32-' + $env:VC.toUpper() + '-' + $env:ARCH + '.zip'
         if (-not (Test-Path c:\build-cache\$bname)) {
-            try {
-                Invoke-WebRequest "http://windows.php.net/downloads/releases/archives/$bname" -OutFile "c:\build-cache\$bname"
-            } catch [System.Net.WebException] {
-                try {
-                    Invoke-WebRequest "http://windows.php.net/downloads/releases/$bname" -OutFile "c:\build-cache\$bname"
-                } catch [System.Net.WebException] {
-                    try {
-                        Invoke-WebRequest "https://windows.php.net/downloads/qa/archives/$bname" -OutFile "c:\build-cache\$bname"
-                    } catch [System.Net.WebException] {
-                        Invoke-WebRequest "https://windows.php.net/downloads/qa/$bname" -OutFile "c:\build-cache\$bname"
-                    }
-                }
+            if ($env:PHP_RELEASE -eq 'GA') {
+                Invoke-WebRequest "http://windows.php.net/downloads/releases/$bname" -OutFile "c:\build-cache\$bname"
+            } else {
+                Invoke-WebRequest "https://windows.php.net/downloads/qa/$bname" -OutFile "c:\build-cache\$bname"
             }
         }
-        $dname0 = 'php-' + $env:PHP_VER + '-devel-' + $env:VC.toUpper() + '-' + $env:ARCH
-        $dname1 = 'php-' + $env:PHP_VER + $ts_part + '-devel-' + $env:VC.toUpper() + '-' + $env:ARCH
+        $dname0 = 'php-' + $env:PHP_VERSION + '-devel-' + $env:VC.toUpper() + '-' + $env:ARCH
+        $dname1 = 'php-' + $env:PHP_VERSION + $ts_part + '-devel-' + $env:VC.toUpper() + '-' + $env:ARCH
         if (-not (Test-Path c:\build-cache\$dname1)) {
             7z x c:\build-cache\$bname -oc:\build-cache
             if ($dname0 -ne $dname1) {
@@ -171,9 +174,9 @@ after_build:
         $arch_part = ''
         if ('x64' -eq $env:ARCH) { $arch_part = '-x86_64' }
         if ($env:APPVEYOR_REPO_TAG -eq "true") {
-            $bname = 'php_xdebug-' + $env:APPVEYOR_REPO_TAG_NAME + '-' + $env:PHP_VER.substring(0, 3) + '-' + $env:VC + $ts_part + $arch_part
+            $bname = 'php_xdebug-' + $env:APPVEYOR_REPO_TAG_NAME + '-' + $env:PHP_VER + '-' + $env:VC + $ts_part + $arch_part
         } else {
-            $bname = 'php_xdebug-' + $env:APPVEYOR_REPO_COMMIT.substring(0, 8) + '-' + $env:PHP_VER.substring(0, 3) + '-' + $env:VC + $ts_part + $arch_part
+            $bname = 'php_xdebug-' + $env:APPVEYOR_REPO_COMMIT.substring(0, 8) + '-' + $env:PHP_VER + '-' + $env:VC + $ts_part + $arch_part
         }
         $zip_bname = $bname + '.zip'
         $dll_bname = $bname + '.dll'
@@ -192,23 +195,15 @@ test_script:
         $ErrorActionPreference = "Stop"
         $ts_part = ''
         if ('0' -eq $env:TS) { $ts_part = '-nts' }
-        $bname = 'php-' + $env:PHP_VER + $ts_part + '-Win32-' + $env:VC.toUpper() + '-' + $env:ARCH + '.zip'
+        $bname = 'php-' + $env:PHP_VERSION + $ts_part + '-Win32-' + $env:VC.toUpper() + '-' + $env:ARCH + '.zip'
         if (-not (Test-Path c:\build-cache\$bname)) {
-            try {
-                Invoke-WebRequest "http://windows.php.net/downloads/releases/archives/$bname" -OutFile "c:\build-cache\$bname"
-            } catch [System.Net.WebException] {
-                try {
-                    Invoke-WebRequest "http://windows.php.net/downloads/releases/$bname" -OutFile "c:\build-cache\$bname"
-                } catch [System.Net.WebException] {
-                    try {
-                        Invoke-WebRequest "https://windows.php.net/downloads/qa/archives/$bname" -OutFile "c:\build-cache\$bname"
-                    } catch [System.Net.WebException] {
-                        Invoke-WebRequest "https://windows.php.net/downloads/qa/$bname" -OutFile "c:\build-cache\$bname"
-                    }
-                }
+            if ($env:PHP_RELEASE -eq 'GA') {
+                Invoke-WebRequest "http://windows.php.net/downloads/releases/$bname" -OutFile "c:\build-cache\$bname"
+            } else {
+                Invoke-WebRequest "https://windows.php.net/downloads/qa/$bname" -OutFile "c:\build-cache\$bname"
             }
         }
-        $dname = 'php-' + $env:PHP_VER + $ts_part + '-' + $env:VC.toUpper() + '-' + $env:ARCH
+        $dname = 'php-' + $env:PHP_VERSION + $ts_part + '-' + $env:VC.toUpper() + '-' + $env:ARCH
         if (-not (Test-Path c:\build-cache\$dname)) {
             7z x c:\build-cache\$bname -oc:\build-cache\$dname
         }


### PR DESCRIPTION
We do no longer specify the exact PHP version to build and test with,
but rather give the minor PHP version, and let the script figure out
its latest release (whether GA or QA).