### PR TITLE
Install zlib for GH CI on Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
                 shell: cmd
         strategy:
             matrix:
-                php: ["7.4"]
+                php: ["8.0"]
                 arch: [x64, x86]
                 ts: [nts, ts]
         steps:
@@ -100,7 +100,7 @@ jobs:
                 - name: Generate Build Files
                   run: phpize
                 - name: Configure Build
-                  run: configure --with-xdebug --with-xdebug-compression --enable-debug-pack --with-prefix=${{steps.setup-php.outputs.prefix}}
+                  run: configure --with-xdebug --enable-debug-pack --with-prefix=${{steps.setup-php.outputs.prefix}}
                 - name: Build
                   run: nmake
                 - name: Define Xdebug Module Env

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,7 +100,7 @@ jobs:
                 - name: Generate Build Files
                   run: phpize
                 - name: Configure Build
-                  run: configure --with-xdebug --enable-debug-pack --with-prefix=${{steps.setup-php.outputs.prefix}}
+                  run: configure --with-xdebug --with-xdebug-compression --enable-debug-pack --with-prefix=${{steps.setup-php.outputs.prefix}}
                 - name: Build
                   run: nmake
                 - name: Define Xdebug Module Env

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
                 shell: cmd
         strategy:
             matrix:
-                php: ["7.4", "8.0", "8.1"]
+                php: ["7.4"]
                 arch: [x64, x86]
                 ts: [nts, ts]
         steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,10 +100,10 @@ jobs:
                 - name: Generate Build Files
                   run: phpize
                 - name: Configure Build with Compression
-                  if: ${{matrix.version >= "7.4"}}
+                  if: ${{matrix.version >= 7.4}}
                   run: configure --with-xdebug --with-xdebug-compression --enable-debug-pack --with-prefix=${{steps.setup-php.outputs.prefix}}
                 - name: Configure Build without Compression
-                  if: ${{matrix.version < "7.4"}}
+                  if: ${{matrix.version < 7.4}}
                   run: configure --with-xdebug --enable-debug-pack --with-prefix=${{steps.setup-php.outputs.prefix}}
                 - name: Build
                   run: nmake

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,8 +64,8 @@ jobs:
         strategy:
             matrix:
                 php: ["8.0"]
-                arch: [x64, x86]
-                ts: [nts, ts]
+                arch: [x64]
+                ts: [nts]
         steps:
                 - name: Checkout Xdebug
                   uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
                 shell: cmd
         strategy:
             matrix:
-                php: ["7.4", "8.0", "8.1"]
+                php: ["7.2", "7.3", "7.4", "8.0", "8.1"]
                 arch: [x64, x86]
                 ts: [nts, ts]
         steps:
@@ -99,8 +99,12 @@ jobs:
                     Expand-Archive zlib-1.2.11.zip ..\deps
                 - name: Generate Build Files
                   run: phpize
-                - name: Configure Build
+                - name: Configure Build with Compression
+                  if: ${{matrix.version >= "7.4"}}
                   run: configure --with-xdebug --with-xdebug-compression --enable-debug-pack --with-prefix=${{steps.setup-php.outputs.prefix}}
+                - name: Configure Build without Compression
+                  if: ${{matrix.version < "7.4"}}
+                  run: configure --with-xdebug --enable-debug-pack --with-prefix=${{steps.setup-php.outputs.prefix}}
                 - name: Build
                   run: nmake
                 - name: Define Xdebug Module Env

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,8 +145,8 @@ jobs:
                     chcp 65001
                     echo "REPORT_EXIT_STATUS=1" >> $env:GITHUB_ENV
                     echo "TEST_PHP_EXECUTABLE=${{steps.setup-php.outputs.prefix}}\php.exe" >> $env:GITHUB_ENV
