### PR TITLE
Properly initialize nanotime for each thread

### DIFF
--- a/src/base/base.c
+++ b/src/base/base.c
@@ -1113,8 +1113,6 @@ void xdebug_base_minit(INIT_FUNC_ARGS)
 	XG_BASE(error_reporting_overridden) = 0;
 	XG_BASE(output_is_tty) = OUTPUT_NOT_CHECKED;
 
-	xdebug_nanotime_init();
-
 #if PHP_VERSION_ID >= 80100
 	zend_observer_fiber_switch_register(xdebug_fiber_switch_observer);
 #endif

--- a/src/lib/timing.c
+++ b/src/lib/timing.c
@@ -125,7 +125,7 @@ static uint64_t xdebug_get_nanotime_rel(xdebug_nanotime_context *nanotime_contex
 }
 #endif
 
-void xdebug_nanotime_init(void)
+void xdebug_nanotime_init(struct xdebug_base_info *base)
 {
 	xdebug_nanotime_context context = {0};
 
@@ -155,7 +155,7 @@ void xdebug_nanotime_init(void)
 	context.last_rel = 0;
 #endif
 
-	XG_BASE(nanotime_context) = context;
+	base->nanotime_context = context;
 }
 
 uint64_t xdebug_get_nanotime(void)

--- a/src/lib/timing.h
+++ b/src/lib/timing.h
@@ -39,7 +39,9 @@ typedef struct _xdebug_nanotime_context {
 #endif
 } xdebug_nanotime_context;
 
-void xdebug_nanotime_init(struct xdebug_base_info *xg);
+typedef struct xdebug_base_info* xdebug_base_info_ptr;
+
+void xdebug_nanotime_init(xdebug_base_info_ptr xg);
 
 uint64_t xdebug_get_nanotime(void);
 

--- a/src/lib/timing.h
+++ b/src/lib/timing.h
@@ -39,7 +39,7 @@ typedef struct _xdebug_nanotime_context {
 #endif
 } xdebug_nanotime_context;
 
-void xdebug_nanotime_init(void);
+void xdebug_nanotime_init(struct xdebug_base_info *xg);
 
 uint64_t xdebug_get_nanotime(void);
 

--- a/xdebug.c
+++ b/xdebug.c
@@ -406,6 +406,7 @@ static void php_xdebug_init_globals(zend_xdebug_globals *xg)
 {
 	xdebug_init_library_globals(&xg->globals.library);
 	xdebug_init_base_globals(&xg->base);
+	xdebug_nanotime_init(&xg->base);
 
 	if (XDEBUG_MODE_IS(XDEBUG_MODE_COVERAGE)) {
 		xdebug_init_coverage_globals(&xg->globals.coverage);


### PR DESCRIPTION
The MINIT based initialization of the `nanotime_context` leaves the
struct unitialized for ZTS environments.  Therefore, we move that
initialization to the GINIT stage.

---

The call to `xdebug_nanotime_init()` might be moved into `xdebug_init_base_globals()`; not sure about that. Anyway, this PR supersedes #793 and #794.