### PR TITLE
Use fwrite directly instead of fprintf

### DIFF
--- a/src/profiler/profiler.c
+++ b/src/profiler/profiler.c
@@ -521,7 +521,7 @@ void xdebug_profiler_function_end(function_stack_entry *fse)
 	}
 	xdebug_str_addc(&file_buffer, '\n');
 
-	fprintf(XG_PROF(profile_file), "%s", file_buffer.d);
+	fwrite(file_buffer.d, sizeof(char), file_buffer.l, XG_PROF(profile_file));
 	xdebug_str_dtor(file_buffer);
 }
 


### PR DESCRIPTION
Hi,

another profiler improvement:
- direct write: 6.2s (no change on `master`)
- buffered fwrite: 5.5s ( https://github.com/mvorisek/xdebug/tree/profiler_print_using_buffer , quick rebase of https://github.com/xdebug/xdebug/pull/606 )
- this PR: 5.1s

I almost do not belive these times, but we should definitely use `fwrite`. Tested on Windows.