### PR TITLE
Implements #1948: bypass php error log for non-critical messages if an active xdebug log is defined

### DIFF
--- a/src/lib/log.c
+++ b/src/lib/log.c
@@ -122,6 +122,10 @@ static inline void xdebug_php_log(int channel, int log_level, const char *error_
 {
 	xdebug_str formatted_message = XDEBUG_STR_INITIALIZER;
 
+    if (XG_LIB(log_file) && log_level > XLOG_CRIT) {
+        return;
+    }
+
 	if (log_level > XLOG_ERR) {
 		return;
 	}


### PR DESCRIPTION
This is an attempt to implement https://bugs.xdebug.org/view.php?id=1948 by returning early in `src/lib/log.c` in the function `xdebug_php_log `.

It's been a while since I wrote some C code, but I hope this is helpful, I've left it as a draft PR for the moment while I dig into tests etc