### PR TITLE
Fix symbol definition on FreeBSD

### DIFF
--- a/src/debugger/com.c
+++ b/src/debugger/com.c
@@ -89,7 +89,7 @@ static int xdebug_create_socket_unix(const char *path)
 #if !WIN32 && !WINNT
 
 /* For OSX */
-#if !defined(SOL_TCP) && defined(IPPROTO_TCP) && defined(__APPLE__)
+#if !defined(SOL_TCP) && defined(IPPROTO_TCP) && (defined(__APPLE__) || defined(__FreeBSD__))
 # define SOL_TCP IPPROTO_TCP
 #endif
 #if !defined(TCP_KEEPIDLE) && defined(TCP_KEEPALIVE) && defined(__APPLE__)


### PR DESCRIPTION
This patch fix symbol definition in FreeBSD, fixing the build.