### PR TITLE
Use custom itoa in profiler instead of slow sprintf

### DIFF
--- a/src/lib/str.c
+++ b/src/lib/str.c
@@ -93,6 +93,28 @@ void xdebug_str_addc(xdebug_str *xs, char letter)
 	xs->l = xs->l + 1;
 }
 
+void xdebug_str_add_uint64(xdebug_str *xs, uint64_t num)
+{
+	char buffer[21];
+	char *pos;
+	int digit;
+
+	pos = &buffer[20];
+	*pos = '\0';
+
+	do {
+		digit = num % 10;
+		num = num / 10;
+		if (digit < 10) {
+			*--pos = '0' + digit;
+		} else {
+			*--pos = 'a' + digit - 10;
+		}
+	} while (num != 0L);
+
+	xdebug_str_addl(xs, pos, &buffer[20] - pos, 0);
+}
+
 void xdebug_str_add_fmt(xdebug_str *xs, const char *fmt, ...)
 {
 	va_list args;

--- a/src/lib/str.c
+++ b/src/lib/str.c
@@ -39,21 +39,7 @@ inline static void realloc_if_needed(xdebug_str *xs, int size_to_fit)
 	}
 }
 
-void xdebug_str_add(xdebug_str *xs, const char *str, int f)
-{
-	int l = strlen(str);
-
-	realloc_if_needed(xs, l);
-
-	memcpy(xs->d + xs->l, str, l);
-	xs->d[xs->l + l] = '\0';
-	xs->l = xs->l + l;
-	if (f) {
-		xdfree((char*) str);
-	}
-}
-
-void xdebug_str_addl(xdebug_str *xs, const char *str, int le, int f)
+inline static void xdebug_str_internal_addl(xdebug_str *xs, const char *str, int le, int f)
 {
 	realloc_if_needed(xs, le);
 
@@ -66,22 +52,24 @@ void xdebug_str_addl(xdebug_str *xs, const char *str, int le, int f)
 	}
 }
 
+void xdebug_str_addl(xdebug_str *xs, const char *str, int le, int f)
+{
+	xdebug_str_internal_addl(xs, str, le, f);
+}
+
+void xdebug_str_add(xdebug_str *xs, const char *str, int f)
+{
+	xdebug_str_internal_addl(xs, str, strlen(str), f);
+}
+
 void xdebug_str_add_str(xdebug_str *xs, const xdebug_str *str)
 {
-	realloc_if_needed(xs, str->l);
-
-	memcpy(xs->d + xs->l, str->d, str->l);
-	xs->d[xs->l + str->l] = '\0';
-	xs->l = xs->l + str->l;
+    xdebug_str_internal_addl(xs, str->d, str->l, 0);
 }
 
 void xdebug_str_add_zstr(xdebug_str *xs, const zend_string *str)
 {
-	realloc_if_needed(xs, ZSTR_LEN(str));
-
-	memcpy(xs->d + xs->l, ZSTR_VAL(str), ZSTR_LEN(str));
-	xs->d[xs->l + ZSTR_LEN(str)] = '\0';
-	xs->l = xs->l + ZSTR_LEN(str);
+    xdebug_str_internal_addl(xs, ZSTR_VAL(str), ZSTR_LEN(str), 0);
 }
 
 void xdebug_str_addc(xdebug_str *xs, char letter)
@@ -112,7 +100,7 @@ void xdebug_str_add_uint64(xdebug_str *xs, uint64_t num)
 		}
 	} while (num != 0L);
 
-	xdebug_str_addl(xs, pos, &buffer[20] - pos, 0);
+	xdebug_str_internal_addl(xs, pos, &buffer[20] - pos, 0);
 }
 
 void xdebug_str_add_fmt(xdebug_str *xs, const char *fmt, ...)

--- a/src/lib/str.h
+++ b/src/lib/str.h
@@ -42,6 +42,7 @@ void xdebug_str_addl(xdebug_str *xs, const char *str, int le, int f);
 void xdebug_str_add_str(xdebug_str *xs, const xdebug_str *str);
 void xdebug_str_add_zstr(xdebug_str *xs, const zend_string *str);
 void xdebug_str_addc(xdebug_str *xs, char letter);
