### PR TITLE
Reduce runtime overhead when extension is disabled

### DIFF
--- a/src/base/base.c
+++ b/src/base/base.c
@@ -666,6 +666,11 @@ function_stack_entry *xdebug_add_stack_frame(zend_execute_data *zdata, zend_op_a
 
 static void xdebug_execute_ex(zend_execute_data *execute_data)
 {
+	if (EXPECTED(XG(globals.library.mode) == XDEBUG_MODE_OFF)) {
+		xdebug_old_execute_ex(execute_data);
+		return;
+	}
+
 	zend_op_array        *op_array = &(execute_data->func->op_array);
 	zend_execute_data    *edata = execute_data->prev_execute_data;
 	function_stack_entry *fse;
@@ -841,6 +846,15 @@ static int check_soap_call(function_stack_entry *fse, zend_execute_data *execute
 
 static void xdebug_execute_internal(zend_execute_data *current_execute_data, zval *return_value)
 {
+	if (XG(globals.library.mode) == XDEBUG_MODE_OFF) {
+		if (xdebug_old_execute_internal) {
+			xdebug_old_execute_internal(current_execute_data, return_value);
+		} else {
+			execute_internal(current_execute_data, return_value);
+		}
+		return;
+	}
+
 	zend_execute_data    *edata = EG(current_execute_data);
 	function_stack_entry *fse;
 	int                   function_nr = 0;

--- a/xdebug.c
+++ b/xdebug.c
@@ -626,6 +626,10 @@ PHP_MINFO_FUNCTION(xdebug)
 
 ZEND_DLEXPORT void xdebug_statement_call(zend_execute_data *frame)
 {
+	if (EXPECTED(XG(globals.library.mode) == XDEBUG_MODE_OFF)) {
+		return;
+	}
+
 	zend_op_array *op_array = &frame->func->op_array;
 	int                   lineno;
 

--- a/xdebug.c
+++ b/xdebug.c
@@ -626,12 +626,12 @@ PHP_MINFO_FUNCTION(xdebug)
 
 ZEND_DLEXPORT void xdebug_statement_call(zend_execute_data *frame)
 {
+	zend_op_array *op_array = &frame->func->op_array;
+	int                   lineno;
+
 	if (EXPECTED(XG(globals.library.mode) == XDEBUG_MODE_OFF)) {
 		return;
 	}
-
-	zend_op_array *op_array = &frame->func->op_array;
-	int                   lineno;
 
 	if (!EG(current_execute_data)) {
 		return;


### PR DESCRIPTION
It has been [previously reported](https://bugs.xdebug.org/view.php?id=1668) that xdebug has a significant overhead when it is loaded but not enabled.

To get a rough idea of the overhead, I ran this (artificial) benchmark:

```php
<?php

function add($a, $b) {
  return $a + $b;
}

for ($i = 0; $i < 50000000; $i++) {
  add($i, $i);
}
```

Which performs 50 million method calls. I ran this with and without xdebug (more numbers below), and also gathered a CPU profile using macOS `sample(1)`. This pointed towards `xdebug_execute_ex` -- unsurprising, as it is run on every function call. It also highlighted `xdebug_statement_call`.

<details>

```
$ sudo sample -wait php

Waiting for 'php' to appear...  php appeared.
Sampling process 61084 for 10 seconds with 1 millisecond of run time between samples
Sampling completed, processing symbols...
Sample analysis of process 61084 written to file /tmp/php_2020-09-27_220751_4AXl.sample.txt

Analysis of sampling php (pid 61084) every 1 millisecond
Process:         php [61084]
Path:            /usr/local/Cellar/php/7.4.10/bin/php
Load Address:    0x10c474000
Identifier:      php
Version:         0
Code Type:       X86-64
Parent Process:  zsh [16141]

Date/Time:       2020-09-27 22:07:51.186 +0200
Launch Time:     2020-09-27 22:07:51.052 +0200
OS Version:      Mac OS X 10.15.6 (19G2021)
Report Version:  7
Analysis Tool:   /usr/bin/sample

Physical footprint:         6180K
Physical footprint (peak):  6180K
----

Call graph:
    9331 Thread_6931884   DispatchQueue_1: com.apple.main-thread  (serial)
      9331 start  (in libdyld.dylib) + 1  [0x7fff6ed7fcc9]
        9331 main  (in php) + 1211  [0x10c8020d3]
          9331 do_cli  (in php) + 3833  [0x10c80316e]
            9331 php_execute_script  (in php) + 482  [0x10c724985]
              9331 zend_execute_scripts  (in php) + 277  [0x10c77c38d]
                9331 zend_execute  (in php) + 352  [0x10c7b948f]
                  9331 xdebug_execute_ex  (in xdebug_master.so) + 1175  [0x10ff6b1b7]
                    9177 execute_ex  (in php) + 35  [0x10c7b92d7]
                    + 6803 ZEND_DO_FCALL_SPEC_RETVAL_UNUSED_HANDLER  (in php) + 403  [0x10c7d4bf6]
                    + ! 3542 xdebug_execute_ex  (in xdebug_master.so) + 295  [0x10ff6ae47]
                    + ! : 1756 xdebug_add_stack_frame  (in xdebug_master.so) + 496  [0x10ff6a830]
                    + ! : | 1577 xdebug_build_fname  (in xdebug_master.so) + 571  [0x10ff6a49b]
                    + ! : | + 1335 strdup  (in libsystem_c.dylib) + 32  [0x7fff6ee25ce6]
                    + ! : | + ! 1285 malloc  (in libsystem_malloc.dylib) + 21  [0x7fff6ef35cf5]
                    + ! : | + ! : 1116 malloc_zone_malloc  (in libsystem_malloc.dylib) + 104  [0x7fff6ef35d7a]
                    + ! : | + ! : | 936 szone_malloc_should_clear  (in libsystem_malloc.dylib) + 66  [0x7fff6ef370c6]
                    + ! : | + ! : | + 936 tiny_malloc_should_clear  (in libsystem_malloc.dylib) + 215,63,...  [0x7fff6ef3824e,0x7fff6ef381b6,...]
                    + ! : | + ! : | 93 szone_malloc_should_clear  (in libsystem_malloc.dylib) + 253,61,...  [0x7fff6ef37181,0x7fff6ef370c1,...]
                    + ! : | + ! : | 86 default_zone_malloc  (in libsystem_malloc.dylib) + 45,41,...  [0x7fff6ef35df8,0x7fff6ef35df4,...]
                    + ! : | + ! : | 1 szone_malloc  (in libsystem_malloc.dylib) + 0  [0x7fff6ef3707d]
                    + ! : | + ! : 168 malloc_zone_malloc  (in libsystem_malloc.dylib) + 23,179,...  [0x7fff6ef35d29,0x7fff6ef35dc5,...]
                    + ! : | + ! : 1 default_zone_malloc  (in libsystem_malloc.dylib) + 54  [0x7fff6ef35e01]
                    + ! : | + ! 50 malloc  (in libsystem_malloc.dylib) + 21,5,...  [0x7fff6ef35cf5,0x7fff6ef35ce5,...]
                    + ! : | + 83 strdup  (in libsystem_c.dylib) + 54  [0x7fff6ee25cfc]
                    + ! : | + ! 83 _platform_memmove$VARIANT$Haswell  (in libsystem_platform.dylib) + 222,202,...  [0x7fff6ef759de,0x7fff6ef759ca,...]
                    + ! : | + 79 strdup  (in libsystem_c.dylib) + 61,6,...  [0x7fff6ee25d03,0x7fff6ee25ccc,...]
                    + ! : | + 49 strdup  (in libsystem_c.dylib) + 18  [0x7fff6ee25cd8]
                    + ! : | + ! 49 _platform_strlen  (in libsystem_platform.dylib) + 0,7,...  [0x7fff6ef75e40,0x7fff6ef75e47,...]
                    + ! : | + 13 DYLD-STUB$$_platform_memmove  (in libsystem_platform.dylib) + 0  [0x7fff6ef7b80a]
                    + ! : | + 9 DYLD-STUB$$memcpy  (in libsystem_c.dylib) + 0  [0x7fff6ee4f3d4]
                    + ! : | + 8 DYLD-STUB$$malloc  (in libsystem_c.dylib) + 0  [0x7fff6ee4f3aa]
                    + ! : | + 1 DYLD-STUB$$strlen  (in libsystem_c.dylib) + 0  [0x7fff6ee4f5d8]
                    + ! : | 123 xdebug_build_fname  (in xdebug_master.so) + 52,100,...  [0x10ff6a294,0x10ff6a2c4,...]
                    + ! : | 44 xdebug_build_fname  (in xdebug_master.so) + 621  [0x10ff6a4cd]
                    + ! : | + 44 _platform_strncmp  (in libsystem_platform.dylib) + 320,7,...  [0x7fff6ef75d40,0x7fff6ef75c07,...]
                    + ! : | 7 DYLD-STUB$$strdup  (in xdebug_master.so) + 0  [0x10ff9261a]
                    + ! : | 5 DYLD-STUB$$strncmp  (in xdebug_master.so) + 0  [0x10ff92638]
                    + ! : 1118 xdebug_add_stack_frame  (in xdebug_master.so) + 469  [0x10ff6a815]
                    + ! : | 1063 xdebug_get_nanotime  (in xdebug_master.so) + 35  [0x10ff726d3]  timing.c:171
                    + ! : | + 556 clock_gettime_nsec_np  (in libsystem_c.dylib) + 325  [0x7fff6edd0fb1]
                    + ! : | + ! 556 mach_absolute_time  (in libsystem_kernel.dylib) + 28,41,...  [0x7fff6eec1298,0x7fff6eec12a5,...]
                    + ! : | + 433 clock_gettime_nsec_np  (in libsystem_c.dylib) + 356,276,...  [0x7fff6edd0fd0,0x7fff6edd0f80,...]
                    + ! : | + 46 clock_gettime_nsec_np  (in libsystem_c.dylib) + 238  [0x7fff6edd0f5a]
                    + ! : | + ! 46 mach_timebase_info  (in libsystem_kernel.dylib) + 5,62,...  [0x7fff6eec121c,0x7fff6eec1255,...]
                    + ! : | + 15 DYLD-STUB$$mach_absolute_time  (in libsystem_c.dylib) + 0  [0x7fff6ee4f374]
                    + ! : | + 13 DYLD-STUB$$mach_timebase_info  (in libsystem_c.dylib) + 0  [0x7fff6ee4f3a4]
                    + ! : | 21 xdebug_get_nanotime  (in xdebug_master.so) + 0,6,...  [0x10ff726b0,0x10ff726b6,...]  timing.c:162
                    + ! : | 8 DYLD-STUB$$clock_gettime_nsec_np  (in xdebug_master.so) + 0  [0x10ff92482]
                    + ! : | 8 xdebug_get_nanotime  (in xdebug_master.so) + 18,11,...  [0x10ff726c2,0x10ff726bb,...]  timing.c:170
                    + ! : | 6 xdebug_get_nanotime  (in xdebug_master.so) + 163,164  [0x10ff72753,0x10ff72754]  timing.c:194
                    + ! : | 5 xdebug_get_nanotime  (in xdebug_master.so) + 70  [0x10ff726f6]  timing.c:0
                    + ! : | 5 xdebug_get_nanotime  (in xdebug_master.so) + 46  [0x10ff726de]  timing.c:173
                    + ! : | 2 xdebug_get_nanotime  (in xdebug_master.so) + 30  [0x10ff726ce]  timing.c:171
                    + ! : 330 xdebug_add_stack_frame  (in xdebug_master.so) + 24,156,...  [0x10ff6a658,0x10ff6a6dc,...]
                    + ! : 180 xdebug_add_stack_frame  (in xdebug_master.so) + 164  [0x10ff6a6e4]
                    + ! : | 180 _platform_bzero$VARIANT$Haswell  (in libsystem_platform.dylib) + 84,89,...  [0x7fff6ef75df4,0x7fff6ef75df9,...]
                    + ! : 69 xdebug_add_stack_frame  (in xdebug_master.so) + 874  [0x10ff6a9aa]
                    + ! : | 30 xdebug_filter_run_tracing  (in xdebug_master.so) + 197,205,...  [0x10ff6c375,0x10ff6c37d,...]  filter.c:165
                    + ! : | 25 xdebug_filter_run_tracing  (in xdebug_master.so) + 0,6,...  [0x10ff6c2b0,0x10ff6c2b6,...]  filter.c:159
                    + ! : | 14 xdebug_filter_run_tracing  (in xdebug_master.so) + 32,18  [0x10ff6c2d0,0x10ff6c2c2]  filter.c:162
                    + ! : 46 xdebug_add_stack_frame  (in xdebug_master.so) + 457  [0x10ff6a809]
                    + ! : | 46 zend_memory_usage  (in php) + 0,27,...  [0x10c75adae,0x10c75adc9,...]
                    + ! : 31 xdebug_add_stack_frame  (in xdebug_master.so) + 891  [0x10ff6a9bb]
                    + ! : | 16 xdebug_coverage_count_line_if_branch_check_active  (in xdebug_master.so) + 0  [0x10ff7b480]  code_coverage.c:941
                    + ! : | 8 xdebug_coverage_count_line_if_branch_check_active  (in xdebug_master.so) + 4  [0x10ff7b484]  code_coverage.c:942
                    + ! : | 7 xdebug_coverage_count_line_if_branch_check_active  (in xdebug_master.so) + 49  [0x10ff7b4b1]  code_coverage.c:945
                    + ! : 6 DYLD-STUB$$xdebug_filter_run_tracing  (in xdebug_master.so) + 0  [0x10ff92848]
                    + ! : 3 DYLD-STUB$$xdebug_get_nanotime  (in xdebug_master.so) + 0  [0x10ff92890]
                    + ! : 2 DYLD-STUB$$__bzero  (in xdebug_master.so) + 0  [0x10ff92374]
                    + ! : 1 DYLD-STUB$$xdebug_build_fname  (in xdebug_master.so) + 0  [0x10ff92704]
                    + ! 1302 xdebug_execute_ex  (in xdebug_master.so) + 1175  [0x10ff6b1b7]
                    + ! : 1157 execute_ex  (in php) + 35  [0x10c7b92d7]
                    + ! : | 344 ZEND_ADD_SPEC_TMPVARCV_TMPVARCV_HANDLER  (in php) + 0,1,...  [0x10c7b9721,0x10c7b9722,...]
                    + ! : | 322 ZEND_EXT_STMT_SPEC_HANDLER  (in php) + 47  [0x10c7e18a3]
                    + ! : | + 264 zend_llist_apply_with_argument  (in php) + 34  [0x10c77087e]
                    + ! : | + ! 52 xdebug_statement_call  (in xdebug_master.so) + 6,55,...  [0x10ff69b76,0x10ff69ba7,...]
                    + ! : | + ! 44 zend_extension_statement_handler  (in php) + 4,20,...  [0x10c800387,0x10c800397,...]
                    + ! : | + ! 25 xdebug_debugger_statement_call  (in xdebug_master.so) + 13,0,...  [0x10ff7e4cd,0x10ff7e4c0,...]  debugger.c:196
                    + ! : | + ! 23 xdebug_debugger_statement_call  (in xdebug_master.so) + 732,718,...  [0x10ff7e79c,0x10ff7e78e,...]  debugger.c:311
                    + ! : | + ! 19 xdebug_debugger_statement_call  (in xdebug_master.so) + 28  [0x10ff7e4dc]  debugger.c:204
                    + ! : | + ! : 11 xdebug_is_debug_connection_active  (in xdebug_master.so) + 0  [0x10ff7d2a0]  com.c:505
                    + ! : | + ! : 8 xdebug_is_debug_connection_active  (in xdebug_master.so) + 11  [0x10ff7d2ab]  com.c:506
                    + ! : | + ! 19 xdebug_debugger_statement_call  (in xdebug_master.so) + 155  [0x10ff7e55b]  debugger.c:220
                    + ! : | + ! : 12 xdebug_is_debug_connection_active  (in xdebug_master.so) + 0,1  [0x10ff7d2a0,0x10ff7d2a1]  com.c:505
                    + ! : | + ! : 7 xdebug_is_debug_connection_active  (in xdebug_master.so) + 11  [0x10ff7d2ab]  com.c:506
                    + ! : | + ! 17 xdebug_debugger_statement_call  (in xdebug_master.so) + 686  [0x10ff7e76e]  debugger.c:308
                    + ! : | + ! : 9 xdebug_is_debug_connection_active  (in xdebug_master.so) + 0  [0x10ff7d2a0]  com.c:505
                    + ! : | + ! : 8 xdebug_is_debug_connection_active  (in xdebug_master.so) + 11  [0x10ff7d2ab]  com.c:506
                    + ! : | + ! 17 xdebug_statement_call  (in xdebug_master.so) + 55  [0x10ff69ba7]
                    + ! : | + ! : 10 xdebug_coverage_count_line_if_active  (in xdebug_master.so) + 11  [0x10ff7b28b]  code_coverage.c:935
                    + ! : | + ! : 6 xdebug_coverage_count_line_if_active  (in xdebug_master.so) + 0  [0x10ff7b280]  code_coverage.c:934
                    + ! : | + ! : 1 xdebug_coverage_count_line_if_active  (in xdebug_master.so) + 38  [0x10ff7b2a6]  code_coverage.c:938
                    + ! : | + ! 14 DYLD-STUB$$xdebug_is_debug_connection_active  (in xdebug_master.so) + 0  [0x10ff92944]
                    + ! : | + ! 10 xdebug_debugger_statement_call  (in xdebug_master.so) + 678  [0x10ff7e766]  debugger.c:0
                    + ! : | + ! 10 xdebug_debugger_statement_call  (in xdebug_master.so) + 35  [0x10ff7e4e3]  debugger.c:210
                    + ! : | + ! 8 DYLD-STUB$$xdebug_coverage_count_line_if_active  (in xdebug_master.so) + 0  [0x10ff9272e]
                    + ! : | + ! 6 xdebug_debugger_statement_call  (in xdebug_master.so) + 23  [0x10ff7e4d7]  debugger.c:204
                    + ! : | + 57 zend_llist_apply_with_argument  (in php) + 8,31,...  [0x10c770864,0x10c77087b,...]
                    + ! : | + 1 zend_extension_statement_handler  (in php) + 17  [0x10c800394]
                    + ! : | 170 ZEND_RECV_SPEC_UNUSED_HANDLER  (in php) + 56,0,...  [0x10c7d53ec,0x10c7d53b4,...]
                    + ! : | 155 zend_leave_helper_SPEC  (in php) + 212,1053,...  [0x10c7fd44f,0x10c7fd798,...]
                    + ! : | 89 ZEND_RETURN_SPEC_TMP_HANDLER  (in php) + 58,0,...  [0x10c7d5270,0x10c7d5236,...]
                    + ! : | 59 ZEND_EXT_STMT_SPEC_HANDLER  (in php) + 51,58,...  [0x10c7e18a7,0x10c7e18ae,...]
                    + ! : | 18 ZEND_EXT_NOP_SPEC_HANDLER  (in php) + 8,1,...  [0x10c7e1930,0x10c7e1929,...]
                    + ! : 145 execute_ex  (in php) + 35,27,...  [0x10c7b92d7,0x10c7b92cf,...]
                    + ! 1295 xdebug_execute_ex  (in xdebug_master.so) + 1351  [0x10ff6b267]
                    + ! : 1194 function_stack_entry_dtor  (in xdebug_master.so) + 27  [0x10ff6b8bb]
                    + ! : | 502 free_tiny  (in libsystem_malloc.dylib) + 479,141,...  [0x7fff6ef3ad9f,0x7fff6ef3ac4d,...]
                    + ! : | 449 free  (in libsystem_malloc.dylib) + 107  [0x7fff6ef36a1c]
                    + ! : | + 402 szone_size  (in libsystem_malloc.dylib) + 45  [0x7fff6ef39385]
                    + ! : | + ! 402 tiny_size  (in libsystem_malloc.dylib) + 313,416,...  [0x7fff6ef3952a,0x7fff6ef39591,...]
                    + ! : | + 47 szone_size  (in libsystem_malloc.dylib) + 0,22,...  [0x7fff6ef39358,0x7fff6ef3936e,...]
                    + ! : | 148 free  (in libsystem_malloc.dylib) + 369,436,...  [0x7fff6ef36b22,0x7fff6ef36b65,...]
                    + ! : | 51 default_zone_free_definite_size  (in libsystem_malloc.dylib) + 49,58,...  [0x7fff6ef36d81,0x7fff6ef36d8a,...]
                    + ! : | 44 szone_free_definite_size  (in libsystem_malloc.dylib) + 57,8,...  [0x7fff6ef396cd,0x7fff6ef3969c,...]
                    + ! : 76 function_stack_entry_dtor  (in xdebug_master.so) + 10,30,...  [0x10ff6b8aa,0x10ff6b8be,...]
                    + ! : 13 free  (in libsystem_malloc.dylib) + 463  [0x7fff6ef36b80]
                    + ! : 12 DYLD-STUB$$free  (in xdebug_master.so) + 0  [0x10ff924e2]
                    + ! 487 xdebug_execute_ex  (in xdebug_master.so) + 1314,1204,...  [0x10ff6b242,0x10ff6b1d4,...]
                    + ! 47 xdebug_execute_ex  (in xdebug_master.so) + 374  [0x10ff6ae96]
                    + ! : 47 _platform_strcmp  (in libsystem_platform.dylib) + 176,213,...  [0x7fff6ef758b0,0x7fff6ef758d5,...]
                    + ! 45 xdebug_execute_ex  (in xdebug_master.so) + 104  [0x10ff6ad88]
                    + ! : 45 _platform_strcmp  (in libsystem_platform.dylib) + 27,7,...  [0x7fff6ef7581b,0x7fff6ef75807,...]
                    + ! 30 xdebug_execute_ex  (in xdebug_master.so) + 63  [0x10ff6ad5f]
                    + ! : 11 xdebug_debugger_bailout_if_no_exec_requested  (in xdebug_master.so) + 11,4  [0x10ff7e2cb,0x10ff7e2c4]  debugger.c:87
                    + ! : 11 xdebug_debugger_bailout_if_no_exec_requested  (in xdebug_master.so) + 42  [0x10ff7e2ea]  debugger.c:92
                    + ! : 8 xdebug_debugger_bailout_if_no_exec_requested  (in xdebug_master.so) + 0  [0x10ff7e2c0]  debugger.c:85
                    + ! 24 DYLD-STUB$$strcmp  (in xdebug_master.so) + 0  [0x10ff92614]
                    + ! 20 xdebug_execute_ex  (in xdebug_master.so) + 1085  [0x10ff6b15d]
                    + ! : 12 xdebug_is_debug_connection_active  (in xdebug_master.so) + 0  [0x10ff7d2a0]  com.c:505
                    + ! : 8 xdebug_is_debug_connection_active  (in xdebug_master.so) + 11,18  [0x10ff7d2ab,0x10ff7d2b2]  com.c:506
                    + ! 11 DYLD-STUB$$xdebug_is_debug_connection_active  (in xdebug_master.so) + 0  [0x10ff92944]
                    + 748 ZEND_EXT_STMT_SPEC_HANDLER  (in php) + 47  [0x10c7e18a3]
                    + ! 597 zend_llist_apply_with_argument  (in php) + 34  [0x10c77087e]
                    + ! : 200 xdebug_statement_call  (in xdebug_master.so) + 37,55,...  [0x10ff69b95,0x10ff69ba7,...]
                    + ! : 75 zend_extension_statement_handler  (in php) + 0,4,...  [0x10c800383,0x10c800387,...]
                    + ! : 64 xdebug_debugger_statement_call  (in xdebug_master.so) + 6,13,...  [0x10ff7e4c6,0x10ff7e4cd,...]  debugger.c:196
                    + ! : 47 xdebug_debugger_statement_call  (in xdebug_master.so) + 725,732,...  [0x10ff7e795,0x10ff7e79c,...]  debugger.c:311
                    + ! : 40 xdebug_debugger_statement_call  (in xdebug_master.so) + 155  [0x10ff7e55b]  debugger.c:220
                    + ! : | 24 xdebug_is_debug_connection_active  (in xdebug_master.so) + 11,19  [0x10ff7d2ab,0x10ff7d2b3]  com.c:506
                    + ! : | 16 xdebug_is_debug_connection_active  (in xdebug_master.so) + 0  [0x10ff7d2a0]  com.c:505
                    + ! : 36 xdebug_debugger_statement_call  (in xdebug_master.so) + 686  [0x10ff7e76e]  debugger.c:308
                    + ! : | 27 xdebug_is_debug_connection_active  (in xdebug_master.so) + 11,19,...  [0x10ff7d2ab,0x10ff7d2b3,...]  com.c:506
                    + ! : | 9 xdebug_is_debug_connection_active  (in xdebug_master.so) + 0  [0x10ff7d2a0]  com.c:505
                    + ! : 32 DYLD-STUB$$xdebug_is_debug_connection_active  (in xdebug_master.so) + 0  [0x10ff92944]
                    + ! : 28 xdebug_statement_call  (in xdebug_master.so) + 55  [0x10ff69ba7]
                    + ! : | 17 xdebug_coverage_count_line_if_active  (in xdebug_master.so) + 0  [0x10ff7b280]  code_coverage.c:934
                    + ! : | 11 xdebug_coverage_count_line_if_active  (in xdebug_master.so) + 11  [0x10ff7b28b]  code_coverage.c:935
                    + ! : 25 xdebug_debugger_statement_call  (in xdebug_master.so) + 28  [0x10ff7e4dc]  debugger.c:204
                    + ! : | 17 xdebug_is_debug_connection_active  (in xdebug_master.so) + 11  [0x10ff7d2ab]  com.c:506
                    + ! : | 8 xdebug_is_debug_connection_active  (in xdebug_master.so) + 0  [0x10ff7d2a0]  com.c:505
                    + ! : 15 xdebug_debugger_statement_call  (in xdebug_master.so) + 678  [0x10ff7e766]  debugger.c:0
                    + ! : 15 xdebug_debugger_statement_call  (in xdebug_master.so) + 35  [0x10ff7e4e3]  debugger.c:210
                    + ! : 13 xdebug_debugger_statement_call  (in xdebug_master.so) + 23,38  [0x10ff7e4d7,0x10ff7e4e6]  debugger.c:204
                    + ! : 7 DYLD-STUB$$xdebug_coverage_count_line_if_active  (in xdebug_master.so) + 0  [0x10ff9272e]
                    + ! 146 zend_llist_apply_with_argument  (in php) + 24,46,...  [0x10c770874,0x10c77088a,...]
                    + ! 5 zend_extension_statement_handler  (in php) + 17  [0x10c800394]
                    + 421 ZEND_INIT_FCALL_SPEC_CONST_HANDLER  (in php) + 0,1,...  [0x10c7d50df,0x10c7d50e0,...]
                    + 340 ZEND_JMPNZ_SPEC_TMPVAR_HANDLER  (in php) + 0,1,...  [0x10c7d0614,0x10c7d0615,...]
                    + 262 ZEND_DO_FCALL_SPEC_RETVAL_UNUSED_HANDLER  (in php) + 190,77,...  [0x10c7d4b21,0x10c7d4ab0,...]
                    + 229 ZEND_SEND_VAR_SPEC_CV_HANDLER  (in php) + 21,0,...  [0x10c7e7855,0x10c7e7840,...]
                    + 164 ZEND_EXT_STMT_SPEC_HANDLER  (in php) + 0,51,...  [0x10c7e1874,0x10c7e18a7,...]
                    + 86 ZEND_IS_SMALLER_SPEC_TMPVARCV_CONST_HANDLER  (in php) + 61,49,...  [0x10c7bf437,0x10c7bf42b,...]
                    + 72 ZEND_POST_INC_SPEC_CV_HANDLER  (in php) + 4,30,...  [0x10c7cfd90,0x10c7cfdaa,...]
                    + 52 ZEND_FREE_SPEC_TMPVAR_HANDLER  (in php) + 4,43,...  [0x10c7d6684,0x10c7d66ab,...]
                    154 execute_ex  (in php) + 27,30,...  [0x10c7b92cf,0x10c7b92d2,...]
```

</details>

You can also see it in this flamegraph, generated form the same sample output: 
[flamegraph.svg.gz](https://github.com/xdebug/xdebug/files/5289005/flamegraph.svg.gz).

Since those two code paths are called very frequently, we can reduce the overhead a lot by skipping them when xdebug is disabled.

To get a sense of the performance impact of this change, I ran this on my macbook (stock PHP 7.4.10, 2,8 GHz i5) with the following configurations:

* Without xdebug loaded
* With stock xdebug (v2.9.7) loaded, and `xdebug.mode=off`
* With current master branch xdebug (v3.0.0-dev, c2294d9) loaded and `xdebug.mode=off`
* With this patch applied and `xdebug.mode=off`

Results:

```
$ hyperfine --warmup 1 \
    'php bench.php' \
    'php -d zend_extension=xdebug.so -d xdebug.mode=off bench.php' \
    'php -d zend_extension=/Users/igor/code/xdebug/modules/xdebug_master.so -d xdebug.mode=off bench.php' \
    'php -d zend_extension=/Users/igor/code/xdebug/modules/xdebug_patched.so -d xdebug.mode=off bench.php'

Benchmark #1: php bench.php
  Time (mean ± σ):      1.951 s ±  0.019 s    [User: 1.907 s, System: 0.021 s]
  Range (min … max):    1.931 s …  1.995 s    10 runs

Benchmark #2: php -d zend_extension=xdebug.so -d xdebug.mode=off bench.php
  Time (mean ± σ):     50.056 s ±  1.219 s    [User: 49.117 s, System: 0.213 s]
  Range (min … max):   48.229 s … 51.927 s    10 runs

Benchmark #3: php -d zend_extension=/Users/igor/code/xdebug/modules/xdebug_master.so -d xdebug.mode=off bench.php
  Time (mean ± σ):     16.932 s ±  0.214 s    [User: 16.621 s, System: 0.082 s]
  Range (min … max):   16.660 s … 17.422 s    10 runs

Benchmark #4: php -d zend_extension=/Users/igor/code/xdebug/modules/xdebug_patched.so -d xdebug.mode=off bench.php
  Time (mean ± σ):      3.671 s ±  0.092 s    [User: 3.573 s, System: 0.032 s]
  Range (min … max):    3.574 s …  3.867 s    10 runs

Summary
  'php bench.php' ran
    1.88 ± 0.05 times faster than 'php -d zend_extension=/Users/igor/code/xdebug/modules/xdebug_patched.so -d xdebug.mode=off bench.php'
    8.68 ± 0.14 times faster than 'php -d zend_extension=/Users/igor/code/xdebug/modules/xdebug_master.so -d xdebug.mode=off bench.php'
   25.66 ± 0.67 times faster than 'php -d zend_extension=xdebug.so -d xdebug.mode=off bench.php'
```

Based on this benchmark, the proposed patch brings the overhead of xdebug on method calls from ~8.5x to ~1.9x.

Now this is maybe a somewhat contrived benchmark measuring the worst case. So I ran the same experiment against the [laravel/framework](https://github.com/laravel/framework) test suite (2ec7738).

Here are the results:

```
Benchmark #1: php vendor/bin/phpunit
  Time (mean ± σ):     15.825 s ±  0.634 s    [User: 9.425 s, System: 1.585 s]
  Range (min … max):   14.924 s … 16.856 s    10 runs

Benchmark #2: php -d zend_extension=xdebug.so -d xdebug.mode=off vendor/bin/phpunit
  Time (mean ± σ):     50.406 s ±  0.886 s    [User: 42.066 s, System: 2.364 s]
  Range (min … max):   49.171 s … 52.055 s    10 runs

Benchmark #3: php -d zend_extension=/Users/igor/code/xdebug/modules/xdebug_master.so -d xdebug.mode=off vendor/bin/phpunit
  Time (mean ± σ):     27.757 s ±  0.890 s    [User: 20.671 s, System: 1.876 s]
  Range (min … max):   26.027 s … 29.077 s    10 runs

Benchmark #4: php -d zend_extension=/Users/igor/code/xdebug/modules/xdebug_patched.so -d xdebug.mode=off vendor/bin/phpunit
  Time (mean ± σ):     16.999 s ±  0.462 s    [User: 10.475 s, System: 1.636 s]
  Range (min … max):   16.399 s … 17.687 s    10 runs

Summary
  'php vendor/bin/phpunit' ran
    1.07 ± 0.05 times faster than 'php -d zend_extension=/Users/igor/code/xdebug/modules/xdebug_patched.so -d xdebug.mode=off vendor/bin/phpunit'
    1.75 ± 0.09 times faster than 'php -d zend_extension=/Users/igor/code/xdebug/modules/xdebug_master.so -d xdebug.mode=off vendor/bin/phpunit'
    3.19 ± 0.14 times faster than 'php -d zend_extension=xdebug.so -d xdebug.mode=off vendor/bin/phpunit'
```

The overhead is reduced from 1.75x to 1.07x, reducing the runtime from 27s to 15s.

Considering xdebug is an extension that a lot of people always have loaded, this patch makes it easier to keep the extension loaded but only _enable_ it on demand.

It could also be extended by making other on-demand mechanisms (the on-demand debugger) cheaper.

Note that this patch _will_ add a little bit of extra overhead when the extension _is_ enabled since we have one extra branch. That said, I was not able to measure a meaningful difference.

Here are the results in case you care:

<details>

```
Benchmark #1: php bench.php
  Time (mean ± σ):      1.943 s ±  0.045 s    [User: 1.908 s, System: 0.018 s]
  Range (min … max):    1.906 s …  2.007 s    10 runs

Benchmark #2: php -d zend_extension=/Users/igor/code/xdebug/modules/xdebug_master.so -d xdebug.mode=develop bench.php
  Time (mean ± σ):     26.159 s ±  1.282 s    [User: 25.707 s, System: 0.122 s]
  Range (min … max):   24.668 s … 28.647 s    10 runs

Benchmark #3: php -d zend_extension=/Users/igor/code/xdebug/modules/xdebug_patched.so -d xdebug.mode=develop bench.php
  Time (mean ± σ):     25.431 s ±  1.164 s    [User: 24.934 s, System: 0.121 s]
  Range (min … max):   24.584 s … 28.588 s    10 runs

Summary
  'php bench.php' ran
   13.09 ± 0.67 times faster than 'php -d zend_extension=/Users/igor/code/xdebug/modules/xdebug_patched.so -d xdebug.mode=develop bench.php'
   13.46 ± 0.73 times faster than 'php -d zend_extension=/Users/igor/code/xdebug/modules/xdebug_master.so -d xdebug.mode=develop bench.php'
```

</details>