### PR TITLE
Fix for removal of JMPZNZ opcode in PHP 8.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [7.3, 7.4, 8.0, 8.1]
+                php: [7.3, 7.4, 8.0, 8.1, 8.2]
                 use-opcache: [true, false]
 
         steps:

--- a/src/coverage/code_coverage.c
+++ b/src/coverage/code_coverage.c
@@ -300,11 +300,13 @@ static int xdebug_find_jumps(zend_op_array *opa, unsigned int position, size_t *
 		*jump_count = 2;
 		return 1;
 
+#if PHP_VERSION_ID < 80200
 	} else if (opcode.opcode == ZEND_JMPZNZ) {
 		jumps[0] = XDEBUG_ZNODE_JMP_LINE(opcode.op2, position, base_address);
 		jumps[1] = position + ((int32_t) opcode.extended_value / (int32_t) sizeof(zend_op));
 		*jump_count = 2;
 		return 1;
+#endif
 
 	} else if (opcode.opcode == ZEND_FE_FETCH_R || opcode.opcode == ZEND_FE_FETCH_RW) {
 		jumps[0] = position + 1;


### PR DESCRIPTION
`JMPZNZ` opcode has been removed in PHP 8.2. So this PR limits the handling of the `JMPZNZ` opcode to lower versions.

Ref: https://github.com/php/php-src/pull/7857

Edit: This PR also adds PHP 8.2 to the GitHub Actions workflow.