-                    echo "TEMP=(Get-Item -LiteralPath $Env:TEMP).FullName" >> $env:GITHUB_ENV
-                    echo "TMP=(Get-Item -LiteralPath $Env:TMP).FullName" >> $env:GITHUB_ENV
+                    echo "TEMP=$((Get-Item -LiteralPath $Env:TEMP).FullName)" >> $env:GITHUB_ENV
+                    echo "TMP=$((Get-Item -LiteralPath $Env:TMP).FullName)" >> $env:GITHUB_ENV
                     echo "XDEBUG_MODE=" >> $env:GITHUB_ENV
                 - name: Run Tests
                   run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,6 +117,7 @@ jobs:
                     $dir = $dir + 'Release'
                     if ('ts' -eq '${{matrix.ts}}') { $dir = $dir + '_TS' }
                     $xdebug_dll_opt = 'TEST_PHP_ARGS=-n -d zend_extension=' + $dir + '\php_xdebug.dll'
+                    $xdebug_dll_opt += ' -d sys_temp_dir=' + (Get-Item -LiteralPath $Env:TEMP).FullName
                     echo $xdebug_dll_opt >> $env:GITHUB_ENV
 
                     $artifact_name = 'php_xdebug-${{env.XDEBUG_VERSION}}-${{matrix.php}}'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
                 shell: cmd
         strategy:
             matrix:
-                php: ["7.4"]
+                php: ["7.4", "8.0", "8.1"]
                 arch: [x64, x86]
                 ts: [nts, ts]
         steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,9 +63,9 @@ jobs:
                 shell: cmd
         strategy:
             matrix:
-                php: ["8.0"]
-                arch: [x64]
-                ts: [nts]
+                php: ["7.4"]
+                arch: [x64, x86]
+                ts: [nts, ts]
         steps:
                 - name: Checkout Xdebug
                   uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
                 shell: cmd
         strategy:
             matrix:
-                php: ["7.2", "7.3", "7.4", "8.0", "8.1"]
+                php: ["7.4", "8.0", "8.1"]
                 arch: [x64, x86]
                 ts: [nts, ts]
         steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,7 +117,6 @@ jobs:
                     $dir = $dir + 'Release'
                     if ('ts' -eq '${{matrix.ts}}') { $dir = $dir + '_TS' }
                     $xdebug_dll_opt = 'TEST_PHP_ARGS=-n -d zend_extension=' + $dir + '\php_xdebug.dll'
-                    $xdebug_dll_opt += ' -d sys_temp_dir=' + (Get-Item -LiteralPath $Env:TEMP).FullName
                     echo $xdebug_dll_opt >> $env:GITHUB_ENV
 
                     $artifact_name = 'php_xdebug-${{env.XDEBUG_VERSION}}-${{matrix.php}}'
@@ -146,6 +145,8 @@ jobs:
                     chcp 65001
                     echo "REPORT_EXIT_STATUS=1" >> $env:GITHUB_ENV
                     echo "TEST_PHP_EXECUTABLE=${{steps.setup-php.outputs.prefix}}\php.exe" >> $env:GITHUB_ENV
+                    echo "TEMP=(Get-Item -LiteralPath $Env:TEMP).FullName" >> $env:GITHUB_ENV
+                    echo "TMP=(Get-Item -LiteralPath $Env:TMP).FullName" >> $env:GITHUB_ENV
                     echo "XDEBUG_MODE=" >> $env:GITHUB_ENV
                 - name: Run Tests
                   run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,6 +90,13 @@ jobs:
                   with:
                       arch: ${{matrix.arch}}
                       toolset: ${{steps.setup-php.outputs.toolset}}
+                - name: Install zlib dependency
+                  shell: powershell
+                  run: |
+                    $versions = @{"7.0" = "vc14"; "7.1" = "vc14"; "7.2" = "vc15"; "7.3" = "vc15"; "7.4" = "vc15"; "8.0" = "vs16"; "8.1" = "vs16"}
+                    $crt = $versions."${{matrix.php}}"
+                    Invoke-WebRequest https://windows.php.net/downloads/php-sdk/deps/$crt/${{matrix.arch}}/zlib-1.2.11-$crt-${{matrix.arch}}.zip -OutFile zlib-1.2.11.zip
+                    Expand-Archive zlib-1.2.11.zip ..\deps
                 - name: Generate Build Files
                   run: phpize
                 - name: Configure Build

