### PR TITLE
use SPDX license ID

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -50,7 +50,7 @@ Code Coverage Analysis
   <release>stable</release>
   <api>stable</api>
  </stability>
- <license uri="http://www.opensource.org/licenses/bsd-license.php">BSD style</license>
+ <license uri="https://xdebug.org/license/1.03" filesource="LICENSE">Xdebug-1.03</license>
  <notes>
 Tue, Mar 21, 2023 - Xdebug 3.2.1
 


### PR DESCRIPTION
See https://github.com/spdx/license-list-XML/pull/1913

BTW it will be nice to have a better URL for the License file, such as https://xdebug.org/license/1.03.txt (following https://www.php.net/license/3_01.txt)

And perhaps a page like https://www.php.net/license/