### PR TITLE
Fixed bug #2083: const defined with enum

### DIFF
--- a/src/debugger/handler_dbgp.c
+++ b/src/debugger/handler_dbgp.c
@@ -1422,7 +1422,7 @@ static int add_constant_node(xdebug_xml_node *node, xdebug_str *name, zval *cons
 		return FAILURE;
 	}
 
-	xdebug_xml_add_attribute(contents, "facet", "constant");
+	xdebug_xml_expand_attribute_value(contents, "facet", "constant");
 	xdebug_xml_add_child(node, contents);
 
 	return SUCCESS;

--- a/tests/debugger/bug02083.inc
+++ b/tests/debugger/bug02083.inc
@@ -1,0 +1,9 @@
+<?php
+
+enum TestEnum {
+    case EnumCase;
+}
+
+const TEST_CONST = TestEnum::EnumCase;
+
+$value = TEST_CONST;

--- a/tests/debugger/bug02083.phpt
+++ b/tests/debugger/bug02083.phpt
@@ -1,0 +1,45 @@
+--TEST--
+Test for bug #2083: Constant defined with an enum case
+--SKIPIF--
+<?php
+require __DIR__ . '/../utils.inc';
+check_reqs('dbgp; PHP >= 8.1');
+?>
+--FILE--
+<?php
+require 'dbgp/dbgpclient.php';
+$filename = dirname(__FILE__) . '/bug02083.inc';
+
+$commands = array(
+	'step_into',
+	'breakpoint_set -t line -n 9',
+	'run',
+	'context_get -c 2',
+	'detach',
+);
+
+dbgpRunFile( $filename, $commands );
+?>
+--EXPECTF--
+<?xml version="1.0" encoding="iso-8859-1"?>
+<init xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" fileuri="file://bug02083.inc" language="PHP" xdebug:language_version="" protocol_version="1.0" appid=""><engine version=""><![CDATA[Xdebug]]></engine><author><![CDATA[Derick Rethans]]></author><url><![CDATA[https://xdebug.org]]></url><copyright><![CDATA[Copyright (c) 2002-2099 by Derick Rethans]]></copyright></init>
+
+-> step_into -i 1
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="step_into" transaction_id="1" status="break" reason="ok"><xdebug:message filename="file://bug02083.inc" lineno="3"></xdebug:message></response>
+
+-> breakpoint_set -i 2 -t line -n 9
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="breakpoint_set" transaction_id="2" id="{{PID}}0001"></response>
+
+-> run -i 3
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="3" status="break" reason="ok"><xdebug:message filename="file://bug02083.inc" lineno="9"></xdebug:message></response>
+
+-> context_get -i 4 -c 2
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="context_get" transaction_id="4" context="2"><property name="TEST_CONST" fullname="TEST_CONST" type="object" facet="enum constant" classname="TestEnum" children="1" numchildren="1" page="0" pagesize="32"><property name="name" fullname="TEST_CONST-&gt;name" facet="public readonly" type="string" size="8" encoding="base64"><![CDATA[RW51bUNhc2U=]]></property></property></response>
+
+-> detach -i 5
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="detach" transaction_id="5" status="stopping" reason="ok"></response>


### PR DESCRIPTION
Fixes issue https://bugs.xdebug.org/view.php?id=2083 by ensuring only a single `facet` attribute is included in a `<property>` element of the `context_get` command result when an enum case is used as the value of a constant.

Verified expected behavior in PhpStorm: 
- Step debugging works again
- The constant is present in the list of constants with an enum case as the value

---

```php
<?php

enum TestEnum {
    case EnumCase;
}

const TEST_CONST = TestEnum::EnumCase;

$value = TEST_CONST;

var_dump($value);
```

Stepping into the above with a breakpoint on `var_dump`:

<img width="278" alt="Screen Shot 2022-04-13 at 3 07 44 PM" src="https://user-images.githubusercontent.com/1628287/163261766-6d9b8934-1cb4-4981-bd77-f4d973821916.png">
