### PR TITLE
Fixed issue #1969: Add breakpoint information when a break happens

### DIFF
--- a/src/debugger/handler_dbgp.h
+++ b/src/debugger/handler_dbgp.h
@@ -101,7 +101,7 @@ int xdebug_dbgp_init(xdebug_con *context, int mode);
 int xdebug_dbgp_deinit(xdebug_con *context);
 int xdebug_dbgp_error(xdebug_con *context, int type, char *exception_type, char *message, const char *location, const unsigned int line, xdebug_vector *stack);
 int xdebug_dbgp_break_on_line(xdebug_con *context, xdebug_brk_info *brk, zend_string *filename, int lineno);
-int xdebug_dbgp_breakpoint(xdebug_con *context, xdebug_vector *stack, zend_string *filename, long lineno, int type, char *exception, char *code, const char *message);
+int xdebug_dbgp_breakpoint(xdebug_con *context, xdebug_vector *stack, zend_string *filename, long lineno, int type, char *exception, char *code, const char *message, xdebug_brk_info *brk_info);
 int xdebug_dbgp_resolve_breakpoints(xdebug_con *context, zend_string *filename);
 int xdebug_dbgp_stream_output(const char *string, unsigned int length);
 int xdebug_dbgp_notification(xdebug_con *context, zend_string *filename, long lineno, int type, char *type_string, char *message);

--- a/src/debugger/handlers.h
+++ b/src/debugger/handlers.h
@@ -76,6 +76,7 @@ struct _xdebug_con {
 	xdebug_hash           *exception_breakpoints;
 	xdebug_debug_list      list;
 	int                    do_break;
+	xdebug_brk_info       *pending_breakpoint;
 
 	int                    do_step;
 	int                    do_next;
@@ -88,6 +89,7 @@ struct _xdebug_con {
 	int                    inhibit_notifications;
 
 	int                    resolved_breakpoints;
+	int                    breakpoint_details;
 
 	/* Statistics and diagnostics */
 	char *connected_hostname;
@@ -140,7 +142,7 @@ struct _xdebug_remote_handler {
 
 	/* Breakpoints */
 	int (*break_on_line)(xdebug_con *h, xdebug_brk_info *brk, zend_string *filename, int lineno);
-	int (*remote_breakpoint)(xdebug_con *h, xdebug_vector *stack, zend_string *filename, long lineno, int type, char *exception, char *code, const char *message);
+	int (*remote_breakpoint)(xdebug_con *h, xdebug_vector *stack, zend_string *filename, long lineno, int type, char *exception, char *code, const char *message, xdebug_brk_info *brk_info);
 	int (*resolve_breakpoints)(xdebug_con *h, zend_string *opa);
 
 	/* Output redirection */

--- a/src/lib/log.c
+++ b/src/lib/log.c
@@ -653,6 +653,10 @@ static void print_step_debug_information(void)
 				"<tr><td class=\"e\">Resolved Breakpoints</td><td class=\"v\">%s</td><td class=\"d\">&nbsp;</td></tr>\n",
 				XG_DBG(context).resolved_breakpoints ? "Yes" : "No"
 			);
+			xdebug_info_printf(
+				"<tr><td class=\"e\">Breakpoint Details</td><td class=\"v\">%s</td><td class=\"d\">&nbsp;</td></tr>\n",
+				XG_DBG(context).breakpoint_details ? "Yes" : "No"
+			);
 		}
 	} else {
 		php_info_print_table_colspan_header(2, (char*) "Step Debugging");
@@ -687,6 +691,7 @@ static void print_step_debug_information(void)
 			xdebug_info_printf("Extended Properties => %s\n", options->extended_properties ? "Yes" : "No");
 			xdebug_info_printf("Notifications => %s\n", XG_DBG(context).send_notifications ? "Yes" : "No");
 			xdebug_info_printf("Resolved Breakpoints => %s\n", XG_DBG(context).resolved_breakpoints ? "Yes" : "No");
+			xdebug_info_printf("Breakpoint Details => %s\n", XG_DBG(context).breakpoint_details ? "Yes" : "No");
 		}
 	}
 	php_info_print_table_end();

