### PR TITLE
add missing php-header.h file for PECL package

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -135,6 +135,7 @@ Wed, Jul 20, 2022 - Xdebug 3.2.0alpha1
      <file name="llist.c" role="src" />
      <file name="llist.h" role="src" />
      <file name="mm.h" role="src" />
+     <file name="php-header.h" role="src" />
      <file name="set.c" role="src" />
      <file name="set.h" role="src" />
      <file name="str.c" role="src" />


### PR DESCRIPTION
https://github.com/xdebug/xdebug/commit/011cb3a702e452d765e542b60b015e9c948cc5de

```
/home/skilld/aports/testing/php82-pecl-xdebug/src/xdebug-3.2.0alpha1/src/base/base.c:17:10: fatal error: lib/php-header.h: No such file or directory
   17 | #include "lib/php-header.h"
      |          ^~~~~~~~~~~~~~~~~~
compilation terminated.
/home/skilld/aports/testing/php82-pecl-xdebug/src/xdebug-3.2.0alpha1/xdebug.c:21:10: fatal error: lib/php-header.h: No such file or directory
   21 | #include "lib/php-header.h"
      |          ^~~~~~~~~~~~~~~~~~
compilation terminated.
make: *** [Makefile:261: xdebug.lo] Error 1
make: *** Waiting for unfinished jobs....
```