### PR TITLE
Raise default max nesting level

### DIFF
--- a/xdebug.c
+++ b/xdebug.c
@@ -287,7 +287,7 @@ PHP_INI_BEGIN()
 	STD_PHP_INI_ENTRY("xdebug.var_display_max_depth",    "3",       PHP_INI_ALL,    OnUpdateLong,   settings.library.display_max_depth,    zend_xdebug_globals, xdebug_globals)
 
 	/* Base settings */
-	STD_PHP_INI_ENTRY("xdebug.max_nesting_level", "256",                PHP_INI_ALL,    OnUpdateLong,   settings.base.max_nesting_level, zend_xdebug_globals, xdebug_globals)
+	STD_PHP_INI_ENTRY("xdebug.max_nesting_level", "512",                PHP_INI_ALL,    OnUpdateLong,   settings.base.max_nesting_level, zend_xdebug_globals, xdebug_globals)
 
 	/* Develop settings */
 	STD_PHP_INI_ENTRY("xdebug.cli_color",         "0",                  PHP_INI_ALL,    OnUpdateLong,   settings.develop.cli_color,         zend_xdebug_globals, xdebug_globals)

--- a/xdebug.ini
+++ b/xdebug.ini
@@ -715,7 +715,7 @@
 ; -----------------------------------------------------------------------------
 ; xdebug.max_nesting_level
 ;
-; Type: integer, Default value: 256
+; Type: integer, Default value: 512
 ;
 ; Controls the protection mechanism for infinite recursion protection. The value
 ; of this setting is the maximum level of nested functions that are allowed
@@ -726,7 +726,7 @@
 ; [1] https://www.php.net/manual/class.error.php
 ;
 ;
-;xdebug.max_nesting_level = 256
+;xdebug.max_nesting_level = 512
 
 ; -----------------------------------------------------------------------------
 ; xdebug.max_stack_frames


### PR DESCRIPTION
As shown in https://github.com/symfony/symfony/discussions/48515 it is currently possible with basic Symfony projects to trigger the default max_nesting_level of 256 during DI container compilation.

As it's more important that there is a limit than its specific number we should ensure that the defaults continue to work in (almost) all regular situations with common tools and libraries. I think we should therefore raise the default limit to 512.