--- a/tests/debugger/dbgp-breakpoint-call-function.inc
+++ b/tests/debugger/dbgp-breakpoint-call-function.inc
@@ -1,0 +1,14 @@
+<?php
+function breakOnMe()
+{
+	echo "break in the breakOnMe function\n";
+}
+
+breakOnMe();
+
+$array = range( 0, 7 );
+array_reverse( $array );
+
+$array = array_push( $array, 42 );
+array_reverse( $array );
+?>

--- a/tests/debugger/dbgp-breakpoint-call-function.phpt
+++ b/tests/debugger/dbgp-breakpoint-call-function.phpt
@@ -1,0 +1,55 @@
+--TEST--
+DBGP: call breakpoints
+--SKIPIF--
+<?php
+require __DIR__ . '/../utils.inc';
+check_reqs('dbgp');
+?>
+--FILE--
+<?php
+require 'dbgp/dbgpclient.php';
+$filename = dirname(__FILE__) . '/dbgp-breakpoint-call-function.inc';
+
+$commands = array(
+	'feature_set -n breakpoint_details -v 1',
+	'breakpoint_set -t call -m breakOnMe',
+	'breakpoint_set -t call -m array_reverse',
+	'run',
+	'run',
+	'run',
+	'detach',
+);
+
+dbgpRunFile( $filename, $commands );
+?>
+--EXPECT--
+<?xml version="1.0" encoding="iso-8859-1"?>
+<init xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" fileuri="file://dbgp-breakpoint-call-function.inc" language="PHP" xdebug:language_version="" protocol_version="1.0" appid=""><engine version=""><![CDATA[Xdebug]]></engine><author><![CDATA[Derick Rethans]]></author><url><![CDATA[https://xdebug.org]]></url><copyright><![CDATA[Copyright (c) 2002-2099 by Derick Rethans]]></copyright></init>
+
+-> feature_set -i 1 -n breakpoint_details -v 1
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="feature_set" transaction_id="1" feature="breakpoint_details" success="1"></response>
+
+-> breakpoint_set -i 2 -t call -m breakOnMe
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="breakpoint_set" transaction_id="2" id=""></response>
+
+-> breakpoint_set -i 3 -t call -m array_reverse
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="breakpoint_set" transaction_id="3" id=""></response>
+
+-> run -i 4
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="4" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-call-function.inc" lineno="4"></xdebug:message><xdebug:breakpoint type="call" function="breakOnMe" state="enabled" hit_count="1" hit_value="0" id=""></xdebug:breakpoint></response>
+
+-> run -i 5
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="5" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-call-function.inc" lineno="10"></xdebug:message><xdebug:breakpoint type="call" function="array_reverse" state="enabled" hit_count="1" hit_value="0" id=""></xdebug:breakpoint></response>
+
+-> run -i 6
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="6" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-call-function.inc" lineno="13"></xdebug:message><xdebug:breakpoint type="call" function="array_reverse" state="enabled" hit_count="2" hit_value="0" id=""></xdebug:breakpoint></response>
+
+-> detach -i 7
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="detach" transaction_id="7" status="stopping" reason="ok"></response>

--- a/tests/debugger/dbgp-breakpoint-call-method.inc
+++ b/tests/debugger/dbgp-breakpoint-call-method.inc
@@ -1,0 +1,21 @@
+<?php
+class breaking
+{
+	function onMe()
+	{
+		echo "break in the onMe method\n";
+	}
+
+	static function staticMe()
+	{
+		echo "break in the staticMe method\n";
+	}
+}
+
+breaking::staticMe();
+
+$a = new breaking;
+$a->onMe();
+$a->staticMe();
+$a->onMe();
+?>

