### PR TITLE
Always initialize code_coverage_active

### DIFF
--- a/src/coverage/code_coverage.c
+++ b/src/coverage/code_coverage.c
@@ -972,7 +972,7 @@ void xdebug_coverage_count_line_if_branch_check_active(zend_op_array *op_array, 
 
 void xdebug_coverage_record_if_active(zend_execute_data *execute_data, zend_op_array *op_array)
 {
-	if (!op_array->reserved[XG_COV(code_coverage_filter_offset)] && XG_COV(code_coverage_active)) {
+	if (XG_COV(code_coverage_active) && !op_array->reserved[XG_COV(code_coverage_filter_offset)]) {
 		xdebug_print_opcode_info(execute_data, execute_data->opline);
 	}
 }

--- a/xdebug.c
+++ b/xdebug.c
@@ -409,6 +409,8 @@ static void php_xdebug_init_globals(zend_xdebug_globals *xg)
 
 	if (XDEBUG_MODE_IS(XDEBUG_MODE_COVERAGE)) {
 		xdebug_init_coverage_globals(&xg->globals.coverage);
+	} else {
+		xg->globals.coverage.code_coverage_active = 0;
 	}
 	if (XDEBUG_MODE_IS(XDEBUG_MODE_STEP_DEBUG)) {
 		xdebug_init_debugger_globals(&xg->globals.debugger);


### PR DESCRIPTION
Alternatively, xdebug_init_coverage_globals() could be called unconditionally.