### PR TITLE
Fix warnings on macOS

### DIFF
--- a/src/gcstats/gc_stats.c
+++ b/src/gcstats/gc_stats.c
@@ -26,11 +26,7 @@
 #include "lib/log.h"
 
 /* Set correct int format to use */
-#if SIZEOF_ZEND_LONG == 4
-# define XDEBUG_GCINT_FMT "d"
-#else
-# define XDEBUG_GCINT_FMT "ld"
-#endif
+#define XDEBUG_GCINT_FMT ZEND_LONG_FMT_SPEC
 
 ZEND_EXTERN_MODULE_GLOBALS(xdebug)
 

--- a/xdebug.c
+++ b/xdebug.c
@@ -143,11 +143,11 @@ static PHP_INI_MH(OnUpdateSession)
 
 static PHP_INI_MH(OnUpdateMode)
 {
-	if (!new_value || !new_value->val) {
+	if (!new_value) {
 		return FAILURE;
 	}
 
-	if (!xdebug_lib_set_mode(new_value->val)) {
+	if (!xdebug_lib_set_mode(ZSTR_VAL(new_value))) {
 		return FAILURE;
 	}
 
@@ -156,11 +156,11 @@ static PHP_INI_MH(OnUpdateMode)
 
 static PHP_INI_MH(OnUpdateStartWithRequest)
 {
-	if (!new_value || !new_value->val) {
+	if (!new_value) {
 		return FAILURE;
 	}
 
-	if (!xdebug_lib_set_start_with_request(new_value->val)) {
+	if (!xdebug_lib_set_start_with_request(ZSTR_VAL(new_value))) {
 		return FAILURE;
 	}
 
@@ -169,11 +169,11 @@ static PHP_INI_MH(OnUpdateStartWithRequest)
 
 static PHP_INI_MH(OnUpdateStartUponError)
 {
-	if (!new_value || !new_value->val) {
+	if (!new_value) {
 		return FAILURE;
 	}
 
-	if (!xdebug_lib_set_start_upon_error(new_value->val)) {
+	if (!xdebug_lib_set_start_upon_error(ZSTR_VAL(new_value))) {
 		return FAILURE;
 	}
 
@@ -185,7 +185,7 @@ static PHP_INI_MH(OnUpdateRemovedSetting)
 	if (! (EG(error_reporting) & E_DEPRECATED)) {
 		return SUCCESS;
 	}
-	if (new_value && new_value->val && strlen(new_value->val) > 0 && strncmp("This setting", new_value->val, 11) != 0) {
+	if (new_value && ZSTR_LEN(new_value) > 0 && strncmp("This setting", ZSTR_VAL(new_value), 11) != 0) {
 		xdebug_log_ex(
 			XLOG_CHAN_CONFIG, XLOG_CRIT, "REMOVED",
 			"The setting '%s' has been removed, see the upgrading guide at %supgrade_guide#changed-%s",
@@ -200,7 +200,7 @@ static PHP_INI_MH(OnUpdateChangedSetting)
 	if (! (EG(error_reporting) & E_DEPRECATED)) {
 		return SUCCESS;
 	}
-	if (new_value && new_value->val && strlen(new_value->val) > 0 && strncmp("This setting", new_value->val, 11) != 0) {
+	if (new_value && ZSTR_LEN(new_value) > 0 && strncmp("This setting", ZSTR_VAL(new_value), 11) != 0) {
 		xdebug_log_ex(
 			XLOG_CHAN_CONFIG, XLOG_CRIT, "CHANGED",
 			"The setting '%s' has been renamed, see the upgrading guide at %supgrade_guide#changed-%s",


### PR DESCRIPTION
Fixes the following warnings that were emitted a number of times:
- `xdebug/src/gcstats/gc_stats.c:209:4: warning: format specifies type 'long' but the argument has type 'zend_long'`
- `xdebug/xdebug.c:146:32: warning: address of array 'new_value->val' will always evaluate to 'true' [-Wpointer-bool-conversion]`