+void xdebug_str_add_uint64(xdebug_str *xs, uint64_t num);
 void xdebug_str_add_fmt(xdebug_str *xs, const char *fmt, ...);
 #define xdebug_str_add_literal(s,l) xdebug_str_addl((s), (l), sizeof(l)-1, 0)
 #define xdebug_str_add_const(s,l) xdebug_str_addl((s), (l), strlen(l), 0)

--- a/src/lib/str.h
+++ b/src/lib/str.h
@@ -37,8 +37,8 @@ typedef struct xdebug_str {
 	char *d;
 } xdebug_str;
 
-void xdebug_str_add(xdebug_str *xs, const char *str, int f);
 void xdebug_str_addl(xdebug_str *xs, const char *str, int le, int f);
+void xdebug_str_add(xdebug_str *xs, const char *str, int f);
 void xdebug_str_add_str(xdebug_str *xs, const xdebug_str *str);
 void xdebug_str_add_zstr(xdebug_str *xs, const zend_string *str);
 void xdebug_str_addc(xdebug_str *xs, char letter);

--- a/src/profiler/profiler.c
+++ b/src/profiler/profiler.c
@@ -472,11 +472,14 @@ void xdebug_profiler_function_end(function_stack_entry *fse)
 		fse->profile.time -= call_entry->time_taken;
 		fse->profile.memory -= call_entry->mem_used;
 	}
-	xdebug_str_add_fmt(
-		&file_buffer, "%d %lu %lu\n",
-		fse->profiler.lineno,
-		(unsigned long) (fse->profile.time * 1000000), fse->profile.memory >= 0 ? fse->profile.memory : 0
-	);
+
+	/* Adds %d %lu %lu, with lineno, time, and memory */
+	xdebug_str_add_uint64(&file_buffer, fse->profiler.lineno);
+	xdebug_str_addc(&file_buffer, ' ');
+	xdebug_str_add_uint64(&file_buffer, (unsigned long) (fse->profile.time * 1000000));
+	xdebug_str_addc(&file_buffer, ' ');
+	xdebug_str_add_uint64(&file_buffer, fse->profile.memory >= 0 ? fse->profile.memory : 0);
+	xdebug_str_addc(&file_buffer, '\n');
 
 	/* dump call list */
 	for (le = XDEBUG_LLIST_HEAD(fse->profile.call_list); le != NULL; le = XDEBUG_LLIST_NEXT(le))
@@ -512,12 +515,14 @@ void xdebug_profiler_function_end(function_stack_entry *fse)
 		}
 
 		xdebug_str_add_literal(&file_buffer, "calls=1 0 0\n");
-		xdebug_str_add_fmt(
-			&file_buffer, "%d %lu %lu\n",
-			call_entry->lineno,
-			(unsigned long) (call_entry->time_taken * 1000000),
-			call_entry->mem_used >= 0 ? call_entry->mem_used : 0
-		);
+
+		/* Adds %d %lu %lu, with lineno, time, and memory */
+		xdebug_str_add_uint64(&file_buffer, call_entry->lineno);
+		xdebug_str_addc(&file_buffer, ' ');
+		xdebug_str_add_uint64(&file_buffer, (unsigned long) (call_entry->time_taken * 1000000));
+		xdebug_str_addc(&file_buffer, ' ');
+		xdebug_str_add_uint64(&file_buffer, call_entry->mem_used >= 0 ? call_entry->mem_used : 0);
+		xdebug_str_addc(&file_buffer, '\n');
 	}
 	xdebug_str_addc(&file_buffer, '\n');
 


### PR DESCRIPTION
impl. inspired by Wine source (_ui64toa in dlls/ntdll/string.c)

based on internet sprintf is simply slow:
https://www.zverovich.net/2013/09/07/integer-to-string-conversion-in-cplusplus.html
https://github.com/miloyip/itoa-benchmark

benchmark:
- before: 5.1s
- after: 4.3s