### PR TITLE
Relax test

### DIFF
--- a/tests/debugger/bug01782.phpt
+++ b/tests/debugger/bug01782.phpt
@@ -22,5 +22,5 @@ var_dump( xdebug_get_headers( ) );
 %sbug01782.php:2:
 array(1) {
   [0] =>
-  string(%d) "Set-Cookie: XDEBUG_SESSION=testing; expires=%s; Max-Age=1234; path=/; SameSite=Strict"
+  string(%d) "Set-Cookie: XDEBUG_SESSION=testing; expires=%s; Max-Age=123%d; path=/; SameSite=Strict"
 }


### PR DESCRIPTION
Look like this may be 1233, run conditon, time change between launch time and xdebug_get_headers call on slow computer

Randomly encountered during some aarch64 builds

```
TEST 526/679 [tests/debugger/bug01782.phpt]
========DIFF========
004+   string(112) "Set-Cookie: XDEBUG_SESSION=testing; expires=Thu, 17-Sep-2020 05:51:29 GMT; Max-Age=1233; path=/; SameSite=Strict"
004-   string(%d) "Set-Cookie: XDEBUG_SESSION=testing; expires=%s; Max-Age=1234; path=/; SameSite=Strict"
========DONE========
FAIL Test for bug #1782: Make sure we use SameSite=Strict cookies (>= PHP 7.3) [tests/debugger/bug01782.phpt] 

```