### PR TITLE
zend_post_startup_cb() returns a `zend_result` as of PHP 8.0.0

### DIFF
--- a/xdebug.c
+++ b/xdebug.c
@@ -72,7 +72,7 @@
 #if PHP_VERSION_ID >= 80000
 static zend_result (*xdebug_orig_post_startup_cb)(void);
 static zend_result xdebug_post_startup(void);
-#if PHP_VERSION_ID >= 70300
+#elif PHP_VERSION_ID >= 70300
 static int (*xdebug_orig_post_startup_cb)(void);
 static int xdebug_post_startup(void);
 #endif

--- a/xdebug.c
+++ b/xdebug.c
@@ -69,6 +69,9 @@
 #include "profiler/profiler.h"
 #include "tracing/tracing.h"
 
+#if PHP_VERSION_ID >= 80000
+static zend_result (*xdebug_orig_post_startup_cb)(void);
+static zend_result xdebug_post_startup(void);
 #if PHP_VERSION_ID >= 70300
 static int (*xdebug_orig_post_startup_cb)(void);
 static int xdebug_post_startup(void);


### PR DESCRIPTION
At least MSVC complains about that: warning C4133: '=': incompatible
types - from 'zend_result (__cdecl *)(void)' to 'int (__cdecl *)(void)'