--- a/tests/debugger/dbgp-breakpoint-call-method.phpt
+++ b/tests/debugger/dbgp-breakpoint-call-method.phpt
@@ -1,0 +1,60 @@
+--TEST--
+DBGP: call breakpoints with method
+--SKIPIF--
+<?php
+require __DIR__ . '/../utils.inc';
+check_reqs('dbgp');
+?>
+--FILE--
+<?php
+require 'dbgp/dbgpclient.php';
+$filename = dirname(__FILE__) . '/dbgp-breakpoint-call-method.inc';
+
+$commands = array(
+	'feature_set -n breakpoint_details -v 1',
+	'breakpoint_set -t call -m breaking::staticMe',
+	'breakpoint_set -t call -m breaking::onMe',
+	'run',
+	'run',
+	'run',
+	'run',
+	'detach',
+);
+
+dbgpRunFile( $filename, $commands );
+?>
+--EXPECT--
+<?xml version="1.0" encoding="iso-8859-1"?>
+<init xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" fileuri="file://dbgp-breakpoint-call-method.inc" language="PHP" xdebug:language_version="" protocol_version="1.0" appid=""><engine version=""><![CDATA[Xdebug]]></engine><author><![CDATA[Derick Rethans]]></author><url><![CDATA[https://xdebug.org]]></url><copyright><![CDATA[Copyright (c) 2002-2099 by Derick Rethans]]></copyright></init>
+
+-> feature_set -i 1 -n breakpoint_details -v 1
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="feature_set" transaction_id="1" feature="breakpoint_details" success="1"></response>
+
+-> breakpoint_set -i 2 -t call -m breaking::staticMe
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="breakpoint_set" transaction_id="2" id=""></response>
+
+-> breakpoint_set -i 3 -t call -m breaking::onMe
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="breakpoint_set" transaction_id="3" id=""></response>
+
+-> run -i 4
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="4" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-call-method.inc" lineno="11"></xdebug:message><xdebug:breakpoint type="call" function="breaking::staticMe" state="enabled" hit_count="1" hit_value="0" id=""></xdebug:breakpoint></response>
+
+-> run -i 5
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="5" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-call-method.inc" lineno="6"></xdebug:message><xdebug:breakpoint type="call" function="breaking::onMe" state="enabled" hit_count="1" hit_value="0" id=""></xdebug:breakpoint></response>
+
+-> run -i 6
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="6" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-call-method.inc" lineno="11"></xdebug:message><xdebug:breakpoint type="call" function="breaking::staticMe" state="enabled" hit_count="2" hit_value="0" id=""></xdebug:breakpoint></response>
+
+-> run -i 7
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="7" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-call-method.inc" lineno="6"></xdebug:message><xdebug:breakpoint type="call" function="breaking::onMe" state="enabled" hit_count="2" hit_value="0" id=""></xdebug:breakpoint></response>
+
+-> detach -i 8
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="detach" transaction_id="8" status="stopping" reason="ok"></response>

