### PR TITLE
Quick-fix for missing tracing initialization on ZTS Windows

### DIFF
--- a/src/lib/timing.c
+++ b/src/lib/timing.c
@@ -164,6 +164,14 @@ uint64_t xdebug_get_nanotime(void)
 	xdebug_nanotime_context *context;
 
 	context = &XG_BASE(nanotime_context);
+#if PHP_WIN32
+	if (IsWindows8OrGreater()) {
+		context->win_precise_time_func = (WIN_PRECISE_TIME_FUNC)GetProcAddress(
+			GetModuleHandle(TEXT("kernel32.dll")),
+			"GetSystemTimePreciseAsFileTime"
+		);
+	}
+#endif
 
 #if PHP_WIN32 | HAVE_XDEBUG_CLOCK_GETTIME | HAVE_XDEBUG_CLOCK_GETTIME_NSEC_NP
 	/* Relative timing */


### PR DESCRIPTION
If tracing is done in a ZTS environment on Windows 8.0+,
xdebug_nanotime_context.win_precise_time_func is not properly
initialized, and the wrong code path is taken, resulting in a division
by zero, which causes the Apache worker process to be terminated.

This is a quick-fix to solve this issue, which may at least serve to
figure out whether bugs 2016, 2924 and 2028 actually have this very
root cause.  A proper fix might be to make xdebug_nanotime_context a
proper module global, and to initialize it in GINIT.