### PR TITLE
Optimize step_over command

### DIFF
--- a/src/base/base.c
+++ b/src/base/base.c
@@ -1155,7 +1155,10 @@ static void xdebug_fiber_switch_observer(zend_fiber_context *from, zend_fiber_co
 	xdebug_vector *current_stack;
 
 	if (from->status == ZEND_FIBER_STATUS_DEAD) {
-		XG_DBG(context).next_stack = NULL;
+		if (XG_DBG(context).next_stack == find_stack_for_fiber(from)) {
+			XG_DBG(context).next_stack = NULL;
+		}
+
 		remove_stack_for_fiber(from);
 	}
 	if (to->status == ZEND_FIBER_STATUS_INIT) {

--- a/src/base/base.c
+++ b/src/base/base.c
@@ -1155,6 +1155,7 @@ static void xdebug_fiber_switch_observer(zend_fiber_context *from, zend_fiber_co
 	xdebug_vector *current_stack;
 
 	if (from->status == ZEND_FIBER_STATUS_DEAD) {
+		XG_DBG(context).next_stack = NULL;
 		remove_stack_for_fiber(from);
 	}
 	if (to->status == ZEND_FIBER_STATUS_INIT) {

--- a/src/debugger/debugger.c
+++ b/src/debugger/debugger.c
@@ -231,8 +231,14 @@ int next_condition_met(void)
 		level = fse->level;
 	}
 
-	if (XG_DBG(context).next_level >= level) {
-		return 1;
+	if (XG_DBG(context).next_stack != NULL) {
+		if ((XG_DBG(context).next_stack == XG_BASE(stack)) && (XG_DBG(context).next_level >= level)) {
+			return 1;
+		}
+	} else {
+		if (XG_DBG(context).next_level >= level) {
+			return 1;
+		}
 	}
 
 	return 0;

--- a/src/debugger/handler_dbgp.c
+++ b/src/debugger/handler_dbgp.c
@@ -1219,11 +1219,7 @@ DBGP_FUNC(step_over)
 
 	if ((fse = XDEBUG_VECTOR_TAIL(XG_BASE(stack)))) {
 		XG_DBG(context).next_level = fse->level;
-		if (EG(current_execute_data)->opline->lineno == fse->op_array->line_end) {
-			XG_DBG(context).next_stack = NULL;
-		} else {
-			XG_DBG(context).next_stack = XG_BASE(stack);
-		}
+		XG_DBG(context).next_stack = XG_BASE(stack);
 	} else {
 		XG_DBG(context).next_level = 0;
 		XG_DBG(context).next_stack = NULL;

--- a/src/debugger/handler_dbgp.c
+++ b/src/debugger/handler_dbgp.c
@@ -1219,8 +1219,14 @@ DBGP_FUNC(step_over)
 
 	if ((fse = XDEBUG_VECTOR_TAIL(XG_BASE(stack)))) {
 		XG_DBG(context).next_level = fse->level;
+		if (EG(current_execute_data)->opline->lineno == fse->op_array->line_end) {
+			XG_DBG(context).next_stack = NULL;
+		} else {
+			XG_DBG(context).next_stack = XG_BASE(stack);
+		}
 	} else {
 		XG_DBG(context).next_level = 0;
+		XG_DBG(context).next_stack = NULL;
 	}
 }
 

--- a/src/debugger/handlers.h
+++ b/src/debugger/handlers.h
@@ -78,6 +78,7 @@ struct _xdebug_con {
 	xdebug_debug_list      list;
 	int                    do_break;
 	xdebug_brk_info       *pending_breakpoint;
+	xdebug_vector         *next_stack;
 
 	int                    do_step;
 	int                    do_next;

--- a/tests/debugger/step_fiber-001.inc
+++ b/tests/debugger/step_fiber-001.inc
@@ -1,0 +1,30 @@
+<?php
+
+(new Fiber(function (): void {
+    $fiber1 = new Fiber(function (): void {
+        $a = 1;
+        Fiber::suspend();
+        $a = 2;
+    });
+    $fiber1->start();
+
+    $fiber2 = new Fiber(function (): void {
+        $a = 1;
+        Fiber::suspend();
+        $a = 2;
+    });
+    $fiber2->start();
+
+    $fiber3 = new Fiber(function (): void {
+        $a = 1;
+        Fiber::suspend();
+        $a = 2;
+    });
+    $fiber3->start();
+
+    $fiber1->resume();
+    $fiber2->resume();
+    $fiber3->resume();
+    $a = 1;
+}))->start();
+?>

--- a/tests/debugger/step_into_fiber-001.phpt
+++ b/tests/debugger/step_into_fiber-001.phpt
@@ -3,7 +3,7 @@ Test for step_into fiber 001: step_into command will step into other fiber
 --SKIPIF--
 <?php
 require __DIR__ . '/../utils.inc';
-check_reqs('dbgp');
+check_reqs('PHP >= 8.1; dbgp');
 ?>
 --FILE--
 <?php

--- a/tests/debugger/step_into_fiber-001.phpt
+++ b/tests/debugger/step_into_fiber-001.phpt
@@ -1,0 +1,60 @@
+--TEST--
+Test for step_into fiber 001: step_into command will step into other fiber
+--SKIPIF--
+<?php
+require __DIR__ . '/../utils.inc';
+check_reqs('dbgp');
+?>
+--FILE--
+<?php
+require 'dbgp/dbgpclient.php';
+$filename = dirname(__FILE__) . '/step_fiber-001.inc';
+
+$commands = array(
+	'step_into',
+	'breakpoint_set -t line -n 9',
+	'breakpoint_set -t line -n 28',
+	'run',
+	'step_into',
+	'run',
+	'step_into',
+	'detach',
+);
+
+dbgpRunFile( $filename, $commands );
+?>
+--EXPECTF--
+<?xml version="1.0" encoding="iso-8859-1"?>
+<init xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" fileuri="file://step_fiber-001.inc" language="PHP" xdebug:language_version="" protocol_version="1.0" appid=""><engine version=""><![CDATA[Xdebug]]></engine><author><![CDATA[Derick Rethans]]></author><url><![CDATA[https://xdebug.org]]></url><copyright><![CDATA[Copyright (c) 2002-2099 by Derick Rethans]]></copyright></init>
+
+-> step_into -i 1
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="step_into" transaction_id="1" status="break" reason="ok"><xdebug:message filename="file://step_fiber-001.inc" lineno="3"></xdebug:message></response>
+
+-> breakpoint_set -i 2 -t line -n 9
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="breakpoint_set" transaction_id="2" id="{{PID}}0001"></response>
+
+-> breakpoint_set -i 3 -t line -n 28
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="breakpoint_set" transaction_id="3" id="{{PID}}0002"></response>
+
+-> run -i 4
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="4" status="break" reason="ok"><xdebug:message filename="file://step_fiber-001.inc" lineno="9"></xdebug:message></response>
+
+-> step_into -i 5
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="step_into" transaction_id="5" status="break" reason="ok"><xdebug:message filename="file://step_fiber-001.inc" lineno="5"></xdebug:message></response>
+
+-> run -i 6
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="6" status="break" reason="ok"><xdebug:message filename="file://step_fiber-001.inc" lineno="28"></xdebug:message></response>
+
+-> step_into -i 7
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="step_into" transaction_id="7" status="break" reason="ok"><xdebug:message filename="file://step_fiber-001.inc" lineno="29"></xdebug:message></response>
+
+-> detach -i 8
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="detach" transaction_id="8" status="stopping" reason="ok"></response>

--- a/tests/debugger/step_over_fiber-001.phpt
+++ b/tests/debugger/step_over_fiber-001.phpt
@@ -3,7 +3,7 @@ Test for step_over fiber 001: step_over command don't step into other fiber
 --SKIPIF--
 <?php
 require __DIR__ . '/../utils.inc';
-check_reqs('dbgp');
+check_reqs('PHP >= 8.1; dbgp');
 ?>
 --FILE--
 <?php

--- a/tests/debugger/step_over_fiber-001.phpt
+++ b/tests/debugger/step_over_fiber-001.phpt
@@ -1,0 +1,60 @@
+--TEST--
+Test for step_over fiber 001: step_over command don't step into other fiber
+--SKIPIF--
+<?php
+require __DIR__ . '/../utils.inc';
+check_reqs('dbgp');
+?>
+--FILE--
+<?php
+require 'dbgp/dbgpclient.php';
+$filename = dirname(__FILE__) . '/step_fiber-001.inc';
+
+$commands = array(
+	'step_into',
+	'breakpoint_set -t line -n 9',
+	'breakpoint_set -t line -n 28',
+	'run',
+	'step_over',
+	'run',
+	'step_over',
+	'detach',
+);
+
+dbgpRunFile( $filename, $commands );
+?>
+--EXPECTF--
+<?xml version="1.0" encoding="iso-8859-1"?>
+<init xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" fileuri="file://step_fiber-001.inc" language="PHP" xdebug:language_version="" protocol_version="1.0" appid=""><engine version=""><![CDATA[Xdebug]]></engine><author><![CDATA[Derick Rethans]]></author><url><![CDATA[https://xdebug.org]]></url><copyright><![CDATA[Copyright (c) 2002-2099 by Derick Rethans]]></copyright></init>
+
+-> step_into -i 1
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="step_into" transaction_id="1" status="break" reason="ok"><xdebug:message filename="file://step_fiber-001.inc" lineno="3"></xdebug:message></response>
+
+-> breakpoint_set -i 2 -t line -n 9
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="breakpoint_set" transaction_id="2" id="{{PID}}0001"></response>
+
+-> breakpoint_set -i 3 -t line -n 28
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="breakpoint_set" transaction_id="3" id="{{PID}}0002"></response>
+
+-> run -i 4
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="4" status="break" reason="ok"><xdebug:message filename="file://step_fiber-001.inc" lineno="9"></xdebug:message></response>
+
+-> step_over -i 5
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="step_over" transaction_id="5" status="break" reason="ok"><xdebug:message filename="file://step_fiber-001.inc" lineno="11"></xdebug:message></response>
+
+-> run -i 6
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="6" status="break" reason="ok"><xdebug:message filename="file://step_fiber-001.inc" lineno="28"></xdebug:message></response>
+
+-> step_over -i 7
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="step_over" transaction_id="7" status="break" reason="ok"><xdebug:message filename="file://step_fiber-001.inc" lineno="29"></xdebug:message></response>
+
+-> detach -i 8
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="detach" transaction_id="8" status="stopping" reason="ok"></response>

--- a/tests/debugger/step_over_fiber-002.phpt
+++ b/tests/debugger/step_over_fiber-002.phpt
@@ -1,0 +1,70 @@
+--TEST--
+Test for step_over fiber 002: step_over command don't step into other fiber
+--SKIPIF--
+<?php
+require __DIR__ . '/../utils.inc';
+check_reqs('dbgp');
+?>
+--FILE--
+<?php
+require 'dbgp/dbgpclient.php';
+$filename = dirname(__FILE__) . '/step_fiber-001.inc';
+
+$commands = array(
+	'step_into',
+	'breakpoint_set -t line -n 7',
+	'run',
+	'step_over',
+	'step_over',
+	'step_over',
+	'step_over',
+	'step_over',
+	'step_over',
+	'detach',
+);
+
+dbgpRunFile( $filename, $commands );
+?>
+--EXPECTF--
+<?xml version="1.0" encoding="iso-8859-1"?>
+<init xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" fileuri="file://step_fiber-001.inc" language="PHP" xdebug:language_version="" protocol_version="1.0" appid=""><engine version=""><![CDATA[Xdebug]]></engine><author><![CDATA[Derick Rethans]]></author><url><![CDATA[https://xdebug.org]]></url><copyright><![CDATA[Copyright (c) 2002-2099 by Derick Rethans]]></copyright></init>
+
+-> step_into -i 1
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="step_into" transaction_id="1" status="break" reason="ok"><xdebug:message filename="file://step_fiber-001.inc" lineno="3"></xdebug:message></response>
+
+-> breakpoint_set -i 2 -t line -n 7
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="breakpoint_set" transaction_id="2" id="{{PID}}0001"></response>
+
+-> run -i 3
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="3" status="break" reason="ok"><xdebug:message filename="file://step_fiber-001.inc" lineno="7"></xdebug:message></response>
+
+-> step_over -i 4
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="step_over" transaction_id="4" status="break" reason="ok"><xdebug:message filename="file://step_fiber-001.inc" lineno="8"></xdebug:message></response>
+
+-> step_over -i 5
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="step_over" transaction_id="5" status="break" reason="ok"><xdebug:message filename="file://step_fiber-001.inc" lineno="26"></xdebug:message></response>
+
+-> step_over -i 6
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="step_over" transaction_id="6" status="break" reason="ok"><xdebug:message filename="file://step_fiber-001.inc" lineno="27"></xdebug:message></response>
+
+-> step_over -i 7
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="step_over" transaction_id="7" status="break" reason="ok"><xdebug:message filename="file://step_fiber-001.inc" lineno="28"></xdebug:message></response>
+
+-> step_over -i 8
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="step_over" transaction_id="8" status="break" reason="ok"><xdebug:message filename="file://step_fiber-001.inc" lineno="29"></xdebug:message></response>
+
+-> step_over -i 9
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="step_over" transaction_id="9" status="stopping" reason="ok"></response>
+
+-> detach -i 10
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="detach" transaction_id="10" status="stopping" reason="ok"></response>

--- a/tests/debugger/step_over_fiber-002.phpt
+++ b/tests/debugger/step_over_fiber-002.phpt
@@ -3,7 +3,7 @@ Test for step_over fiber 002: step_over command don't step into other fiber
 --SKIPIF--
 <?php
 require __DIR__ . '/../utils.inc';
-check_reqs('dbgp');
+check_reqs('PHP >= 8.1; dbgp');
 ?>
 --FILE--
 <?php

--- a/tests/tracing/bug00173.phpt
+++ b/tests/tracing/bug00173.phpt
@@ -34,4 +34,4 @@ Call Stack:
 
 
 Variables in local scope (#1):
-  $trace_file = '%s.%d.xt%S'
+  $trace_file = '%s.%d.%sxt%S'

--- a/tests/tracing/bug00173.phpt
+++ b/tests/tracing/bug00173.phpt
@@ -34,4 +34,4 @@ Call Stack:
 
 
 Variables in local scope (#1):
-  $trace_file = '%s.%d.%sxt%S'
+  $trace_file = '%s.%d.xt%S'


### PR DESCRIPTION
It seems that the step_over command to stop is not a good behavior in other coroutines, unless this coroutine is destroyed.
For example:

```php
<?php

use Swoole\Coroutine;

use function Swoole\Coroutine\run;

require __DIR__ . '/vendor/autoload.php';

run(function () {
    $a = 1; // position 1
    Coroutine::create(function () {
        $a = 1; // position 2
        Coroutine::sleep(1);
        $a = 1;
    });
    Coroutine::create(function () {
        $a = 1;
        Coroutine::sleep(1);
        $a = 1;
    });
    Coroutine::create(function () {
        $a = 1;
    });
    $b = 1; // position 3
});
$a = 1;
```

Assuming the program stops at position 1, if I execute the "step_over" command, the program will stop at position 2 (If I want the program to stop at position 2, I think this is what the 'step_into' command should do). According to my understanding, the program should not stop inside any coroutine and should stop at position 3. Currently, the behavior of xdebug in handling the "step_over" command causes erratic behavior when there is an IO switch in a coroutine.