### PR TITLE
Derive PHP_XDEBUG_FOUND_VERNUM from php-config directly

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -15,7 +15,7 @@ m4_include([m4/clocks.m4])
 if test "$PHP_XDEBUG" != "no"; then
   AC_MSG_CHECKING([Check for supported PHP versions])
   PHP_XDEBUG_FOUND_VERSION=`${PHP_CONFIG} --version`
-  PHP_XDEBUG_FOUND_VERNUM=`echo "${PHP_XDEBUG_FOUND_VERSION}" | $AWK 'BEGIN { FS = "."; } { printf "%d", ([$]1 * 100 + [$]2) * 100 + [$]3;}'`
+  PHP_XDEBUG_FOUND_VERNUM=`${PHP_CONFIG} --vernum`
   if test "$PHP_XDEBUG_FOUND_VERNUM" -lt "80000"; then
     AC_MSG_ERROR([not supported. Need a PHP version >= 8.0.0 and < 8.5.0 (found $PHP_XDEBUG_FOUND_VERSION)])
   else


### PR DESCRIPTION
php-config --vernum has been supported since 5.4 (php/php-src@f0fe4e05b91b5a6815ee056dee204262810b862f)

This was inspired by my recent work on https://github.com/mongodb/mongo-php-driver/pull/1477.