### PR TITLE
Update debugger.c

### DIFF
--- a/src/debugger/debugger.c
+++ b/src/debugger/debugger.c
@@ -633,7 +633,7 @@ void xdebug_debugger_rinit(void)
 			)
 			&& !SG(headers_sent)
 		) {
-			xdebug_setcookie("XDEBUG_SESSION", sizeof("XDEBUG_SESSION"), (char*) "", 0, 0, "/", 1, NULL, 0, 0, 1, 0);
+			xdebug_setcookie("XDEBUG_SESSION", sizeof("XDEBUG_SESSION")-1, (char*) "", 0, 0, "/", 1, NULL, 0, 0, 1, 0);
 			XG_DBG(no_exec) = 1;
 		}
 		zend_string_release(stop_no_exec);


### PR DESCRIPTION
I had to do this for windows to get it to work otherwise I got a buffer overrun with this error in the php log: PHP Warning:  Header may not contain NUL bytes in Unknown on line 0