### PR TITLE
Disable `maximum_function_nesting` in Xdebug 3.0+ default settings to be more production-alike

### DIFF
--- a/tests/develop/max_nesting_level-003.phpt
+++ b/tests/develop/max_nesting_level-003.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Test for xdebug.max_nesting_level (unconfigured) [2]
+--FILE--
+<?php
+
+function foo(int $i) : int
+{
+    if ($i >= 10000) {
+        return $i;
+    }
+
+	return foo($i + 1);
+}
+echo foo(0);
+?>
+--EXPECTF--
+10000

--- a/xdebug.c
+++ b/xdebug.c
@@ -207,7 +207,7 @@ PHP_INI_BEGIN()
 	STD_PHP_INI_ENTRY("xdebug.var_display_max_depth",    "3",       PHP_INI_ALL,    OnUpdateLong,   settings.library.display_max_depth,    zend_xdebug_globals, xdebug_globals)
 
 	/* Base settings */
-	STD_PHP_INI_ENTRY("xdebug.max_nesting_level", "256",                PHP_INI_ALL,    OnUpdateLong,   base.settings.max_nesting_level, zend_xdebug_globals, xdebug_globals)
+	STD_PHP_INI_ENTRY("xdebug.max_nesting_level", "-1",                PHP_INI_ALL,    OnUpdateLong,   base.settings.max_nesting_level, zend_xdebug_globals, xdebug_globals)
 
 	/* Develop settings */
 	STD_PHP_INI_ENTRY("xdebug.cli_color",         "0",                  PHP_INI_ALL,    OnUpdateLong,   settings.develop.cli_color,         zend_xdebug_globals, xdebug_globals)

--- a/xdebug.ini
+++ b/xdebug.ini
@@ -231,7 +231,7 @@
 ;
 ; Introduced in version 2.1
 ;
-; Type: string, Default value: 
+; Type: string, Default value:
 ;
 ; This setting determines the format of the links that are made in the display
 ; of stack traces where file names are used. This allows IDEs to set up a
@@ -341,7 +341,7 @@
 ;     "netbeans://open/?f=%f:%l"
 ;
 ;
-;xdebug.file_link_format = 
+;xdebug.file_link_format =
 
 ; -----------------------------------------------------------------------------
 ; xdebug.filename_format
@@ -506,7 +506,7 @@
 ; -----------------------------------------------------------------------------
 ; xdebug.max_nesting_level
 ;
-; Type: integer, Default value: 256
+; Type: integer, Default value: -1
 ;
 ; Controls the protection mechanism for infinite recursion protection. The value
 ; of this setting is the maximum level of nested functions that are allowed
@@ -515,12 +515,15 @@
 ; Before Xdebug 2.6, this would create a fatal exception if exceeded. From
 ; Xdebug 2.6 and later, an "Error [1]" exception is thrown instead.
 ;
+; Set this value to ``-1`` in order to disable this protection mechanism.
+;
 ; [1] https://www.php.net/manual/class.error.php
 ;
 ; Before Xdebug 2.3, the default value was ``100``.
+; Before Xdebug 3.0, the default value was ``256``.
 ;
 ;
-;xdebug.max_nesting_level = 256
+;xdebug.max_nesting_level = -1
 
 ; -----------------------------------------------------------------------------
 ; xdebug.max_stack_frames
@@ -741,7 +744,7 @@
 ; -----------------------------------------------------------------------------
 ; xdebug.remote_log
 ;
-; Type: string, Default value: 
+; Type: string, Default value:
 ;
 ; If set to a value, it is used as filename to a file to which all remote
 ; debugger communications are logged. The file is always opened in append-mode,
@@ -755,7 +758,7 @@
 ;     -> <response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/db ... ></response>
 ;
 ;
-;xdebug.remote_log = 
+;xdebug.remote_log =
 
 ; -----------------------------------------------------------------------------
 ; xdebug.remote_log_level


### PR DESCRIPTION
The `xdebug.max_nesting_level` setting is a problematic flag-alike that, while
sometimes helping in avoiding infinite recursion bugs,
does not prevent such problems in production environment, and leads
to diverging runtime behavior between development and production
environments.

In practice, many un-experienced users usually install Xdebug, then run
some off-the-shelf tool from somewhere, and they experience a crash that
requires re-configuring Xdebug to either have a higher `max_nesting_level`
or to be `-1` by default.

This limit has initially been `100` (before Xdebug 2.3), then raised to
`256`, and in general will keep raising as recursive execution usage increases.

By disabling this behavior in the **default** configuration of Xdebug (feature
still exists, if the end user willingly enables it), we align the behavior
of complex recursive execution schemes in production environments to what
developers run in their local environment.

Note: users will still run into memory consumption issues due to stack frame
allocation, but at least that's the default behavior of PHP with or without Xdebug
installed.

Related: https://github.com/laminas/laminas-cli/issues/40
/cc @boesing @geerteltink @weierophinney 