### PR TITLE
Fixed issue #1902: Compillation failure on AIX

### DIFF
--- a/src/lib/timing.c
+++ b/src/lib/timing.c
@@ -112,7 +112,7 @@ static uint64_t xdebug_get_nanotime_rel(xdebug_nanotime_context *nanotime_contex
 }
 
 // Linux/Unix with clock_gettime
-#elif CLOCK_MONOTONIC
+#elif defined(CLOCK_MONOTONIC)
 static uint64_t xdebug_get_nanotime_rel(xdebug_nanotime_context *nanotime_context)
 {
 	struct timespec ts;
@@ -144,13 +144,13 @@ void xdebug_nanotime_init(void)
 		context.use_rel_time = 1;
 	}
 
-#elif __APPLE__ | CLOCK_MONOTONIC
+#elif __APPLE__ | defined(CLOCK_MONOTONIC)
 	context.use_rel_time = 1;
 #endif
 
 	context.start_abs = xdebug_get_nanotime_abs(&context);
 	context.last_abs = 0;
-#if PHP_WIN32 | __APPLE__ | CLOCK_MONOTONIC
+#if PHP_WIN32 | __APPLE__ | defined(CLOCK_MONOTONIC)
 	context.start_rel = xdebug_get_nanotime_rel(&context);
 	context.last_rel = 0;
 #endif
@@ -165,7 +165,7 @@ uint64_t xdebug_get_nanotime(void)
 
 	context = &XG_BASE(nanotime_context);
 
-#if PHP_WIN32 | __APPLE__ | CLOCK_MONOTONIC
+#if PHP_WIN32 | __APPLE__ | defined(CLOCK_MONOTONIC)
 	/* Relative timing */
 	if (context->use_rel_time) {
 		nanotime = xdebug_get_nanotime_rel(context);

--- a/src/lib/timing.h
+++ b/src/lib/timing.h
@@ -31,7 +31,7 @@ typedef void (WINAPI *WIN_PRECISE_TIME_FUNC)(LPFILETIME);
 typedef struct _xdebug_nanotime_context {
 	uint64_t start_abs;
 	uint64_t last_abs;
-#if PHP_WIN32 | __APPLE__ | CLOCK_MONOTONIC
+#if PHP_WIN32 | __APPLE__ | defined(CLOCK_MONOTONIC)
 	uint64_t start_rel;
 	uint64_t last_rel;
 	int      use_rel_time;


### PR DESCRIPTION
Otherwise, GCC emits the following error:

```
/home/calvin/rpmbuild/BUILD/xdebug-3.0.0/src/lib/timing.h:34:29: error: missing binary operator before token "10"
 if PHP_WIN32 | __APPLE__ | CLOCK_MONOTONIC
                             ^
```

(# omitted because git)