### PR TITLE
Fixed bug #2019: uninitialized stack globals leads to crash

### DIFF
--- a/xdebug.c
+++ b/xdebug.c
@@ -386,6 +386,7 @@ PHP_INI_END()
 
 static void xdebug_init_base_globals(struct xdebug_base_info *xg)
 {
+	xg->stack                = NULL;
 	xg->in_debug_info        = 0;
 	xg->output_is_tty        = OUTPUT_NOT_CHECKED;
 	xg->in_execution         = 0;


### PR DESCRIPTION
Not being initialized, checking `XG_BASE(stack)` may not work, especially if memory is not zeroed, this is the case with *musl libc*.

This bug has been introduced in 9437d03a496fe11d0da0dbfa94ede3690bcbaace.
