### PR TITLE
Fixed issue #2045: Remove smileys

### DIFF
--- a/src/debugger/com.c
+++ b/src/debugger/com.c
@@ -412,7 +412,7 @@ static void xdebug_init_normal_debugger(xdebug_str *connection_attempts)
 
 	if (!remote_addr) {
 		xdebug_str_add_fmt(connection_attempts, "%s:%ld (fallback through xdebug.client_host/xdebug.client_port)", XINI_DBG(client_host), XINI_DBG(client_port));
-		xdebug_log_ex(XLOG_CHAN_DEBUG, XLOG_WARN, "HDR", "Could not discover client host through HTTP headers, connecting to configured address/port: %s:%ld. :-|", XINI_DBG(client_host), (long int) XINI_DBG(client_port));
+		xdebug_log_ex(XLOG_CHAN_DEBUG, XLOG_WARN, "HDR", "Could not discover client host through HTTP headers, connecting to configured address/port: %s:%ld.", XINI_DBG(client_host), (long int) XINI_DBG(client_port));
 
 		XG_DBG(context).socket = xdebug_create_socket(XINI_DBG(client_host), XINI_DBG(client_port), XINI_DBG(connect_timeout_ms));
 		return;
@@ -432,7 +432,7 @@ static void xdebug_init_normal_debugger(xdebug_str *connection_attempts)
 
 	if (XG_DBG(context).socket < 0) {
 		xdebug_str_add_fmt(connection_attempts, ", %s:%ld (fallback through xdebug.client_host/xdebug.client_port)", XINI_DBG(client_host), XINI_DBG(client_port));
-		xdebug_log_ex(XLOG_CHAN_DEBUG, XLOG_WARN, "CON", "Could not connect to client host discovered through HTTP headers, connecting to configured address/port: %s:%ld. :-|", XINI_DBG(client_host), (long int) XINI_DBG(client_port));
+		xdebug_log_ex(XLOG_CHAN_DEBUG, XLOG_WARN, "CON", "Could not connect to client host discovered through HTTP headers, connecting to configured address/port: %s:%ld.", XINI_DBG(client_host), (long int) XINI_DBG(client_port));
 
 		XG_DBG(context).socket = xdebug_create_socket(XINI_DBG(client_host), XINI_DBG(client_port), XINI_DBG(connect_timeout_ms));
 	}
@@ -495,12 +495,12 @@ static void xdebug_init_debugger()
 
 	/* Check whether we're connected, or why not */
 	if (XG_DBG(context).socket >= 0) {
-		xdebug_log(XLOG_CHAN_DEBUG, XLOG_INFO, "Connected to debugging client: %s. :-)", connection_attempts->d);
+		xdebug_log(XLOG_CHAN_DEBUG, XLOG_INFO, "Connected to debugging client: %s.", connection_attempts->d);
 		xdebug_mark_debug_connection_pending();
 
 		if (!XG_DBG(context).handler->remote_init(&(XG_DBG(context)), XDEBUG_REQ)) {
 			/* The request could not be started, ignore it then */
-			xdebug_log_ex(XLOG_CHAN_DEBUG, XLOG_ERR, "SES-INIT", "The debug session could not be started. Tried: %s. :-(", connection_attempts->d);
+			xdebug_log_ex(XLOG_CHAN_DEBUG, XLOG_ERR, "SES-INIT", "The debug session could not be started. Tried: %s.", connection_attempts->d);
 		} else {
 			/* All is well, turn off script time outs */
 			zend_unset_timeout();
@@ -508,11 +508,11 @@ static void xdebug_init_debugger()
 			zend_set_timeout(EG(timeout_seconds), 0);
 		}
 	} else if (XG_DBG(context).socket == -1) {
-		xdebug_log_ex(XLOG_CHAN_DEBUG, XLOG_ERR, "NOCON", "Could not connect to debugging client. Tried: %s :-(", connection_attempts->d);
+		xdebug_log_ex(XLOG_CHAN_DEBUG, XLOG_ERR, "NOCON", "Could not connect to debugging client. Tried: %s.", connection_attempts->d);
 	} else if (XG_DBG(context).socket == -2) {
-		xdebug_log_ex(XLOG_CHAN_DEBUG, XLOG_ERR, "TIMEOUT", "Time-out connecting to debugging client, waited: " ZEND_LONG_FMT " ms. Tried: %s :-(", XINI_DBG(connect_timeout_ms), connection_attempts->d);
+		xdebug_log_ex(XLOG_CHAN_DEBUG, XLOG_ERR, "TIMEOUT", "Time-out connecting to debugging client, waited: " ZEND_LONG_FMT " ms. Tried: %s.", XINI_DBG(connect_timeout_ms), connection_attempts->d);
 	} else if (XG_DBG(context).socket == -3) {
-		xdebug_log_ex(XLOG_CHAN_DEBUG, XLOG_ERR, "NOPERM", "No permission connecting to debugging client (%s). This could be SELinux related. :-(", connection_attempts->d);
+		xdebug_log_ex(XLOG_CHAN_DEBUG, XLOG_ERR, "NOPERM", "No permission connecting to debugging client (%s). This could be SELinux related.", connection_attempts->d);
 	}
 
 	xdebug_str_free(connection_attempts);

--- a/tests/debugger/bug01656.phpt
+++ b/tests/debugger/bug01656.phpt
@@ -13,5 +13,5 @@ xdebug.client_port=9999
 var_dump( $_SERVER['I_LIKE_COOKIES'] );
 ?>
 --EXPECTF--
-Xdebug: [Step Debug] %sTried: 127.0.0.1:9999 (from I_LIKE_COOKIES HTTP header), localhost:9999 (fallback through xdebug.client_host/xdebug.client_port) :-(
+Xdebug: [Step Debug] %sTried: 127.0.0.1:9999 (from I_LIKE_COOKIES HTTP header), localhost:9999 (fallback through xdebug.client_host/xdebug.client_port).
 string(20) "127.0.0.1, 127.0.0.2"

--- a/tests/debugger/bug01782.phpt
+++ b/tests/debugger/bug01782.phpt
@@ -17,7 +17,7 @@ xdebug.client_port=9172
 var_dump( xdebug_get_headers( ) );
 ?>
 --EXPECTF--
-Xdebug: [Step Debug] %sTried: localhost:9172 (through xdebug.client_host/xdebug.client_port) :-(
+Xdebug: [Step Debug] %sTried: localhost:9172 (through xdebug.client_host/xdebug.client_port).
 %sbug01782.php:2:
 array(1) {
   [0] =>

--- a/tests/debugger/remote_log-unix-2.phpt
+++ b/tests/debugger/remote_log-unix-2.phpt
@@ -27,6 +27,6 @@ unlink (sys_get_temp_dir() . '/' . getenv('UNIQ_RUN_ID') . 'remote-unix.txt' );
 [%d] [Step Debug] INFO: Checking remote connect back address.
 [%d] [Step Debug] INFO: Checking user configured header 'I_LIKE_COOKIES'.
 [%d] [Step Debug] WARN: Invalid remote address provided containing URI spec 'unix:///tmp/haxx0r.sock'.
-[%d] [Step Debug] WARN: Could not discover client host through HTTP headers, connecting to configured address/port: unix:///tmp/xdbg.sock:0. :-|
+[%d] [Step Debug] WARN: Could not discover client host through HTTP headers, connecting to configured address/port: unix:///tmp/xdbg.sock:0.
 [%d] [Step Debug] WARN: Creating socket for 'unix:///tmp/xdbg.sock', connect: No such file or directory.
-[%d] [Step Debug] ERR: Could not connect to debugging client. Tried: unix:///tmp/xdbg.sock:0 (fallback through xdebug.client_host/xdebug.client_port) :-(
+[%d] [Step Debug] ERR: Could not connect to debugging client. Tried: unix:///tmp/xdbg.sock:0 (fallback through xdebug.client_host/xdebug.client_port).

--- a/tests/debugger/remote_log-unix.phpt
+++ b/tests/debugger/remote_log-unix.phpt
@@ -24,4 +24,4 @@ unlink (sys_get_temp_dir() . '/' . getenv('UNIQ_RUN_ID') . 'remote-log4.txt' );
 [%d] Log opened at %d-%d-%d %d:%d:%d.%d
 [%d] [Step Debug] INFO: Connecting to configured address/port: unix:///tmp/xdbg.sock:0.
 [%d] [Step Debug] WARN: Creating socket for 'unix:///tmp/xdbg.sock', connect: No such file or directory.
-[%d] [Step Debug] ERR: Could not connect to debugging client. Tried: unix:///tmp/xdbg.sock:0 (through xdebug.client_host/xdebug.client_port) :-(
+[%d] [Step Debug] ERR: Could not connect to debugging client. Tried: unix:///tmp/xdbg.sock:0 (through xdebug.client_host/xdebug.client_port).

--- a/tests/debugger/remote_log-win.phpt
+++ b/tests/debugger/remote_log-win.phpt
@@ -29,6 +29,6 @@ echo file_get_contents("C:\\Windows\\Temp\\remote-log4.txt");
 [%d] [Step Debug] INFO: Checking user configured header 'I_LIKE_COOKIES'.
 [%d] [Step Debug] INFO: Client host discovered through HTTP header, connecting to doesnotexist3:9003.
 [%d] [Step Debug] WARN: Creating socket for 'doesnotexist3:9003', getaddrinfo: %d.
-[%d] [Step Debug] WARN: Could not connect to client host discovered through HTTP headers, connecting to configured address/port: doesnotexist2:9003. :-|
+[%d] [Step Debug] WARN: Could not connect to client host discovered through HTTP headers, connecting to configured address/port: doesnotexist2:9003.
 [%d] [Step Debug] WARN: Creating socket for 'doesnotexist2:9003', getaddrinfo: 11001.
-[%d] [Step Debug] ERR: Could not connect to debugging client. Tried: doesnotexist3:9003 (from I_LIKE_COOKIES HTTP header), doesnotexist2:9003 (fallback through xdebug.client_host/xdebug.client_port) :-(
+[%d] [Step Debug] ERR: Could not connect to debugging client. Tried: doesnotexist3:9003 (from I_LIKE_COOKIES HTTP header), doesnotexist2:9003 (fallback through xdebug.client_host/xdebug.client_port).

--- a/tests/debugger/remote_log1.phpt
+++ b/tests/debugger/remote_log1.phpt
@@ -24,4 +24,4 @@ unlink (sys_get_temp_dir() . '/' . getenv('UNIQ_RUN_ID') . 'remote-log1.txt' );
 [%d] Log opened at %d-%d-%d %d:%d:%d.%d
 [%d] [Step Debug] INFO: Connecting to configured address/port: doesnotexist:9002.
 [%d] [Step Debug] WARN: Creating socket for 'doesnotexist:9002', getaddrinfo: %s.
-[%d] [Step Debug] ERR: Could not connect to debugging client. Tried: doesnotexist:9002 (through xdebug.client_host/xdebug.client_port) :-(
+[%d] [Step Debug] ERR: Could not connect to debugging client. Tried: doesnotexist:9002 (through xdebug.client_host/xdebug.client_port).

--- a/tests/debugger/remote_log2.phpt
+++ b/tests/debugger/remote_log2.phpt
@@ -24,6 +24,6 @@ unlink (sys_get_temp_dir() . '/' . getenv('UNIQ_RUN_ID') . 'remote-log2.txt' );
 [%d] [Step Debug] INFO: Checking remote connect back address.
 [%d] [Step Debug] INFO: Checking header 'HTTP_X_FORWARDED_FOR'.
 [%d] [Step Debug] INFO: Checking header 'REMOTE_ADDR'.
-[%d] [Step Debug] WARN: Could not discover client host through HTTP headers, connecting to configured address/port: doesnotexist2:9003. :-|
+[%d] [Step Debug] WARN: Could not discover client host through HTTP headers, connecting to configured address/port: doesnotexist2:9003.
 [%d] [Step Debug] WARN: Creating socket for 'doesnotexist2:9003', getaddrinfo: %s.
-[%d] [Step Debug] ERR: Could not connect to debugging client. Tried: doesnotexist2:9003 (fallback through xdebug.client_host/xdebug.client_port) :-(
+[%d] [Step Debug] ERR: Could not connect to debugging client. Tried: doesnotexist2:9003 (fallback through xdebug.client_host/xdebug.client_port).

--- a/tests/debugger/remote_log3.phpt
+++ b/tests/debugger/remote_log3.phpt
@@ -26,6 +26,6 @@ unlink (sys_get_temp_dir() . '/' . getenv('UNIQ_RUN_ID') . 'remote-log3.txt' );
 [%d] [Step Debug] INFO: Checking user configured header 'I_LIKE_COOKIES'.
 [%d] [Step Debug] INFO: Checking header 'HTTP_X_FORWARDED_FOR'.
 [%d] [Step Debug] INFO: Checking header 'REMOTE_ADDR'.
-[%d] [Step Debug] WARN: Could not discover client host through HTTP headers, connecting to configured address/port: doesnotexist2:9003. :-|
+[%d] [Step Debug] WARN: Could not discover client host through HTTP headers, connecting to configured address/port: doesnotexist2:9003.
 [%d] [Step Debug] WARN: Creating socket for 'doesnotexist2:9003', getaddrinfo: %s.
-[%d] [Step Debug] ERR: Could not connect to debugging client. Tried: doesnotexist2:9003 (fallback through xdebug.client_host/xdebug.client_port) :-(
+[%d] [Step Debug] ERR: Could not connect to debugging client. Tried: doesnotexist2:9003 (fallback through xdebug.client_host/xdebug.client_port).

--- a/tests/debugger/remote_log4.phpt
+++ b/tests/debugger/remote_log4.phpt
@@ -28,6 +28,6 @@ unlink (sys_get_temp_dir() . '/' . getenv('UNIQ_RUN_ID') . 'remote-log4.txt' );
 [%d] [Step Debug] INFO: Checking user configured header 'I_LIKE_COOKIES'.
 [%d] [Step Debug] INFO: Client host discovered through HTTP header, connecting to cookiehost:9003.
 [%d] [Step Debug] WARN: Creating socket for 'cookiehost:9003', getaddrinfo: %s.
-[%d] [Step Debug] WARN: Could not connect to client host discovered through HTTP headers, connecting to configured address/port: doesnotexist2:9003. :-|
+[%d] [Step Debug] WARN: Could not connect to client host discovered through HTTP headers, connecting to configured address/port: doesnotexist2:9003.
 [%d] [Step Debug] WARN: Creating socket for 'doesnotexist2:9003', getaddrinfo: %s.
-[%d] [Step Debug] ERR: Could not connect to debugging client. Tried: cookiehost:9003 (from I_LIKE_COOKIES HTTP header), doesnotexist2:9003 (fallback through xdebug.client_host/xdebug.client_port) :-(
+[%d] [Step Debug] ERR: Could not connect to debugging client. Tried: cookiehost:9003 (from I_LIKE_COOKIES HTTP header), doesnotexist2:9003 (fallback through xdebug.client_host/xdebug.client_port).

--- a/tests/debugger/remote_log5.phpt
+++ b/tests/debugger/remote_log5.phpt
@@ -20,5 +20,5 @@ xdebug.client_discovery_header=I_LIKE_COOKIES
 echo strlen("foo"), "\n";
 ?>
 --EXPECTF--
-Xdebug: [Step Debug] Could not connect to debugging client. Tried: cookiehost:9003 (from I_LIKE_COOKIES HTTP header), doesnotexist2:9003 (fallback through xdebug.client_host/xdebug.client_port) :-(
+Xdebug: [Step Debug] Could not connect to debugging client. Tried: cookiehost:9003 (from I_LIKE_COOKIES HTTP header), doesnotexist2:9003 (fallback through xdebug.client_host/xdebug.client_port).
 3

--- a/tests/develop/bug00609.phpt
+++ b/tests/develop/bug00609.phpt
@@ -12,8 +12,8 @@ xdebug.mode=develop
 try {
 	  $sc = new SoapClient("some-wrong.wsdl", array('exceptions' => true));
 } catch (Exception $e) {
-	  echo 'Error Caught :-)';
+	  echo 'Error Caught';
 }
 ?>
 --EXPECTF--
-Error Caught :-)
+Error Caught

--- a/tests/develop/bug00747.phpt
+++ b/tests/develop/bug00747.phpt
@@ -12,7 +12,7 @@ xdebug.mode=develop
 try {
 	  $sc = new SoapServer("some-wrong.wsdl", array('exceptions' => true));
 } catch (Exception $e) {
-	  echo 'Error Caught :-)';
+	  echo 'Error Caught';
 }
 ?>
 --EXPECTF--

--- a/xdebug.ini
+++ b/xdebug.ini
@@ -520,7 +520,7 @@
 ;
 ;     [2693358] Log opened at 2020-09-02 07:19:09.616195
 ;     [2693358] [Step Debug] INFO: Connecting to configured address/port: localhost:9003.
-;     [2693358] [Step Debug] ERR: Could not connect to debugging client. Tried: localhost:9003 (through xdebug.client_host/xdebug.client_port) :-(
+;     [2693358] [Step Debug] ERR: Could not connect to debugging client. Tried: localhost:9003 (through xdebug.client_host/xdebug.client_port).
 ;     [2693358] [Profiler] ERR: File '/foo/cachegrind.out.2693358' could not be opened.
 ;     [2693358] [Profiler] WARN: /foo: No such file or directory
 ;     [2693358] [Tracing] ERR: File '/foo/trace.1485761369' could not be opened.
@@ -529,8 +529,7 @@
 ;
 ; It includes the opening time ( ``2020-09-02 07:19:09.616195``), the
 ; IP/Hostname and port Xdebug is trying to connect to ( ``localhost:9003``), and
-; whether it succeeded ( ``Connected to client :-)``). The number in brackets (
-; ``[2693358]``) is the Process ID.
+; whether it succeeded ( ``Connected to client``). The number in brackets ( ``[2693358]``) is the Process ID.
 ;
 ; It includes:
 ;
@@ -543,7 +542,7 @@
 ; For Step Debugging:
 ;
 ;     INFO: Connecting to configured address/port: localhost:9003.
-;     ERR: Could not connect to debugging client. Tried: localhost:9003 (through xdebug.client_host/xdebug.client_port) :-(
+;     ERR: Could not connect to debugging client. Tried: localhost:9003 (through xdebug.client_host/xdebug.client_port).
 ;
 ; For Profiling:
 ;


### PR DESCRIPTION
this pr addresses the https://bugs.xdebug.org/view.php?id=2045

- remove smileys from the xdebug log
- solve minor inconsistency: two of the log messages didn't have `.` at the end
- removed a few smileys from the tests