--- a/config.w32
+++ b/config.w32
@@ -34,7 +34,7 @@ if (PHP_XDEBUG != 'no') {
 	ADD_SOURCES(configure_module_dirname + "/src/tracing", XDEBUG_TRACING_SOURCES, "xdebug");
 
 	// PHP_ZLIB is "yes"/"no" for in-tree builds, but boolean for phpize builds
-	var XDEBUG_ZLIB = (!MODE_PHIZE && PHP_ZLIB == "yes") || (MODE_PHPIZE && PHP_ZLIB);
+	var XDEBUG_ZLIB = (!MODE_PHPIZE && PHP_ZLIB == "yes") || (MODE_PHPIZE && PHP_ZLIB);
 
 	if (PHP_XDEBUG_COMPRESSION != "no") {
 		if (((!XDEBUG_ZLIB) && (CHECK_LIB("zlib_a.lib;zlib.lib", "xdebug", PHP_XDEBUG))) ||

--- a/config.w32
+++ b/config.w32
@@ -31,8 +31,8 @@ if (PHP_XDEBUG != 'no') {
 	ADD_SOURCES(configure_module_dirname + "/src/profiler", XDEBUG_PROFILER_SOURCES, "xdebug");
 	ADD_SOURCES(configure_module_dirname + "/src/tracing", XDEBUG_TRACING_SOURCES, "xdebug");
 
-	if (CHECK_LIB("zlib_a.lib", "xdebug", PHP_XDEBUG) &&
-		CHECK_HEADER_ADD_INCLUDE("zlib.h", "CFLAGS", "..\\zlib;" + php_usual_include_suspects)
+	if (((PHP_ZLIB=="no") && (CHECK_LIB("zlib_a.lib;zlib.lib", "xdebug", PHP_XDEBUG))) ||
+		(PHP_ZLIB_SHARED && CHECK_LIB("zlib.lib", "xdebug", PHP_XDEBUG)) || (PHP_ZLIB == "yes" && (!PHP_ZLIB_SHARED))
 	) {
 		AC_DEFINE('HAVE_XDEBUG_ZLIB', 1);
 	}

--- a/config.w32
+++ b/config.w32
@@ -34,8 +34,8 @@ if (PHP_XDEBUG != 'no') {
 	ADD_SOURCES(configure_module_dirname + "/src/tracing", XDEBUG_TRACING_SOURCES, "xdebug");
 
 	if (PHP_XDEBUG_COMPRESSION != "no") {
-		if (((PHP_ZLIB=="no") && (CHECK_LIB("zlib_a.lib;zlib.lib", "xdebug", PHP_XDEBUG))) ||
-			(PHP_ZLIB_SHARED && CHECK_LIB("zlib.lib", "xdebug", PHP_XDEBUG)) || (PHP_ZLIB == "yes" && (!PHP_ZLIB_SHARED))
+		if (((!PHP_ZLIB) && (CHECK_LIB("zlib_a.lib;zlib.lib", "xdebug", PHP_XDEBUG))) ||
+			(PHP_ZLIB_SHARED && CHECK_LIB("zlib.lib", "xdebug", PHP_XDEBUG)) || (PHP_ZLIB && (!PHP_ZLIB_SHARED))
 		) {
 			AC_DEFINE('HAVE_XDEBUG_ZLIB', 1);
 		}

--- a/config.w32
+++ b/config.w32
@@ -2,6 +2,8 @@
 
 ARG_WITH("xdebug", "Xdebug support", "no");
 
+ARG_WITH("xdebug-compression", "whether to compress profiler files (requires zlib)", "no");
+
 if (PHP_XDEBUG != 'no') {
 	var XDEBUG_BASE_SOURCES="base.c filter.c"
 	var XDEBUG_LIB_SOURCES="usefulstuff.c compat.c crc32.c file.c hash.c headers.c lib.c llist.c log.c set.c str.c timing.c var.c var_export_html.c var_export_line.c var_export_text.c var_export_xml.c xml.c"
@@ -31,10 +33,12 @@ if (PHP_XDEBUG != 'no') {
 	ADD_SOURCES(configure_module_dirname + "/src/profiler", XDEBUG_PROFILER_SOURCES, "xdebug");
 	ADD_SOURCES(configure_module_dirname + "/src/tracing", XDEBUG_TRACING_SOURCES, "xdebug");
 
-	if (((PHP_ZLIB=="no") && (CHECK_LIB("zlib_a.lib;zlib.lib", "xdebug", PHP_XDEBUG))) ||
-		(PHP_ZLIB_SHARED && CHECK_LIB("zlib.lib", "xdebug", PHP_XDEBUG)) || (PHP_ZLIB == "yes" && (!PHP_ZLIB_SHARED))
-	) {
-		AC_DEFINE('HAVE_XDEBUG_ZLIB', 1);
+	if (PHP_XDEBUG_COMPRESSION != "no") {
+		if (((PHP_ZLIB=="no") && (CHECK_LIB("zlib_a.lib;zlib.lib", "xdebug", PHP_XDEBUG))) ||
+			(PHP_ZLIB_SHARED && CHECK_LIB("zlib.lib", "xdebug", PHP_XDEBUG)) || (PHP_ZLIB == "yes" && (!PHP_ZLIB_SHARED))
+		) {
+			AC_DEFINE('HAVE_XDEBUG_ZLIB', 1);
+		}
 	}
 
 	AC_DEFINE("HAVE_XDEBUG", 1, "Xdebug support");

--- a/config.w32
+++ b/config.w32
@@ -33,9 +33,13 @@ if (PHP_XDEBUG != 'no') {
 	ADD_SOURCES(configure_module_dirname + "/src/profiler", XDEBUG_PROFILER_SOURCES, "xdebug");
 	ADD_SOURCES(configure_module_dirname + "/src/tracing", XDEBUG_TRACING_SOURCES, "xdebug");
 
+	// PHP_ZLIB is "yes"/"no" for in-tree builds, but boolean for phpize builds
+	var XDEBUG_ZLIB = (!MODE_PHIZE && PHP_ZLIB == "yes") || (MODE_PHPIZE && PHP_ZLIB);
+
 	if (PHP_XDEBUG_COMPRESSION != "no") {
-		if (((!PHP_ZLIB) && (CHECK_LIB("zlib_a.lib;zlib.lib", "xdebug", PHP_XDEBUG))) ||
-			(PHP_ZLIB_SHARED && CHECK_LIB("zlib.lib", "xdebug", PHP_XDEBUG)) || (PHP_ZLIB && (!PHP_ZLIB_SHARED))
+		if (((!XDEBUG_ZLIB) && (CHECK_LIB("zlib_a.lib;zlib.lib", "xdebug", PHP_XDEBUG))) ||
+			(PHP_ZLIB_SHARED && CHECK_LIB("zlib.lib", "xdebug", PHP_XDEBUG)) ||
+			(XDEBUG_ZLIB && (!PHP_ZLIB_SHARED))
 		) {
 			AC_DEFINE('HAVE_XDEBUG_ZLIB', 1);
 		}

--- a/config.w32
+++ b/config.w32
@@ -31,5 +31,11 @@ if (PHP_XDEBUG != 'no') {
 	ADD_SOURCES(configure_module_dirname + "/src/profiler", XDEBUG_PROFILER_SOURCES, "xdebug");
 	ADD_SOURCES(configure_module_dirname + "/src/tracing", XDEBUG_TRACING_SOURCES, "xdebug");
 
+	if (CHECK_LIB("zlib_a.lib", "xdebug", PHP_XDEBUG) &&
+		CHECK_HEADER_ADD_INCLUDE("zlib.h", "CFLAGS", "..\\zlib;" + php_usual_include_suspects)
+	) {
+		AC_DEFINE('HAVE_XDEBUG_ZLIB', 1);
+	}
+
 	AC_DEFINE("HAVE_XDEBUG", 1, "Xdebug support");
 }

--- a/src/tracing/trace_computerized.c
+++ b/src/tracing/trace_computerized.c
@@ -70,11 +70,7 @@ void xdebug_trace_computerized_write_footer(void *ctxt)
 	nanotime = xdebug_get_nanotime();
 
 	xdebug_file_printf(context->trace_file, "\t\t\t%F\t", XDEBUG_SECONDS_SINCE_START(nanotime));
-#if WIN32|WINNT
-	xdebug_file_printf(context->trace_file, "%Iu", zend_memory_usage(0));
-#else
 	xdebug_file_printf(context->trace_file, "%zu", zend_memory_usage(0));
-#endif
 	xdebug_file_printf(context->trace_file, "\n");
 
 	str_time = xdebug_nanotime_to_chars(xdebug_get_nanotime(), 6);

--- a/src/tracing/trace_textual.c
+++ b/src/tracing/trace_textual.c
@@ -69,11 +69,7 @@ void xdebug_trace_textual_write_footer(void *ctxt)
 	tmp = xdebug_sprintf("%10.4F ", XDEBUG_SECONDS_SINCE_START(nanotime));
 	xdebug_file_printf(context->trace_file, "%s", tmp);
 	xdfree(tmp);
-#if WIN32|WINNT
-	xdebug_file_printf(context->trace_file, "%10Iu", zend_memory_usage(0));
-#else
 	xdebug_file_printf(context->trace_file, "%10zu", zend_memory_usage(0));
-#endif
 	xdebug_file_printf(context->trace_file, "\n");
 
 	str_time = xdebug_nanotime_to_chars(nanotime, 6);

--- a/tests/profiler/bug02001-no-zlib-compression.phpt
+++ b/tests/profiler/bug02001-no-zlib-compression.phpt
@@ -3,7 +3,7 @@ Test for bug #2001: no zlib, use_compression=1
 --SKIPIF--
 <?php
 require __DIR__ . '/../utils.inc';
-check_reqs('!ext-flag compression; !win');
+check_reqs('!ext-flag compression');
 ?>
 --INI--
 xdebug.mode=profile

--- a/tests/profiler/bug02001-no-zlib-compression.phpt
+++ b/tests/profiler/bug02001-no-zlib-compression.phpt
@@ -13,16 +13,12 @@ xdebug.profiler_output_name=cachegrind.out
 xdebug.log={TMPDIR}/{RUNID}bug2001-no-zlib-compression.txt
 --FILE--
 <?php
-$file = xdebug_get_profiler_filename();
-var_dump($file);
-if ($file) {
-	unlink($file);
-}
+require_once 'capture-profile.inc';
 
 echo file_get_contents(sys_get_temp_dir() . '/' . getenv('UNIQ_RUN_ID') . 'bug2001-no-zlib-compression.txt' );
 unlink (sys_get_temp_dir() . '/' . getenv('UNIQ_RUN_ID') . 'bug2001-no-zlib-compression.txt' );
 ?>
 --EXPECTF--
-string(%d) "%scachegrind.out"
 [%d] Log opened at %s
 [%d] [Config] WARN: Cannot create the compressed file '%s.out.gz', because support for zlib has not been compiled in. Falling back to '%s.out'
+%A

--- a/tests/profiler/bug02001-no-zlib-no-compression.phpt
+++ b/tests/profiler/bug02001-no-zlib-no-compression.phpt
@@ -3,7 +3,7 @@ Test for bug #2001: no zlib, use_compression=0
 --SKIPIF--
 <?php
 require __DIR__ . '/../utils.inc';
-check_reqs('!ext-flag compression; !win');
+check_reqs('!ext-flag compression');
 ?>
 --INI--
 xdebug.mode=profile

--- a/tests/profiler/bug02001-no-zlib-no-compression.phpt
+++ b/tests/profiler/bug02001-no-zlib-no-compression.phpt
@@ -12,11 +12,10 @@ xdebug.use_compression=0
 xdebug.profiler_output_name=cachegrind.out.%R.end
 --FILE--
 <?php
+require_once 'capture-profile.inc';
 $file = xdebug_get_profiler_filename();
 var_dump($file);
-if ($file) {
-	unlink($file);
-}
 ?>
 --EXPECTF--
 string(%d) "%send"
+%A

--- a/tests/profiler/bug02001-zlib-compression.phpt
+++ b/tests/profiler/bug02001-zlib-compression.phpt
@@ -12,11 +12,10 @@ xdebug.use_compression=1
 xdebug.profiler_output_name=cachegrind.out.%R.end
 --FILE--
 <?php
+require_once 'capture-profile.inc';
 $file = xdebug_get_profiler_filename();
 var_dump($file);
-if ($file) {
-	unlink($file);
-}
 ?>
 --EXPECTF--
 string(%d) "%send.gz"
+%A

--- a/tests/profiler/bug02001-zlib-compression.phpt
+++ b/tests/profiler/bug02001-zlib-compression.phpt
@@ -3,7 +3,7 @@ Test for bug #2001: zlib, use_compression=1
 --SKIPIF--
 <?php
 require __DIR__ . '/../utils.inc';
-check_reqs('ext-flag compression; !win');
+check_reqs('ext-flag compression');
 ?>
 --INI--
 xdebug.mode=profile

--- a/tests/profiler/bug02001-zlib-no-compression.phpt
+++ b/tests/profiler/bug02001-zlib-no-compression.phpt
@@ -3,7 +3,7 @@ Test for bug #2001: zlib, use_compression=0
 --SKIPIF--
 <?php
 require __DIR__ . '/../utils.inc';
-check_reqs('ext-flag compression; !win');
+check_reqs('ext-flag compression');
 ?>
 --INI--
 xdebug.mode=profile

--- a/tests/profiler/bug02001-zlib-no-compression.phpt
+++ b/tests/profiler/bug02001-zlib-no-compression.phpt
@@ -12,11 +12,10 @@ xdebug.use_compression=0
 xdebug.profiler_output_name=cachegrind.out.%R.end
 --FILE--
 <?php
+require_once 'capture-profile.inc';
 $file = xdebug_get_profiler_filename();
 var_dump($file);
-if ($file) {
-	unlink($file);
-}
 ?>
 --EXPECTF--
 string(%d) "%send"
+%A

--- a/tests/profiler/bug02001-zlib-no-compression.phpt
+++ b/tests/profiler/bug02001-zlib-no-compression.phpt
@@ -3,7 +3,7 @@ Test for bug #2001: zlib, use_compression=0
 --SKIPIF--
 <?php
 require __DIR__ . '/../utils.inc';
-check_reqs('ext-flag compression');
+check_reqs('!ext-flag compression');
 ?>
 --INI--
 xdebug.mode=profile

--- a/tests/tracing/start_no_zlib_compression.phpt
+++ b/tests/tracing/start_no_zlib_compression.phpt
@@ -3,7 +3,7 @@ Compression: no zlib, use_compression=1
 --SKIPIF--
 <?php
 require __DIR__ . '/../utils.inc';
-check_reqs('!ext-flag compression; !win');
+check_reqs('!ext-flag compression');
 ?>
 --INI--
 xdebug.mode=trace

--- a/tests/tracing/start_no_zlib_no_compression.phpt
+++ b/tests/tracing/start_no_zlib_no_compression.phpt
@@ -3,7 +3,7 @@ Compression: no zlib, use_compression=0
 --SKIPIF--
 <?php
 require __DIR__ . '/../utils.inc';
-check_reqs('!ext-flag compression; !win');
+check_reqs('!ext-flag compression');
 ?>
 --INI--
 xdebug.mode=trace

--- a/tests/tracing/start_zlib_compression.phpt
+++ b/tests/tracing/start_zlib_compression.phpt
@@ -3,7 +3,7 @@ Compression: zlib, use_compression=1
 --SKIPIF--
 <?php
 require __DIR__ . '/../utils.inc';
-check_reqs('ext-flag compression; !win');
+check_reqs('ext-flag compression');
 ?>
 --INI--
 xdebug.mode=trace

--- a/tests/tracing/start_zlib_no_compression.phpt
+++ b/tests/tracing/start_zlib_no_compression.phpt
@@ -3,7 +3,7 @@ Compression: zlib, use_compression=0
 --SKIPIF--
 <?php
 require __DIR__ . '/../utils.inc';
-check_reqs('ext-flag compression; !win');
+check_reqs('ext-flag compression');
 ?>
 --INI--
 xdebug.mode=trace


### PR DESCRIPTION
A suitable zlib package needs to be available for zlib support on
Windows (PR #782).  This patch downloads and unzips this to the default
dependency folder, so that it should be recognized and used without
further ado.

Note that this solution hard-codes the zlib version, which is no
problem for now, but might be in the future.  A clean solution would
need to download and parse the respective series file first, to find
out which zlib version is actually available.  However, that should
better be provided by cmb69/setup-php-sdk.