### PR TITLE
Tweak 'breakpoint_resolved' feature to use 'breakpoint' instead of 'xdebug:breakpoint' sub-element

### DIFF
--- a/src/debugger/handler_dbgp.c
+++ b/src/debugger/handler_dbgp.c
@@ -2641,7 +2641,7 @@ int xdebug_dbgp_breakpoint(xdebug_con *context, xdebug_vector *stack, zend_strin
 	xdebug_xml_add_child(response, error_container);
 
 	if (XG_DBG(context).breakpoint_details && brk_info) {
-		xdebug_xml_node *breakpoint_node = xdebug_xml_node_init("xdebug:breakpoint");
+		xdebug_xml_node *breakpoint_node = xdebug_xml_node_init("breakpoint");
 		breakpoint_brk_info_add(breakpoint_node, brk_info);
 		xdebug_xml_add_child(response, breakpoint_node);
 	}

--- a/tests/debugger/dbgp-breakpoint-call-function.phpt
+++ b/tests/debugger/dbgp-breakpoint-call-function.phpt
@@ -40,15 +40,15 @@ dbgpRunFile( $filename, $commands );
 
 -> run -i 4
 <?xml version="1.0" encoding="iso-8859-1"?>
-<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="4" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-call-function.inc" lineno="4"></xdebug:message><xdebug:breakpoint type="call" function="breakOnMe" state="enabled" hit_count="1" hit_value="0" id=""></xdebug:breakpoint></response>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="4" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-call-function.inc" lineno="4"></xdebug:message><breakpoint type="call" function="breakOnMe" state="enabled" hit_count="1" hit_value="0" id=""></breakpoint></response>
 
 -> run -i 5
 <?xml version="1.0" encoding="iso-8859-1"?>
-<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="5" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-call-function.inc" lineno="10"></xdebug:message><xdebug:breakpoint type="call" function="array_reverse" state="enabled" hit_count="1" hit_value="0" id=""></xdebug:breakpoint></response>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="5" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-call-function.inc" lineno="10"></xdebug:message><breakpoint type="call" function="array_reverse" state="enabled" hit_count="1" hit_value="0" id=""></breakpoint></response>
 
 -> run -i 6
 <?xml version="1.0" encoding="iso-8859-1"?>
-<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="6" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-call-function.inc" lineno="13"></xdebug:message><xdebug:breakpoint type="call" function="array_reverse" state="enabled" hit_count="2" hit_value="0" id=""></xdebug:breakpoint></response>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="6" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-call-function.inc" lineno="13"></xdebug:message><breakpoint type="call" function="array_reverse" state="enabled" hit_count="2" hit_value="0" id=""></breakpoint></response>
 
 -> detach -i 7
 <?xml version="1.0" encoding="iso-8859-1"?>

--- a/tests/debugger/dbgp-breakpoint-call-method.phpt
+++ b/tests/debugger/dbgp-breakpoint-call-method.phpt
@@ -41,19 +41,19 @@ dbgpRunFile( $filename, $commands );
 
 -> run -i 4
 <?xml version="1.0" encoding="iso-8859-1"?>
-<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="4" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-call-method.inc" lineno="11"></xdebug:message><xdebug:breakpoint type="call" function="breaking::staticMe" state="enabled" hit_count="1" hit_value="0" id=""></xdebug:breakpoint></response>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="4" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-call-method.inc" lineno="11"></xdebug:message><breakpoint type="call" function="breaking::staticMe" state="enabled" hit_count="1" hit_value="0" id=""></breakpoint></response>
 
 -> run -i 5
 <?xml version="1.0" encoding="iso-8859-1"?>
-<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="5" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-call-method.inc" lineno="6"></xdebug:message><xdebug:breakpoint type="call" function="breaking::onMe" state="enabled" hit_count="1" hit_value="0" id=""></xdebug:breakpoint></response>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="5" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-call-method.inc" lineno="6"></xdebug:message><breakpoint type="call" function="breaking::onMe" state="enabled" hit_count="1" hit_value="0" id=""></breakpoint></response>
 
 -> run -i 6
 <?xml version="1.0" encoding="iso-8859-1"?>
-<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="6" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-call-method.inc" lineno="11"></xdebug:message><xdebug:breakpoint type="call" function="breaking::staticMe" state="enabled" hit_count="2" hit_value="0" id=""></xdebug:breakpoint></response>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="6" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-call-method.inc" lineno="11"></xdebug:message><breakpoint type="call" function="breaking::staticMe" state="enabled" hit_count="2" hit_value="0" id=""></breakpoint></response>
 
 -> run -i 7
 <?xml version="1.0" encoding="iso-8859-1"?>
-<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="7" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-call-method.inc" lineno="6"></xdebug:message><xdebug:breakpoint type="call" function="breaking::onMe" state="enabled" hit_count="2" hit_value="0" id=""></xdebug:breakpoint></response>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="7" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-call-method.inc" lineno="6"></xdebug:message><breakpoint type="call" function="breaking::onMe" state="enabled" hit_count="2" hit_value="0" id=""></breakpoint></response>
 
 -> detach -i 8
 <?xml version="1.0" encoding="iso-8859-1"?>

--- a/tests/debugger/dbgp-breakpoint-error.phpt
+++ b/tests/debugger/dbgp-breakpoint-error.phpt
@@ -39,11 +39,11 @@ dbgpRunFile( $filename, $commands );
 
 -> run -i 4
 <?xml version="1.0" encoding="iso-8859-1"?>
-<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="4" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-error.inc" lineno="4" exception="Notice" code="1024"><![CDATA[FOO]]></xdebug:message><xdebug:breakpoint type="exception" exception="*" state="enabled" hit_count="1" hit_value="0" id=""></xdebug:breakpoint></response>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="4" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-error.inc" lineno="4" exception="Notice" code="1024"><![CDATA[FOO]]></xdebug:message><breakpoint type="exception" exception="*" state="enabled" hit_count="1" hit_value="0" id=""></breakpoint></response>
 
 -> run -i 5
 <?xml version="1.0" encoding="iso-8859-1"?>
-<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="5" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-error.inc" lineno="10" exception="FooException"><![CDATA[testing foo exception]]></xdebug:message><xdebug:breakpoint type="exception" exception="*" state="enabled" hit_count="2" hit_value="0" id=""></xdebug:breakpoint></response>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="5" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-error.inc" lineno="10" exception="FooException"><![CDATA[testing foo exception]]></xdebug:message><breakpoint type="exception" exception="*" state="enabled" hit_count="2" hit_value="0" id=""></breakpoint></response>
 
 -> detach -i 6
 <?xml version="1.0" encoding="iso-8859-1"?>

--- a/tests/debugger/dbgp-breakpoint-line-with-condition.phpt
+++ b/tests/debugger/dbgp-breakpoint-line-with-condition.phpt
@@ -40,11 +40,11 @@ dbgpRunFile( $filename, $commands );
 
 -> run -i 4
 <?xml version="1.0" encoding="iso-8859-1"?>
-<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="4" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-line-with-condition.inc" lineno="4"></xdebug:message><xdebug:breakpoint type="conditional" filename="file://dbgp-breakpoint-line-with-condition.inc" lineno="4" state="enabled" hit_count="1" hit_value="0" id=""><expression encoding="base64"><![CDATA[JGNoYW5jZSA+IDQw]]></expression></xdebug:breakpoint></response>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="4" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-line-with-condition.inc" lineno="4"></xdebug:message><breakpoint type="conditional" filename="file://dbgp-breakpoint-line-with-condition.inc" lineno="4" state="enabled" hit_count="1" hit_value="0" id=""><expression encoding="base64"><![CDATA[JGNoYW5jZSA+IDQw]]></expression></breakpoint></response>
 
 -> run -i 5
 <?xml version="1.0" encoding="iso-8859-1"?>
-<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="5" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-line-with-condition.inc" lineno="4"></xdebug:message><xdebug:breakpoint type="conditional" filename="file://dbgp-breakpoint-line-with-condition.inc" lineno="4" state="enabled" hit_count="2" hit_value="0" id=""><expression encoding="base64"><![CDATA[JGNoYW5jZSA+IDQw]]></expression></xdebug:breakpoint></response>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="5" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-line-with-condition.inc" lineno="4"></xdebug:message><breakpoint type="conditional" filename="file://dbgp-breakpoint-line-with-condition.inc" lineno="4" state="enabled" hit_count="2" hit_value="0" id=""><expression encoding="base64"><![CDATA[JGNoYW5jZSA+IDQw]]></expression></breakpoint></response>
 
 -> step_into -i 6
 <?xml version="1.0" encoding="iso-8859-1"?>

--- a/tests/debugger/dbgp-breakpoint-line.phpt
+++ b/tests/debugger/dbgp-breakpoint-line.phpt
@@ -38,7 +38,7 @@ dbgpRunFile( $filename, $commands );
 
 -> run -i 4
 <?xml version="1.0" encoding="iso-8859-1"?>
-<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="4" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-line.inc" lineno="3"></xdebug:message><xdebug:breakpoint type="line" filename="file://dbgp-breakpoint-line.inc" lineno="3" state="enabled" hit_count="1" hit_value="0" id=""></xdebug:breakpoint></response>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="4" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-line.inc" lineno="3"></xdebug:message><breakpoint type="line" filename="file://dbgp-breakpoint-line.inc" lineno="3" state="enabled" hit_count="1" hit_value="0" id=""></breakpoint></response>
 
 -> detach -i 5
 <?xml version="1.0" encoding="iso-8859-1"?>

--- a/tests/debugger/dbgp-breakpoint-return-function.phpt
+++ b/tests/debugger/dbgp-breakpoint-return-function.phpt
@@ -40,15 +40,15 @@ dbgpRunFile( $filename, $commands );
 
 -> run -i 4
 <?xml version="1.0" encoding="iso-8859-1"?>
-<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="4" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-call-function.inc" lineno="7"></xdebug:message><xdebug:breakpoint type="return" function="breakOnMe" state="enabled" hit_count="1" hit_value="0" id=""></xdebug:breakpoint></response>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="4" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-call-function.inc" lineno="7"></xdebug:message><breakpoint type="return" function="breakOnMe" state="enabled" hit_count="1" hit_value="0" id=""></breakpoint></response>
 
 -> run -i 5
 <?xml version="1.0" encoding="iso-8859-1"?>
-<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="5" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-call-function.inc" lineno="10"></xdebug:message><xdebug:breakpoint type="return" function="array_reverse" state="enabled" hit_count="1" hit_value="0" id=""></xdebug:breakpoint></response>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="5" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-call-function.inc" lineno="10"></xdebug:message><breakpoint type="return" function="array_reverse" state="enabled" hit_count="1" hit_value="0" id=""></breakpoint></response>
 
 -> run -i 6
 <?xml version="1.0" encoding="iso-8859-1"?>
-<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="6" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-call-function.inc" lineno="13"></xdebug:message><xdebug:breakpoint type="return" function="array_reverse" state="enabled" hit_count="2" hit_value="0" id=""></xdebug:breakpoint></response>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="6" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-call-function.inc" lineno="13"></xdebug:message><breakpoint type="return" function="array_reverse" state="enabled" hit_count="2" hit_value="0" id=""></breakpoint></response>
 
 -> detach -i 7
 <?xml version="1.0" encoding="iso-8859-1"?>

--- a/tests/debugger/dbgp-breakpoint-return-method.phpt
+++ b/tests/debugger/dbgp-breakpoint-return-method.phpt
@@ -41,19 +41,19 @@ dbgpRunFile( $filename, $commands );
 
 -> run -i 4
 <?xml version="1.0" encoding="iso-8859-1"?>
-<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="4" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-call-method.inc" lineno="15"></xdebug:message><xdebug:breakpoint type="return" function="breaking::staticMe" state="enabled" hit_count="1" hit_value="0" id=""></xdebug:breakpoint></response>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="4" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-call-method.inc" lineno="15"></xdebug:message><breakpoint type="return" function="breaking::staticMe" state="enabled" hit_count="1" hit_value="0" id=""></breakpoint></response>
 
 -> run -i 5
 <?xml version="1.0" encoding="iso-8859-1"?>
-<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="5" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-call-method.inc" lineno="18"></xdebug:message><xdebug:breakpoint type="return" function="breaking::onMe" state="enabled" hit_count="1" hit_value="0" id=""></xdebug:breakpoint></response>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="5" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-call-method.inc" lineno="18"></xdebug:message><breakpoint type="return" function="breaking::onMe" state="enabled" hit_count="1" hit_value="0" id=""></breakpoint></response>
 
 -> run -i 6
 <?xml version="1.0" encoding="iso-8859-1"?>
-<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="6" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-call-method.inc" lineno="19"></xdebug:message><xdebug:breakpoint type="return" function="breaking::staticMe" state="enabled" hit_count="2" hit_value="0" id=""></xdebug:breakpoint></response>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="6" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-call-method.inc" lineno="19"></xdebug:message><breakpoint type="return" function="breaking::staticMe" state="enabled" hit_count="2" hit_value="0" id=""></breakpoint></response>
 
 -> run -i 7
 <?xml version="1.0" encoding="iso-8859-1"?>
-<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="7" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-call-method.inc" lineno="20"></xdebug:message><xdebug:breakpoint type="return" function="breaking::onMe" state="enabled" hit_count="2" hit_value="0" id=""></xdebug:breakpoint></response>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="7" status="break" reason="ok"><xdebug:message filename="file://dbgp-breakpoint-call-method.inc" lineno="20"></xdebug:message><breakpoint type="return" function="breaking::onMe" state="enabled" hit_count="2" hit_value="0" id=""></breakpoint></response>
 
 -> detach -i 8
 <?xml version="1.0" encoding="iso-8859-1"?>


### PR DESCRIPTION
I'm tweaking the name slightly. /cc @zobo @logancollins