### PR TITLE
Fixed issue #1820: Increase time tracing precision

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -79,7 +79,7 @@ if test "$PHP_XDEBUG" != "no"; then
   PHP_XDEBUG_CFLAGS="$STD_CFLAGS $MAINTAINER_CFLAGS"
 
   XDEBUG_BASE_SOURCES="src/base/base.c src/base/filter.c"
-  XDEBUG_LIB_SOURCES="src/lib/usefulstuff.c src/lib/compat.c src/lib/crc32.c src/lib/hash.c src/lib/headers.c src/lib/lib.c src/lib/llist.c src/lib/set.c src/lib/str.c src/lib/var.c src/lib/var_export_html.c src/lib/var_export_line.c src/lib/var_export_serialized.c src/lib/var_export_text.c src/lib/var_export_xml.c src/lib/xml.c"
+  XDEBUG_LIB_SOURCES="src/lib/usefulstuff.c src/lib/compat.c src/lib/crc32.c src/lib/hash.c src/lib/headers.c src/lib/lib.c src/lib/llist.c src/lib/set.c src/lib/str.c src/lib/timing.c src/lib/var.c src/lib/var_export_html.c src/lib/var_export_line.c src/lib/var_export_serialized.c src/lib/var_export_text.c src/lib/var_export_xml.c src/lib/xml.c"
 
   XDEBUG_COVERAGE_SOURCES="src/coverage/branch_info.c src/coverage/code_coverage.c"
   XDEBUG_DEBUGGER_SOURCES="src/debugger/com.c src/debugger/debugger.c src/debugger/handler_dbgp.c src/debugger/handlers.c"

--- a/config.m4
+++ b/config.m4
@@ -27,6 +27,7 @@ if test "$PHP_XDEBUG" != "no"; then
   CPPFLAGS="$INCLUDES $CPPFLAGS"
 
   AC_CHECK_FUNCS(gettimeofday)
+  AC_CHECK_FUNCS(clock_gettime)
   AC_CHECK_HEADERS([netinet/in.h poll.h sys/poll.h])
 
   PHP_CHECK_LIBRARY(m, cos, [ PHP_ADD_LIBRARY(m,, XDEBUG_SHARED_LIBADD) ])

