### PR TITLE
fix possible used after free

### DIFF
--- a/src/gcstats/gc_stats.c
+++ b/src/gcstats/gc_stats.c
@@ -136,17 +136,18 @@ static int xdebug_gc_stats_init(char *requested_filename, zend_string *script_na
 	}
 
 	XG_GCSTATS(file) = xdebug_fopen(filename_to_use, "w", NULL, &XG_GCSTATS(filename));
-	xdfree(filename_to_use);
 
 	if (!XG_GCSTATS(file)) {
 		xdebug_log_diagnose_permissions(XLOG_CHAN_GCSTATS, output_dir, filename_to_use);
 
+		xdfree(filename_to_use);
 		if (generated_filename) {
 			xdfree(generated_filename);
 		}
 
 		return FAILURE;
 	}
+	xdfree(filename_to_use);
 
 	fprintf(XG_GCSTATS(file), "Garbage Collection Report\n");
 	fprintf(XG_GCSTATS(file), "version: 1\ncreator: xdebug %s (PHP %s)\n\n", XDEBUG_VERSION, PHP_VERSION);


### PR DESCRIPTION
```
/builddir/build/BUILD/php-pecl-xdebug3-3.1.2/ZTS/src/gcstats/gc_stats.c:142:17: warning: pointer 'filename_to_use_92' may be used after 'free' [-Wuse-after-free]
  142 |                 xdebug_log_diagnose_permissions(XLOG_CHAN_GCSTATS, output_dir, filename_to_use);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /builddir/build/BUILD/php-pecl-xdebug3-3.1.2/ZTS/src/lib/vector.h:21,
                 from /builddir/build/BUILD/php-pecl-xdebug3-3.1.2/ZTS/src/base/base_globals.h:22,
                 from ./php_xdebug.h:34,
                 from /builddir/build/BUILD/php-pecl-xdebug3-3.1.2/ZTS/src/gcstats/gc_stats.c:21:
/builddir/build/BUILD/php-pecl-xdebug3-3.1.2/ZTS/src/lib/mm.h:32:21: note: call to 'free' here
   32 | #define xdfree      free

```