### PR TITLE
Relax test expectation

### DIFF
--- a/tests/develop/error_collection-001.phpt
+++ b/tests/develop/error_collection-001.phpt
@@ -23,7 +23,5 @@ Warning: An error in %serror_collection-001.php on line 4
 
 Call Stack:
 %w%f %w%d   1. {main}() %serror_collection-001.php:0
-%w%f %w%d   2. trigger_error($message = 'An error', $error_%s = 512) %serror_collection-001.php:4
-
-"
+%w%f %w%d   2. trigger_error($message = 'An error', $error_%s = 512) %A
 }


### PR DESCRIPTION
May file when very long path

```
TEST 1/1 [tests/develop/error_collection-001.phpt]
========DIFF========
--
     
     Call Stack:
     %w%f %w%d   1. {main}() %serror_collection-001.php:0
010- %w%f %w%d   2. trigger_error($message = 'An error', $error_%s = 512) %serror_collection-001.php:4
011- 
012- "
010+     0.0000     421328   2. trigger_error($message = 'An error', $error_level = 512) /dev/shm/BUILD/php-pecl-xdebug3-3.2.2/xdebug-a909eb088ad9fd8c8e09fcc71d892fa54b957b31/tests/dev"...
     }
========DONE========
FAIL Test for collection errors (1) [tests/develop/error_collection-001.phpt] 

```