### PR TITLE
Improve performance of xdebug_sprintf() function

### DIFF
--- a/src/lib/str.c
+++ b/src/lib/str.c
@@ -193,7 +193,7 @@ void xdebug_str_free(xdebug_str *s)
 char *xdebug_sprintf(const char* fmt, ...)
 {
 	char   *new_str;
-	int     size = 1;
+	int     size = 32;
 	va_list args;
 
 	new_str = (char *) xdmalloc(size);


### PR DESCRIPTION
original discussion here: https://github.com/xdebug/xdebug/pull/606#discussion_r459991250

this improves the performance for real world usage a lot

use global buffer of some size to which the standard prints should fit (like 4k - 16k) and copy from it if the results fitted, if not, continue increasing the buffer like before

if global buffer refactor is not wanted, merge this PR as is