### PR TITLE
Handle stream wrapper scheme in xdebug_path_to_url

### DIFF
--- a/src/lib/usefulstuff.c
+++ b/src/lib/usefulstuff.c
@@ -313,10 +313,7 @@ char *xdebug_path_to_url(zend_string *fileurl)
 	/* encode the url */
 	encoded_fileurl = xdebug_raw_url_encode(ZSTR_VAL(fileurl), ZSTR_LEN(fileurl), &new_len, 1);
 
-	if (strncmp(ZSTR_VAL(fileurl), "phar://", 7) == 0) {
-		/* ignore, phar is cool */
-		tmp = xdstrdup(ZSTR_VAL(fileurl));
-	} else if (strstr(ZSTR_VAL(fileurl), "://") != NULL) {
+	if (strstr(ZSTR_VAL(fileurl), "://") != NULL && strstr(ZSTR_VAL(fileurl), "://") < strstr(ZSTR_VAL(fileurl), "/")) {
 		/* ignore, some form of stream wrapper scheme */
 		tmp = xdstrdup(ZSTR_VAL(fileurl));
 	} else if (ZSTR_VAL(fileurl)[0] != '/' && ZSTR_VAL(fileurl)[0] != '\\' && ZSTR_VAL(fileurl)[1] != ':') {

--- a/src/lib/usefulstuff.c
+++ b/src/lib/usefulstuff.c
@@ -316,6 +316,9 @@ char *xdebug_path_to_url(zend_string *fileurl)
 	if (strncmp(ZSTR_VAL(fileurl), "phar://", 7) == 0) {
 		/* ignore, phar is cool */
 		tmp = xdstrdup(ZSTR_VAL(fileurl));
+	} else if (strstr(ZSTR_VAL(fileurl), "://") != NULL) {
+		/* ignore, some form of stream wrapper scheme */
+		tmp = xdstrdup(ZSTR_VAL(fileurl));
 	} else if (ZSTR_VAL(fileurl)[0] != '/' && ZSTR_VAL(fileurl)[0] != '\\' && ZSTR_VAL(fileurl)[1] != ':') {
 		/* convert relative paths */
 		cwd_state new_state;

--- a/tests/debugger/bug02211.inc
+++ b/tests/debugger/bug02211.inc
@@ -1,0 +1,6 @@
+<?php
+
+$data = "data://text/plain;base64,".base64_encode("<"."?php\nreturn function() {\nxdebug_break();\n};");
+
+$f = include($data);
+$f();

--- a/tests/debugger/bug02211.phpt
+++ b/tests/debugger/bug02211.phpt
@@ -1,0 +1,35 @@
+--TEST--
+Test for bug #2211: File wrapper gets wrong filename location in stack
+--SKIPIF--
+<?php
+require __DIR__ . '/../utils.inc';
+check_reqs('dbgp');
+?>
+--FILE--
+<?php
+require 'dbgp/dbgpclient.php';
+$filename = dirname(__FILE__) . '/bug02211.inc';
+
+$commands = array(
+	'run',
+	'stack_get',
+	'detach',
+);
+
+dbgpRunFile( $filename, $commands, array( 'allow_url_include' => '1' ) );
+?>
+--EXPECTF--
+<?xml version="1.0" encoding="iso-8859-1"?>
+<init xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" fileuri="file://bug02211.inc" language="PHP" xdebug:language_version="" protocol_version="1.0" appid=""><engine version=""><![CDATA[Xdebug]]></engine><author><![CDATA[Derick Rethans]]></author><url><![CDATA[https://xdebug.org]]></url><copyright><![CDATA[Copyright (c) 2002-2099 by Derick Rethans]]></copyright></init>
+
+-> run -i 1
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="1" status="break" reason="ok"><xdebug:message filename="data://text/plain;base64,PD9waHAKcmV0dXJuIGZ1bmN0aW9uKCkgewp4ZGVidWdfYnJlYWsoKTsKfTs=" lineno="4"></xdebug:message></response>
+
+-> stack_get -i 2
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="stack_get" transaction_id="2"><stack where="{closure:data://text/plain;base64,PD9waHAKcmV0dXJuIGZ1bmN0aW9uKCkgewp4ZGVidWdfYnJlYWsoKTsKfTs=:2-4}" level="0" type="file" filename="data://text/plain;base64,PD9waHAKcmV0dXJuIGZ1bmN0aW9uKCkgewp4ZGVidWdfYnJlYWsoKTsKfTs=" lineno="4"></stack><stack where="{main}" level="1" type="file" filename="file://bug02211.inc" lineno="6"></stack></response>
+
+-> detach -i 3
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="detach" transaction_id="3" status="stopping" reason="ok"></response>

--- a/tests/debugger/bug02211.phpt
+++ b/tests/debugger/bug02211.phpt
@@ -13,6 +13,7 @@ $filename = dirname(__FILE__) . '/bug02211.inc';
 $commands = array(
 	'run',
 	'stack_get',
+	'source -f data://text/plain;base64,PD9waHAKcmV0dXJuIGZ1bmN0aW9uKCkgewp4ZGVidWdfYnJlYWsoKTsKfTs=',
 	'detach',
 );
 
@@ -30,6 +31,10 @@ dbgpRunFile( $filename, $commands, array( 'allow_url_include' => '1' ) );
 <?xml version="1.0" encoding="iso-8859-1"?>
 <response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="stack_get" transaction_id="2"><stack where="{closure:data://text/plain;base64,PD9waHAKcmV0dXJuIGZ1bmN0aW9uKCkgewp4ZGVidWdfYnJlYWsoKTsKfTs=:2-4}" level="0" type="file" filename="data://text/plain;base64,PD9waHAKcmV0dXJuIGZ1bmN0aW9uKCkgewp4ZGVidWdfYnJlYWsoKTsKfTs=" lineno="4"></stack><stack where="{main}" level="1" type="file" filename="file://bug02211.inc" lineno="6"></stack></response>
 
--> detach -i 3
+-> source -i 3 -f data://text/plain;base64,PD9waHAKcmV0dXJuIGZ1bmN0aW9uKCkgewp4ZGVidWdfYnJlYWsoKTsKfTs=
 <?xml version="1.0" encoding="iso-8859-1"?>
-<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="detach" transaction_id="3" status="stopping" reason="ok"></response>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="source" transaction_id="3" encoding="base64"><![CDATA[PD9waHAKcmV0dXJuIGZ1bmN0aW9uKCkgewp4ZGVidWdfYnJlYWsoKTsKfTs=]]></response>
+
+-> detach -i 4
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="detach" transaction_id="4" status="stopping" reason="ok"></response>


### PR DESCRIPTION
The current code will miss-interpret custom scheme filenames like data://xxx or whatever://xxx as relative paths and incorrectly prefix them with file://bbb

Possible improvement would be to check if :// is indeed before any / characters: strstr(ZSTR_VAL(fileurl), "://") != NULL && strstr(ZSTR_VAL(fileurl), "://") < strstr(ZSTR_VAL(fileurl), "/")

Another improvement would be to see what stream wrappers are actually registered and handle only those...