--- a/tests/debugger/dbgp-breakpoint-error.phpt
+++ b/tests/debugger/dbgp-breakpoint-error.phpt
@@ -11,6 +11,7 @@ require 'dbgp/dbgpclient.php';
 $filename = dirname(__FILE__) . '/dbgp-breakpoint-error.inc';
 
 $commands = array(
+	'feature_set -n breakpoint_details -v 1',
 	'step_into',
 	'breakpoint_set -t exception -x *',
 	'run',
@@ -24,22 +25,26 @@ dbgpRunFile( $filename, $commands );
 <?xml version="1.0" encoding="iso-8859-1"?>
 <init xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" fileuri="file://dbgp-breakpoint-error.inc" language="PHP" xdebug:language_version="" protocol_version="1.0" appid=""><engine version=""><![CDATA[Xdebug]]></engine><author><![CDATA[Derick Rethans]]></author><url><![CDATA[https://xdebug.org]]></url><copyright><![CDATA[Copyright (c) 2002-2099 by Derick Rethans]]></copyright></init>
 
--> step_into -i 1
+-> feature_set -i 1 -n breakpoint_details -v 1
 <?xml version="1.0" encoding="iso-8859-1"?>
-<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="step_into" transaction_id="1" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-error.inc" lineno="2"></xdebug:message></response>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="feature_set" transaction_id="1" feature="breakpoint_details" success="1"></response>
 
--> breakpoint_set -i 2 -t exception -x *
+-> step_into -i 2
 <?xml version="1.0" encoding="iso-8859-1"?>
-<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="breakpoint_set" transaction_id="2" id=""></response>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="step_into" transaction_id="2" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-error.inc" lineno="2"></xdebug:message></response>
 
--> run -i 3
+-> breakpoint_set -i 3 -t exception -x *
 <?xml version="1.0" encoding="iso-8859-1"?>
-<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="3" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-error.inc" lineno="4" exception="Notice" code="1024"><![CDATA[FOO]]></xdebug:message></response>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="breakpoint_set" transaction_id="3" id=""></response>
 
 -> run -i 4
 <?xml version="1.0" encoding="iso-8859-1"?>
-<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="4" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-error.inc" lineno="10" exception="FooException"><![CDATA[testing foo exception]]></xdebug:message></response>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="4" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-error.inc" lineno="4" exception="Notice" code="1024"><![CDATA[FOO]]></xdebug:message><xdebug:breakpoint type="exception" exception="*" state="enabled" hit_count="1" hit_value="0" id=""></xdebug:breakpoint></response>
 
--> detach -i 5
+-> run -i 5
 <?xml version="1.0" encoding="iso-8859-1"?>
-<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="detach" transaction_id="5" status="stopping" reason="ok"></response>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="5" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-error.inc" lineno="10" exception="FooException"><![CDATA[testing foo exception]]></xdebug:message><xdebug:breakpoint type="exception" exception="*" state="enabled" hit_count="2" hit_value="0" id=""></xdebug:breakpoint></response>
+
+-> detach -i 6
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="detach" transaction_id="6" status="stopping" reason="ok"></response>

--- a/tests/debugger/dbgp-breakpoint-line-with-condition.inc
+++ b/tests/debugger/dbgp-breakpoint-line-with-condition.inc
@@ -1,0 +1,10 @@
+<?php
+function breakWithCondition(int $chance)
+{
+	echo "Chance = {$chance}\n";
+}
+
+breakWithCondition(1);
+breakWithCondition(42);
+breakWithCondition(100);
+?>

--- a/tests/debugger/dbgp-breakpoint-line-with-condition.phpt
+++ b/tests/debugger/dbgp-breakpoint-line-with-condition.phpt
@@ -1,0 +1,55 @@
+--TEST--
+DBGP: line breakpoint
+--SKIPIF--
+<?php
+require __DIR__ . '/../utils.inc';
+check_reqs('dbgp');
+?>
+--FILE--
+<?php
+require 'dbgp/dbgpclient.php';
+$filename = dirname(__FILE__) . '/dbgp-breakpoint-line-with-condition.inc';
+
+$commands = array(
+	'feature_set -n breakpoint_details -v 1',
+	'step_into',
+	'breakpoint_set -t conditional -n 4 -- ' . base64_encode('$chance > 40'),
+	'run',
+	'run',
+	'step_into',
+	'detach',
+);
+
+dbgpRunFile( $filename, $commands );
+?>
+--EXPECTF--
+<?xml version="1.0" encoding="iso-8859-1"?>
+<init xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" fileuri="file://dbgp-breakpoint-line-with-condition.inc" language="PHP" xdebug:language_version="" protocol_version="1.0" appid=""><engine version=""><![CDATA[Xdebug]]></engine><author><![CDATA[Derick Rethans]]></author><url><![CDATA[https://xdebug.org]]></url><copyright><![CDATA[Copyright (c) 2002-2099 by Derick Rethans]]></copyright></init>
+
+-> feature_set -i 1 -n breakpoint_details -v 1
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="feature_set" transaction_id="1" feature="breakpoint_details" success="1"></response>
+
+-> step_into -i 2
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="step_into" transaction_id="2" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-line-with-condition.inc" lineno="%r(2|7)%r"></xdebug:message></response>
+
+-> breakpoint_set -i 3 -t conditional -n 4 -- JGNoYW5jZSA+IDQw
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="breakpoint_set" transaction_id="3" id=""></response>
+
+-> run -i 4
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="4" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-line-with-condition.inc" lineno="4"></xdebug:message><xdebug:breakpoint type="conditional" filename="file://dbgp-breakpoint-line-with-condition.inc" lineno="4" state="enabled" hit_count="1" hit_value="0" id=""><expression encoding="base64"><![CDATA[JGNoYW5jZSA+IDQw]]></expression></xdebug:breakpoint></response>
+
+-> run -i 5
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="5" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-line-with-condition.inc" lineno="4"></xdebug:message><xdebug:breakpoint type="conditional" filename="file://dbgp-breakpoint-line-with-condition.inc" lineno="4" state="enabled" hit_count="2" hit_value="0" id=""><expression encoding="base64"><![CDATA[JGNoYW5jZSA+IDQw]]></expression></xdebug:breakpoint></response>
+
+-> step_into -i 6
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="step_into" transaction_id="6" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-line-with-condition.inc" lineno="5"></xdebug:message></response>
+
+-> detach -i 7
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="detach" transaction_id="7" status="stopping" reason="ok"></response>

--- a/tests/debugger/dbgp-breakpoint-line.inc
+++ b/tests/debugger/dbgp-breakpoint-line.inc
@@ -1,0 +1,4 @@
+<?php
+define("YES", M_PI); $NO = 42;
+echo "hi\n";
+?>

--- a/tests/debugger/dbgp-breakpoint-line.phpt
+++ b/tests/debugger/dbgp-breakpoint-line.phpt
@@ -1,0 +1,45 @@
+--TEST--
+DBGP: line breakpoint
+--SKIPIF--
+<?php
+require __DIR__ . '/../utils.inc';
+check_reqs('dbgp');
+?>
+--FILE--
+<?php
+require 'dbgp/dbgpclient.php';
+$filename = dirname(__FILE__) . '/dbgp-breakpoint-line.inc';
+
+$commands = array(
+	'feature_set -n breakpoint_details -v 1',
+	'step_into',
+	'breakpoint_set -t line -n 3',
+	'run',
+	'detach',
+);
+
+dbgpRunFile( $filename, $commands );
+?>
+--EXPECT--
+<?xml version="1.0" encoding="iso-8859-1"?>
+<init xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" fileuri="file://dbgp-breakpoint-line.inc" language="PHP" xdebug:language_version="" protocol_version="1.0" appid=""><engine version=""><![CDATA[Xdebug]]></engine><author><![CDATA[Derick Rethans]]></author><url><![CDATA[https://xdebug.org]]></url><copyright><![CDATA[Copyright (c) 2002-2099 by Derick Rethans]]></copyright></init>
+
+-> feature_set -i 1 -n breakpoint_details -v 1
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="feature_set" transaction_id="1" feature="breakpoint_details" success="1"></response>
+
+-> step_into -i 2
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="step_into" transaction_id="2" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-line.inc" lineno="2"></xdebug:message></response>
+
+-> breakpoint_set -i 3 -t line -n 3
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="breakpoint_set" transaction_id="3" id=""></response>
+
+-> run -i 4
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="4" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-line.inc" lineno="3"></xdebug:message><xdebug:breakpoint type="line" filename="file://dbgp-breakpoint-line.inc" lineno="3" state="enabled" hit_count="1" hit_value="0" id=""></xdebug:breakpoint></response>
+
+-> detach -i 5
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="detach" transaction_id="5" status="stopping" reason="ok"></response>

--- a/tests/debugger/dbgp-breakpoint-return-function.phpt
+++ b/tests/debugger/dbgp-breakpoint-return-function.phpt
@@ -1,0 +1,55 @@
+--TEST--
+DBGP: return breakpoints
+--SKIPIF--
+<?php
+require __DIR__ . '/../utils.inc';
+check_reqs('dbgp');
+?>
+--FILE--
+<?php
+require 'dbgp/dbgpclient.php';
+$filename = dirname(__FILE__) . '/dbgp-breakpoint-call-function.inc';
+
+$commands = array(
+	'feature_set -n breakpoint_details -v 1',
+	'breakpoint_set -t return -m breakOnMe',
+	'breakpoint_set -t return -m array_reverse',
+	'run',
+	'run',
+	'run',
+	'detach',
+);
+
+dbgpRunFile( $filename, $commands );
+?>
+--EXPECT--
+<?xml version="1.0" encoding="iso-8859-1"?>
+<init xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" fileuri="file://dbgp-breakpoint-call-function.inc" language="PHP" xdebug:language_version="" protocol_version="1.0" appid=""><engine version=""><![CDATA[Xdebug]]></engine><author><![CDATA[Derick Rethans]]></author><url><![CDATA[https://xdebug.org]]></url><copyright><![CDATA[Copyright (c) 2002-2099 by Derick Rethans]]></copyright></init>
+
+-> feature_set -i 1 -n breakpoint_details -v 1
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="feature_set" transaction_id="1" feature="breakpoint_details" success="1"></response>
+
+-> breakpoint_set -i 2 -t return -m breakOnMe
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="breakpoint_set" transaction_id="2" id=""></response>
+
+-> breakpoint_set -i 3 -t return -m array_reverse
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="breakpoint_set" transaction_id="3" id=""></response>
+
+-> run -i 4
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="4" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-call-function.inc" lineno="7"></xdebug:message><xdebug:breakpoint type="return" function="breakOnMe" state="enabled" hit_count="1" hit_value="0" id=""></xdebug:breakpoint></response>
+
+-> run -i 5
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="5" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-call-function.inc" lineno="10"></xdebug:message><xdebug:breakpoint type="return" function="array_reverse" state="enabled" hit_count="1" hit_value="0" id=""></xdebug:breakpoint></response>
+
+-> run -i 6
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="6" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-call-function.inc" lineno="13"></xdebug:message><xdebug:breakpoint type="return" function="array_reverse" state="enabled" hit_count="2" hit_value="0" id=""></xdebug:breakpoint></response>
+
+-> detach -i 7
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="detach" transaction_id="7" status="stopping" reason="ok"></response>

--- a/tests/debugger/dbgp-breakpoint-return-method.phpt
+++ b/tests/debugger/dbgp-breakpoint-return-method.phpt
@@ -1,0 +1,60 @@
+--TEST--
+DBGP: return breakpoints with method
+--SKIPIF--
+<?php
+require __DIR__ . '/../utils.inc';
+check_reqs('dbgp');
+?>
+--FILE--
+<?php
+require 'dbgp/dbgpclient.php';
+$filename = dirname(__FILE__) . '/dbgp-breakpoint-call-method.inc';
+
+$commands = array(
+	'feature_set -n breakpoint_details -v 1',
+	'breakpoint_set -t return -m breaking::staticMe',
+	'breakpoint_set -t return -m breaking::onMe',
+	'run',
+	'run',
+	'run',
+	'run',
+	'detach',
+);
+
+dbgpRunFile( $filename, $commands );
+?>
+--EXPECT--
+<?xml version="1.0" encoding="iso-8859-1"?>
+<init xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" fileuri="file://dbgp-breakpoint-call-method.inc" language="PHP" xdebug:language_version="" protocol_version="1.0" appid=""><engine version=""><![CDATA[Xdebug]]></engine><author><![CDATA[Derick Rethans]]></author><url><![CDATA[https://xdebug.org]]></url><copyright><![CDATA[Copyright (c) 2002-2099 by Derick Rethans]]></copyright></init>
+
+-> feature_set -i 1 -n breakpoint_details -v 1
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="feature_set" transaction_id="1" feature="breakpoint_details" success="1"></response>
+
+-> breakpoint_set -i 2 -t return -m breaking::staticMe
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="breakpoint_set" transaction_id="2" id=""></response>
+
+-> breakpoint_set -i 3 -t return -m breaking::onMe
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="breakpoint_set" transaction_id="3" id=""></response>
+
+-> run -i 4
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="4" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-call-method.inc" lineno="15"></xdebug:message><xdebug:breakpoint type="return" function="breaking::staticMe" state="enabled" hit_count="1" hit_value="0" id=""></xdebug:breakpoint></response>
+
+-> run -i 5
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="5" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-call-method.inc" lineno="18"></xdebug:message><xdebug:breakpoint type="return" function="breaking::onMe" state="enabled" hit_count="1" hit_value="0" id=""></xdebug:breakpoint></response>
+
+-> run -i 6
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="6" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-call-method.inc" lineno="19"></xdebug:message><xdebug:breakpoint type="return" function="breaking::staticMe" state="enabled" hit_count="2" hit_value="0" id=""></xdebug:breakpoint></response>
+
+-> run -i 7
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="7" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-call-method.inc" lineno="20"></xdebug:message><xdebug:breakpoint type="return" function="breaking::onMe" state="enabled" hit_count="2" hit_value="0" id=""></xdebug:breakpoint></response>
+
+-> detach -i 8
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="detach" transaction_id="8" status="stopping" reason="ok"></response>

--- a/tests/debugger/dbgp-feature-breakpoint-details.phpt
+++ b/tests/debugger/dbgp-feature-breakpoint-details.phpt
@@ -1,0 +1,40 @@
+--TEST--
+DBGP: call breakpoints with method
+--SKIPIF--
+<?php
+require __DIR__ . '/../utils.inc';
+check_reqs('dbgp');
+?>
+--FILE--
+<?php
+require 'dbgp/dbgpclient.php';
+$filename = dirname(__FILE__) . '/dbgp-breakpoint-call-method.inc';
+
+$commands = array(
+	'feature_get -n breakpoint_details',
+	'feature_set -n breakpoint_details -v 1',
+	'feature_get -n breakpoint_details',
+	'detach',
+);
+
+dbgpRunFile( $filename, $commands );
+?>
+--EXPECT--
+<?xml version="1.0" encoding="iso-8859-1"?>
+<init xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" fileuri="file://dbgp-breakpoint-call-method.inc" language="PHP" xdebug:language_version="" protocol_version="1.0" appid=""><engine version=""><![CDATA[Xdebug]]></engine><author><![CDATA[Derick Rethans]]></author><url><![CDATA[https://xdebug.org]]></url><copyright><![CDATA[Copyright (c) 2002-2099 by Derick Rethans]]></copyright></init>
+
+-> feature_get -i 1 -n breakpoint_details
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="feature_get" transaction_id="1" feature_name="breakpoint_details" supported="1"><![CDATA[0]]></response>
+
+-> feature_set -i 2 -n breakpoint_details -v 1
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="feature_set" transaction_id="2" feature="breakpoint_details" success="1"></response>
+
+-> feature_get -i 3 -n breakpoint_details
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="feature_get" transaction_id="3" feature_name="breakpoint_details" supported="1"><![CDATA[1]]></response>
+
+-> detach -i 4
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="detach" transaction_id="4" status="stopping" reason="ok"></response>


### PR DESCRIPTION
The breakpoint information will only be included when you enable the
'breakpoint_details' feature through the 'feature_set' DBGp command.