### PR TITLE
Remove "prev" from function_stack_entry

### DIFF
--- a/src/debugger/handler_dbgp.c
+++ b/src/debugger/handler_dbgp.c
@@ -1940,10 +1940,8 @@ DBGP_FUNC(stack_depth)
 
 DBGP_FUNC(stack_get)
 {
-	xdebug_xml_node      *stackframe;
-	function_stack_entry *le;
-	int                   counter = 0;
-	long                  depth;
+	xdebug_xml_node *stackframe;
+	long             depth;
 
 	if (CMD_OPTION_SET('d')) {
 		depth = strtol(CMD_OPTION_CHAR('d'), NULL, 10);
@@ -1954,11 +1952,12 @@ DBGP_FUNC(stack_get)
 			RETURN_RESULT(XG_DBG(status), XG_DBG(reason), XDEBUG_ERROR_STACK_DEPTH_INVALID);
 		}
 	} else {
-		counter = 0;
-		for (le = XDEBUG_VECTOR_TAIL(XG_BASE(stack)); le != NULL; le = le->prev) {
-			stackframe = return_stackframe(counter);
+		function_stack_entry *fse = XDEBUG_VECTOR_TAIL(XG_BASE(stack));
+		int                   i = 0;
+
+		for (i = 0; i < XDEBUG_VECTOR_COUNT(XG_BASE(stack)); i++, fse--) {
+			stackframe = return_stackframe(i);
 			xdebug_xml_add_child(*retval, stackframe);
-			counter++;
 		}
 	}
 	return XDEBUG_CMD_OK;

--- a/src/develop/stack.c
+++ b/src/develop/stack.c
@@ -546,8 +546,8 @@ void xdebug_append_printable_stack(xdebug_str *str, int html)
 		int scope_nr = XDEBUG_VECTOR_COUNT(XG_BASE(stack));
 
 		fse = XDEBUG_VECTOR_TAIL(XG_BASE(stack));
-		if (fse->user_defined == XDEBUG_BUILT_IN && fse->prev) {
-			fse = fse->prev;
+		if (fse->user_defined == XDEBUG_BUILT_IN && xdebug_vector_element_is_valid(XG_BASE(stack), fse -1)) {
+			fse = fse - 1;
 			scope_nr--;
 		}
 		if (fse->declared_vars && fse->declared_vars->size) {

--- a/src/lib/lib.h
+++ b/src/lib/lib.h
@@ -185,7 +185,6 @@ typedef struct _function_stack_entry {
 	} profiler;
 
 	/* misc properties */
-	struct _function_stack_entry *prev;
 	zend_op_array *op_array;
 } function_stack_entry;
 

--- a/src/lib/vector.h
+++ b/src/lib/vector.h
@@ -73,6 +73,17 @@ static inline void *xdebug_vector_element_get(xdebug_vector *v, size_t index)
 	return ((char*) v->data + (index * (v)->element_size));
 }
 
+static inline int xdebug_vector_element_is_valid(xdebug_vector *v, void *element)
+{
+	if ((char*) element < (char*) v->data) {
+		return 0;
+	}
+	if ((char*) element > ((char*) v->data + ((v->count - 1) * v->element_size))) {
+		return 0;
+	}
+
+	return 1;
+}
 
 #define XDEBUG_VECTOR_HEAD(v) xdebug_vector_element_get((v), 0)
 #define XDEBUG_VECTOR_TAIL(v) xdebug_vector_element_get((v), (v)->count-1)


### PR DESCRIPTION
We don't need it anymore, and it is also not reliable, as the vector can
reallocate the stack to a whole different address at any time.

@mvorisek — This should fix the issue that you saw with your code base.