### PR TITLE
Fixed issue #2027: Branch/path code coverage for traits misses trait name

### DIFF
--- a/src/coverage/code_coverage.c
+++ b/src/coverage/code_coverage.c
@@ -842,6 +842,7 @@ static void add_cc_function(void *ret, xdebug_hash_element *e)
 	xdebug_coverage_function *function = (xdebug_coverage_function*) e->ptr;
 	zval                     *retval = (zval*) ret;
 	zval                     *function_info;
+	zend_string              *trait_scope = NULL;
 
 	XDEBUG_MAKE_STD_ZVAL(function_info);
 	array_init(function_info);
@@ -851,7 +852,14 @@ static void add_cc_function(void *ret, xdebug_hash_element *e)
 		add_paths(function_info, function->branch_info);
 	}
 
-	add_assoc_zval_ex(retval, function->name, HASH_KEY_STRLEN(function->name), function_info);
+	if ((trait_scope = xdebug_get_trait_scope(function->name)) != NULL) {
+		char *with_scope = xdebug_sprintf("%s->%s", ZSTR_VAL(trait_scope), function->name);
+
+		add_assoc_zval_ex(retval, with_scope, strlen(with_scope), function_info);
+	} else {
+		add_assoc_zval_ex(retval, function->name, HASH_KEY_STRLEN(function->name), function_info);
+	}
+
 
 	efree(function_info);
 }

--- a/src/lib/lib.h
+++ b/src/lib/lib.h
@@ -235,6 +235,10 @@ typedef struct _xdebug_library_globals_t {
 	char         *log_open_timestring;
 	xdebug_str   *diagnosis_buffer;
 
+	/* Trait location map */
+	xdebug_hash  *trait_location_map;
+
+	/* Opcode overrite handlers */
 	user_opcode_handler_t          original_opcode_handlers[256];
 	xdebug_multi_opcode_handler_t *opcode_multi_handlers[256];
 	xdebug_set                    *opcode_handlers_set;
@@ -335,6 +339,8 @@ int xdebug_call_original_opcode_handler_if_set(int opcode, XDEBUG_OPCODE_HANDLER
 char *xdebug_lib_get_output_dir(void);
 
 void xdebug_llist_string_dtor(void *dummy, void *elem);
+
+zend_string *xdebug_get_trait_scope(const char *function);
 zend_string* xdebug_wrap_location_around_function_name(const char *prefix, zend_op_array *opa, zend_string *fname);
 zend_string* xdebug_wrap_closure_location_around_function_name(zend_op_array *opa, zend_string *fname);
 

--- a/tests/coverage/bug01938.phpt
+++ b/tests/coverage/bug01938.phpt
@@ -36,7 +36,7 @@ App\Bar->useTrait
 - paths
   - 0: HIT
 
-returnsTrue{trait-method:%sbug01938-FooTrait.inc:9-12}
+App\FooTrait->returnsTrue{trait-method:%sbug01938-FooTrait.inc:9-12}
 - branches
   - 00; OP: 00-%d; line: %d-%d HIT%S
 - paths


### PR DESCRIPTION
When analysing code, the scope is the *trait* name. While the code is running, the method has been copied into the class, and the scope is the *class* name.

I cheated earlier and removed the scope name to make code coverage work.

This "fix" is more of a plaster. We now remember the original scope and then add it when returning information.

PHP doesn't remember the original trait scope *yet*, but we might fix that as part of this PR: https://github.com/php/php-src/pull/12129