--- a/config.w32
+++ b/config.w32
@@ -4,7 +4,7 @@ ARG_WITH("xdebug", "Xdebug support", "no");
 
 if (PHP_XDEBUG != 'no') {
 	var XDEBUG_BASE_SOURCES="base.c filter.c"
-	var XDEBUG_LIB_SOURCES="usefulstuff.c compat.c crc32.c hash.c headers.c lib.c llist.c set.c str.c var.c var_export_html.c var_export_line.c var_export_serialized.c var_export_text.c var_export_xml.c xml.c"
+	var XDEBUG_LIB_SOURCES="usefulstuff.c compat.c crc32.c hash.c headers.c lib.c llist.c set.c str.c timing.c var.c var_export_html.c var_export_line.c var_export_serialized.c var_export_text.c var_export_xml.c xml.c"
 
 	var XDEBUG_COVERAGE_SOURCES="branch_info.c code_coverage.c"
 	var XDEBUG_DEBUGGER_SOURCES="com.c debugger.c handler_dbgp.c handlers.c"

--- a/package.xml
+++ b/package.xml
@@ -105,6 +105,8 @@ Thu, Jul 25, 2019 - xdebug 2.8.0beta1
      <file name="set.h" role="src" />
      <file name="str.c" role="src" />
      <file name="str.h" role="src" />
+     <file name="timing.c" role="src" />
+     <file name="timing.h" role="src" />
      <file name="var.c" role="src" />
      <file name="var.h" role="src" />
      <file name="var_export_html.c" role="src" />

--- a/php_xdebug.h
+++ b/php_xdebug.h
@@ -41,11 +41,10 @@
 #include "lib/hash.h"
 #include "lib/llist.h"
 #include "lib/vector.h"
+#include "lib/timing.h"
 
 extern zend_module_entry xdebug_module_entry;
 #define phpext_xdebug_ptr &xdebug_module_entry
-
-#define MICRO_IN_SEC 1000000.00
 
 #define OUTPUT_NOT_CHECKED -1
 #define OUTPUT_IS_TTY       1
@@ -79,6 +78,7 @@ int xdebug_is_output_tty();
 struct xdebug_base_info {
 	unsigned long level;
 	xdebug_vector *stack;
+	xdebug_nanotime_context nanotime_context;
 	double        start_time;
 	unsigned int  prev_memory;
 	zif_handler   orig_set_time_limit_func;

--- a/src/base/base.c
+++ b/src/base/base.c
@@ -876,6 +876,7 @@ void xdebug_base_minit(INIT_FUNC_ARGS)
 	xdebug_old_execute_internal = zend_execute_internal;
 	zend_execute_internal = xdebug_execute_internal;
 
+	xdebug_nanotime_init();
 	XG_BASE(error_reporting_override) = 0;
 	XG_BASE(error_reporting_overridden) = 0;
 	XG_BASE(output_is_tty) = OUTPUT_NOT_CHECKED;

--- a/src/base/base.c
+++ b/src/base/base.c
@@ -876,10 +876,11 @@ void xdebug_base_minit(INIT_FUNC_ARGS)
 	xdebug_old_execute_internal = zend_execute_internal;
 	zend_execute_internal = xdebug_execute_internal;
 
-	xdebug_nanotime_init();
 	XG_BASE(error_reporting_override) = 0;
 	XG_BASE(error_reporting_overridden) = 0;
 	XG_BASE(output_is_tty) = OUTPUT_NOT_CHECKED;
+
+	xdebug_nanotime_init();
 }
 
 void xdebug_base_mshutdown()

--- a/src/lib/lib.h
+++ b/src/lib/lib.h
@@ -27,8 +27,6 @@
 #include "zend_API.h"
 #include "compat.h"
 
-#define MICRO_IN_SEC 1000000.00
-
 typedef struct xdebug_var_name {
 	zend_string *name;
 	zval         data;

--- a/src/lib/timing.c
+++ b/src/lib/timing.c
@@ -1,0 +1,205 @@
+/*
+   +----------------------------------------------------------------------+
+   | Xdebug                                                               |
+   +----------------------------------------------------------------------+
+   | Copyright (c) 2002-2020 Derick Rethans                               |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 1.01 of the Xdebug license,   |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available at through the world-wide-web at                           |
+   | https://xdebug.org/license.php                                       |
+   | If you did not receive a copy of the Xdebug license and are unable   |
+   | to obtain it through the world-wide-web, please send a note to       |
+   | derick@xdebug.org so we can mail you a copy immediately.             |
+   +----------------------------------------------------------------------+
+   | Authors: Derick Rethans <derick@xdebug.org>                          |
+   |          Michael Voříšek <mvorisek@mvorisek.cz>                      |
+   +----------------------------------------------------------------------+
+ */
+
+#include "php_xdebug.h"
+#if PHP_WIN32
+# include "win32/time.h"
+# include <versionhelpers.h>
+#else
+# include <sys/time.h>
+#endif
+#if __APPLE__
+# include <mach/mach_time.h>
+#endif
+
+#include "timing.h"
+
+#define NANOTIME_MIN_STEP 10
+
+#if PHP_WIN32
+# define WIN_NANOS_IN_TICK          100
+# define WIN_TICKS_SINCE_1601_JAN_1 116444736000000000ULL
+#endif
+
+ZEND_EXTERN_MODULE_GLOBALS(xdebug)
+
+static uint64_t xdebug_get_nanotime_abs(xdebug_nanotime_context *nanotime_context)
+{
+#if PHP_WIN32
+	FILETIME filetime;
+#endif
+#if _SC_MONOTONIC_CLOCK
+	struct timespec ts;
+#endif
+#if HAVE_GETTIMEOFDAY
+	struct timeval tp;
+#endif
+
+	// Windows
+#if PHP_WIN32
+	if (nanotime_context->win_precise_time_func != NULL) {
+		nanotime_context->win_precise_time_func(&filetime);
+		return ((((uint64_t)filetime.dwHighDateTime << 32) + (uint64_t)filetime.dwLowDateTime) - WIN_TICKS_SINCE_1601_JAN_1)
+			* WIN_NANOS_IN_TICK;
+	}
+#endif
+
+	// Linux/Unix
+#if _SC_MONOTONIC_CLOCK
+	if (clock_gettime(CLOCK_MONOTONIC, &ts) == 0) {
+		return (uint64_t)ts.tv_sec * NANOS_IN_SEC + (uint64_t)ts.tv_nsec;
+	}
+
+	return 0;
+#endif
+
+	// fallback if better platform specific time is not available
+#if HAVE_GETTIMEOFDAY
+	if (gettimeofday(&tp, NULL) == 0) {
+		return (uint64_t)tp.tv_sec * NANOS_IN_SEC + (uint64_t)tp.tv_usec * NANOS_IN_MICROSEC;
+	}
+#endif
+
+	return 0;
+}
+
+#if PHP_WIN32
+static uint64_t xdebug_counter_and_freq_to_nanotime(uint64_t counter, uint64_t freq)
+{
+	uint32_t mul = 1, freq32;
+	uint64_t q, r;
+
+	while (freq >= (1ULL << 32)) {
+		freq /= 2;
+		mul *= 2;
+	}
+	freq32 = (uint32_t)freq;
+
+	q = counter / freq32;
+	r = counter % freq32;
+	return (q * NANOS_IN_SEC + (r * NANOS_IN_SEC) / freq32) * mul;
+}
+#endif
+
+static uint64_t xdebug_get_nanotime_rel(xdebug_nanotime_context *nanotime_context)
+{
+	// Windows Windows 7 and lower
+#if PHP_WIN32
+	LARGE_INTEGER tcounter;
+
+	if (nanotime_context->win_precise_time_func == NULL) {
+		QueryPerformanceCounter(&tcounter);
+		return xdebug_counter_and_freq_to_nanotime((uint64_t)tcounter.QuadPart, nanotime_context->win_freq);
+	}
+#endif
+
+	// Mac
+	// should be fast but can be relative
+#if __APPLE__
+	return clock_gettime_nsec_np(CLOCK_UPTIME_RAW);
+#endif
+
+	return 0;
+}
+
+void xdebug_nanotime_init(void)
+{
+	xdebug_nanotime_context context = {0};
+#if PHP_WIN32
+	LARGE_INTEGER tcounter;
+
+	if (IsWindows8OrGreater()) {
+		context.win_precise_time_func = (WIN_PRECISE_TIME_FUNC)GetProcAddress(
+			GetModuleHandle(TEXT("kernel32.dll")),
+			"GetSystemTimePreciseAsFileTime"
+		);
+	} else {
+		context.win_precise_time_func = NULL;
+		QueryPerformanceFrequency(&tcounter);
+		context.win_freq = (uint64_t)tcounter.QuadPart;
+	}
+#endif
+	context.start_abs = xdebug_get_nanotime_abs(&context);
+	context.start_rel = xdebug_get_nanotime_rel(&context);
+	context.last_abs = 0;
+	context.last_rel = 0;
+
+	XG_BASE(nanotime_context) = context;
+}
+
+uint64_t xdebug_get_nanotime(void)
+{
+	uint64_t nanotime;
+	xdebug_nanotime_context *context;
+
+	context = &XG_BASE(nanotime_context);
+
+	nanotime = xdebug_get_nanotime_rel(context);
+	if (nanotime > 0) {
+		if (nanotime < context->last_rel + NANOTIME_MIN_STEP) {
+			context->last_rel += NANOTIME_MIN_STEP;
+			nanotime = context->last_rel;
+		}
+		context->last_rel = nanotime;
+		nanotime = context->start_abs + (xdebug_get_nanotime_rel(context) - context->start_rel);
+	} else {
+		nanotime = xdebug_get_nanotime_abs(context);
+		if (nanotime < context->last_abs + NANOTIME_MIN_STEP) {
+			context->last_abs += NANOTIME_MIN_STEP;
+			nanotime = context->last_abs;
+		}
+		context->last_abs = nanotime;
+	}
+
+	return nanotime;
+}
+
+double xdebug_get_utime(void)
+{
+	return xdebug_get_nanotime() / (double)NANOS_IN_SEC;
+}
+
+char* xdebug_get_time(void)
+{
+	uint64_t nanotime;
+
+	nanotime = xdebug_get_nanotime();
+	return xdebug_nanotime_to_chars(nanotime, 0);
+}
+
+char* xdebug_nanotime_to_chars(uint64_t nanotime, unsigned char precision)
+{
+	char *res;
+	time_t secs;
+
+	secs = (time_t)(nanotime / NANOS_IN_SEC);
+	if (precision > 0) {
+		res = xdmalloc(30);
+	} else {
+		res = xdmalloc(20);
+	}
+	strftime(res, 20, "%Y-%m-%d %H:%M:%S", gmtime(&secs));
+	if (precision > 0) {
+		sprintf(res + 19, ".%09u", (uint32_t)(nanotime % NANOS_IN_SEC));
+		if (precision < 9) {
+			*(res + 20 + precision) = '\0';
+		}
+	}
+	return res;
+}

--- a/src/lib/timing.c
+++ b/src/lib/timing.c
@@ -79,6 +79,7 @@ static uint64_t xdebug_get_nanotime_abs(xdebug_nanotime_context *nanotime_contex
 #endif
 
 	// We give up
+	php_error(E_WARNING, "Xdebug could not determine a suitable clock source on your system");
 	return 0;
 }
 

--- a/src/lib/timing.h
+++ b/src/lib/timing.h
@@ -29,9 +29,12 @@ typedef void (WINAPI *WIN_PRECISE_TIME_FUNC)(LPFILETIME);
 
 typedef struct _xdebug_nanotime_context {
 	uint64_t start_abs;
-	uint64_t start_rel;
 	uint64_t last_abs;
+#if PHP_WIN32 | __APPLE__
+	uint64_t start_rel;
 	uint64_t last_rel;
+	int      use_rel_time;
+#endif
 #if PHP_WIN32
 	WIN_PRECISE_TIME_FUNC win_precise_time_func;
 	uint64_t win_freq;

--- a/src/lib/timing.h
+++ b/src/lib/timing.h
@@ -1,0 +1,49 @@
+/*
+   +----------------------------------------------------------------------+
+   | Xdebug                                                               |
+   +----------------------------------------------------------------------+
+   | Copyright (c) 2002-2020 Derick Rethans                               |
+   +----------------------------------------------------------------------+
+   | This source file is subject to version 1.01 of the Xdebug license,   |
+   | that is bundled with this package in the file LICENSE, and is        |
+   | available at through the world-wide-web at                           |
+   | https://xdebug.org/license.php                                       |
+   | If you did not receive a copy of the Xdebug license and are unable   |
+   | to obtain it through the world-wide-web, please send a note to       |
+   | derick@xdebug.org so we can mail you a copy immediately.             |
+   +----------------------------------------------------------------------+
+   | Authors: Derick Rethans <derick@xdebug.org>                          |
+   |          Michael Voříšek <mvorisek@mvorisek.cz>                      |
+   +----------------------------------------------------------------------+
+ */
+
+#ifndef __XDEBUG_TIMING_H__
+#define __XDEBUG_TIMING_H__
+
+#define NANOS_IN_SEC      1000000000
+#define NANOS_IN_MICROSEC 1000
+
+#if PHP_WIN32
+typedef void (WINAPI *WIN_PRECISE_TIME_FUNC)(LPFILETIME);
+#endif
+
+typedef struct _xdebug_nanotime_context {
+	uint64_t start_abs;
+	uint64_t start_rel;
+	uint64_t last_abs;
+	uint64_t last_rel;
+#if PHP_WIN32
+	WIN_PRECISE_TIME_FUNC win_precise_time_func;
+	uint64_t win_freq;
+#endif
+} xdebug_nanotime_context;
+
+void xdebug_nanotime_init(void);
+
+uint64_t xdebug_get_nanotime(void);
+double xdebug_get_utime(void);
+char* xdebug_get_time(void);
+
+char* xdebug_nanotime_to_chars(uint64_t nanotime, unsigned char precision);
+
+#endif

--- a/src/lib/usefulstuff.c
+++ b/src/lib/usefulstuff.c
@@ -22,14 +22,12 @@
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/socket.h>
-#include <sys/time.h>
 #include <sys/resource.h>
 #include <sys/file.h>
 #else
 #define PATH_MAX MAX_PATH
 #include <winsock2.h>
 #include <io.h>
-#include "win32/time.h"
 #include <process.h>
 #endif
 #include "php_xdebug.h"
@@ -141,37 +139,6 @@ char* xdebug_strrstr(const char* haystack, const char* needle)
 	}
 
 	return loc;
-}
-
-double xdebug_get_utime(void)
-{
-#ifdef HAVE_GETTIMEOFDAY
-	struct timeval tp;
-	long sec = 0L;
-	double msec = 0.0;
-
-	if (gettimeofday((struct timeval *) &tp, NULL) == 0) {
-		sec = tp.tv_sec;
-		msec = (double) (tp.tv_usec / MICRO_IN_SEC);
-
-		if (msec >= 1.0) {
-			msec -= (long) msec;
-		}
-		return msec + sec;
-	}
-#endif
-	return 0;
-}
-
-char* xdebug_get_time(void)
-{
-	time_t cur_time;
-	char  *str_time;
-
-	str_time = xdmalloc(24);
-	cur_time = time(NULL);
-	strftime(str_time, 24, "%Y-%m-%d %H:%M:%S", gmtime (&cur_time));
-	return str_time;
 }
 
 /* not all versions of php export this */

--- a/src/lib/usefulstuff.h
+++ b/src/lib/usefulstuff.h
@@ -44,8 +44,6 @@ xdebug_str* xdebug_join(const char *delim, xdebug_arg *args, int begin, int end)
 void xdebug_explode(const char *delim, const char *str, xdebug_arg *args, int limit);
 const char* xdebug_memnstr(const char *haystack, const char *needle, int needle_len, const char *end);
 char* xdebug_strrstr(const char* haystack, const char* needle);
-double xdebug_get_utime(void);
-char* xdebug_get_time(void);
 char *xdebug_path_to_url(zend_string *fileurl);
 char *xdebug_path_from_url(zend_string *fileurl);
 FILE *xdebug_fopen(char *fname, const char *mode, const char *extension, char **new_fname);

--- a/tests/develop/xdebug_time_index.phpt
+++ b/tests/develop/xdebug_time_index.phpt
@@ -1,0 +1,28 @@
+--TEST--
+xdebug_time_index()
+--INI--
+xdebug.mode=develop
+--FILE--
+<?php
+usleep( 250000 );
+
+$rq = $_SERVER['REQUEST_TIME_FLOAT'];
+$c  = microtime( true );
+$xt = xdebug_time_index();
+
+$d  = ($rq + $xt) - $c;
+
+echo "Request time (float): ", $rq, "\n";
+echo "Xdebug time index:    ", $xt, "\n";
+echo "Current microtime:    ", $c,  "\n";
+echo "Difference:           ", $d,  "\n";
+
+echo "The difference is ", abs($d) > 1e-2 ? "too high\n" : "fine\n";
+?>
+--EXPECTF--
+Request time (float): 1%d.%d
+Xdebug time index:    0.2%d
+Current microtime:    1%d.%d
+Difference:           %f
+The difference is fine
+


### PR DESCRIPTION
Hi @mvorisek,

I've taken your PR #602 and squished your commits into one. I then went over it and split code out so that anything to do with relative time only happens on Windows and OSX, where Windows will still use it only if it's >= Win 8. I think I did it right, and the tests seem to pass on Windows. Can you please check it?

Before I merge it, I would like to have https://twitter.com/jimbojsb check it out on OSX, due to him writing [a blog post](https://joshbutts.com/posts/patching-xdebug-docker-for-mac/) about the timing slowdown.

Thanks very much for working on this!

cheers,
Derick