### PR TITLE
Declare xdebug_is_output_tty() on Windows as well

### DIFF
--- a/php_xdebug.h
+++ b/php_xdebug.h
@@ -71,9 +71,7 @@ PHP_RSHUTDOWN_FUNCTION(xdebug);
 PHP_MINFO_FUNCTION(xdebug);
 ZEND_MODULE_POST_ZEND_DEACTIVATE_D(xdebug);
 
-#ifndef PHP_WIN32
 int xdebug_is_output_tty();
-#endif
 
 struct xdebug_base_info {
 	unsigned long level;


### PR DESCRIPTION
The implementation is obviously supposed to work on Windows, so we
should also declare the function there.