### PR TITLE
Cater to PHP patchlevel releases in AppVeyor CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -145,6 +145,9 @@ build_script:
         $dname1 = 'php-' + $env:PHP_VERSION + $ts_part + '-devel-' + $env:VC.toUpper() + '-' + $env:ARCH
         if (-not (Test-Path c:\build-cache\$dname1)) {
             7z x -aoa c:\build-cache\$bname -oc:\build-cache
+            if ($env:PHP_VERSION.split('-').length -gt 1) {
+                move "c:\build-cache\php-$($env:PHP_VERSION.split('-')[0])-devel-$($env:VC.toUpper())-$env:ARCH" c:\build-cache\$dname0
+            }
             if ($dname0 -ne $dname1) {
                 move c:\build-cache\$dname0 c:\build-cache\$dname1
             }


### PR DESCRIPTION
Windows patchlevel releases (i.e. releases which only update dependency
libs) have a trailing `-<num>` in the version.  However, the toplevel
folder of the devel packages does not have that trailing `-<num>`.
We cater to that by renaming that folder after unpacking to work
smoothly with the rest of the CI scripts.