### PR TITLE
Fixed bug #2085: Crash when used with source guardian encoded files

### DIFF
--- a/src/base/filter.c
+++ b/src/base/filter.c
@@ -60,7 +60,7 @@ void xdebug_filter_register_constants(INIT_FUNC_ARGS)
 
 static int xdebug_filter_match_path_include(function_stack_entry *fse, unsigned char *filtered_flag, char *filter)
 {
-	if (strncasecmp(filter, ZSTR_VAL(fse->filename), strlen(filter)) == 0) {
+	if (fse->filename && strncasecmp(filter, ZSTR_VAL(fse->filename), strlen(filter)) == 0) {
 		*filtered_flag = 0;
 		return 1;
 	}
@@ -69,7 +69,7 @@ static int xdebug_filter_match_path_include(function_stack_entry *fse, unsigned 
 
 static int xdebug_filter_match_path_exclude(function_stack_entry *fse, unsigned char *filtered_flag, char *filter)
 {
-	if (strncasecmp(filter, ZSTR_VAL(fse->filename), strlen(filter)) == 0) {
+	if (fse->filename && strncasecmp(filter, ZSTR_VAL(fse->filename), strlen(filter)) == 0) {
 		*filtered_flag = 1;
 		return 1;
 	}

--- a/tests/coverage/bug02085.inc
+++ b/tests/coverage/bug02085.inc
@@ -1,0 +1,16 @@
+<?php
+
+// To get this test to fail before the fix, this file must be
+// encoded using the Source Guardian encoder and source guardian
+// loaders must be installed. https://www.sourceguardian.com/loaders.html
+//
+// That extension somehow sets the zend_op_array->filename member for encoded files to NULL
+// So, when xdebug filtering is enabled, the xdebug_filter_match_path_include function
+// will try to see if the zend_op_array->filename matches a filter
+// But since zend_op_array->filename is NULL, we get a segmentation fault
+//
+// This fix will guard against the possibility of other extensions that may set
+// the zend_op_array->filename to NULL since it is absolutely possible that
+// the zend_op_array->filename could be NULL when checking against filter paths
+
+echo "I'm encoded";

--- a/tests/coverage/bug02085.phpt
+++ b/tests/coverage/bug02085.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Test for bug #2085: Crash when used with source guardian encoded files
+--INI--
+xdebug.mode=coverage
+--FILE--
+<?php
+xdebug_set_filter(
+	XDEBUG_FILTER_CODE_COVERAGE,
+	XDEBUG_PATH_INCLUDE,
+	["src/"]
+);
+xdebug_start_code_coverage();
+require_once __DIR__ . "/bug02085.inc";
+xdebug_stop_code_coverage();
+
+?>
+--EXPECTF--
+%AI'm encoded


### PR DESCRIPTION
This fix guards against possible null pointer segmentation faults when xdebug coverage is enabled with path include or exclude filters.

This fix changes the xdebug_filter_match_path_include and xdebug_filter_match_path_exclude functions by adding a value check before comparing strings

Before the fix, if fse->filename happens to be NULL or not set, the program will crash because the strncasecmp function expects to compare 2 strings.

After the fix, if fse->filename happens to be NULL or not set, then the function simply returns 0 to indicate that the file didn't match any of the filters. This is ok because coverage in encoded files is meaningless anyway.

The reason fse->filename needs to be checked is because it is possible for it to be unset. And if it's unset, PHP will crash. The SourceGuardian extension for PHP does just that for encoded files. I'm not sure why or how, but the end result is that zend_op_array->filename is unset for encoded files which then gets referenced by fse->filename. 

That being said, other extensions might do the same thing.... extensions like Ioncube encoder and maybe others. The fact that it's possible for fse->filename to be unset warrants the necessity for this check.