### PR TITLE
Expose __EXCEPTION virtual variable for current EG(exception)

### DIFF
--- a/src/debugger/debugger.h
+++ b/src/debugger/debugger.h
@@ -65,6 +65,7 @@ PHP_INI_MH(OnUpdateDebugMode);
 void xdebug_init_debugger_globals(xdebug_debugger_globals_t *xg);
 
 #define XDEBUG_RETURN_VALUE_VAR_NAME "__RETURN_VALUE"
+#define XDEBUG_EXCEPTION_VALUE_VAR_NAME "__EXCEPTION"
 
 void xdebug_debugger_reset_ide_key(char *envval);
 int xdebug_debugger_bailout_if_no_exec_requested(void);

--- a/src/debugger/handler_dbgp.c
+++ b/src/debugger/handler_dbgp.c
@@ -1430,6 +1430,11 @@ DBGP_FUNC(feature_get)
 			xdebug_xml_add_attribute(*retval, "supported", "1");
 		XDEBUG_STR_CASE_END
 
+		XDEBUG_STR_CASE("virtual_exception_value")
+			xdebug_xml_add_text(*retval, xdebug_sprintf("%ld", XG_DBG(context).virtual_exception_value));
+			xdebug_xml_add_attribute(*retval, "supported", "1");
+		XDEBUG_STR_CASE_END
+
 		XDEBUG_STR_CASE_DEFAULT
 			xdebug_xml_add_text(*retval, xdstrdup(lookup_cmd(CMD_OPTION_CHAR('n')) ? "1" : "0"));
 			xdebug_xml_add_attribute(*retval, "supported", lookup_cmd(CMD_OPTION_CHAR('n')) ? "1" : "0");
@@ -1503,6 +1508,10 @@ DBGP_FUNC(feature_set)
 
 		XDEBUG_STR_CASE("breakpoint_include_return_value")
 			XG_DBG(context).breakpoint_include_return_value = strtol(CMD_OPTION_CHAR('v'), NULL, 10);
+		XDEBUG_STR_CASE_END
+
+		XDEBUG_STR_CASE("virtual_exception_value")
+			XG_DBG(context).virtual_exception_value = strtol(CMD_OPTION_CHAR('v'), NULL, 10);
 		XDEBUG_STR_CASE_END
 
 		XDEBUG_STR_CASE_DEFAULT
@@ -1959,6 +1968,21 @@ static int attach_context_vars(xdebug_xml_node *node, xdebug_var_export_options 
 		xdebug_str_free(name);
 
 		return 0;
+	}
+
+	/* Add special exception value if enabled, if it exists in engine global and if depth = 0 */
+	if (XG_DBG(context).virtual_exception_value && EG(exception) && depth == 0) {
+		xdebug_xml_node *tmp_node;
+		xdebug_str *name = xdebug_str_create_from_const_char("$"XDEBUG_EXCEPTION_VALUE_VAR_NAME);
+		zval val;
+
+		ZVAL_OBJ(&val, EG(exception));
+
+		tmp_node = xdebug_get_zval_value_xml_node(name, &val, options);
+		xdebug_xml_expand_attribute_value(tmp_node, "facet", "readonly virtual");
+
+		xdebug_xml_add_child(node, tmp_node);
+		xdebug_str_free(name);
 	}
 
 	/* Here the context_id is 0 */
@@ -2433,6 +2457,7 @@ int xdebug_dbgp_init(xdebug_con *context, int mode)
 	context->resolved_breakpoints = 0;
 	context->breakpoint_details = 0;
 	context->breakpoint_include_return_value = 0;
+	context->virtual_exception_value = 0;
 
 	xdebug_mark_debug_connection_active();
 	xdebug_dbgp_cmdloop(context, XDEBUG_CMDLOOP_BAIL);

--- a/src/debugger/handlers.h
+++ b/src/debugger/handlers.h
@@ -94,6 +94,7 @@ struct _xdebug_con {
 	int                    resolved_breakpoints;
 	int                    breakpoint_details;
 	int                    breakpoint_include_return_value;
+	int                    virtual_exception_value;
 
 	/* Statistics and diagnostics */
 	char *connected_hostname;

--- a/src/lib/log.c
+++ b/src/lib/log.c
@@ -774,6 +774,7 @@ static void print_step_debug_information(void)
 			xdebug_info_printf("Resolved Breakpoints => %s\n", XG_DBG(context).resolved_breakpoints ? "Yes" : "No");
 			xdebug_info_printf("Breakpoint: Details => %s\n", XG_DBG(context).breakpoint_details ? "Yes" : "No");
 			xdebug_info_printf("Breakpoint: Include Return Values => %s\n", XG_DBG(context).breakpoint_include_return_value ? "Yes" : "No");
+			xdebug_info_printf("Virtual __EXCEPTION value => %s\n", XG_DBG(context).virtual_exception_value ? "Yes" : "No");
 		}
 	}
 	php_info_print_table_end();

--- a/src/lib/var.c
+++ b/src/lib/var.c
@@ -423,6 +423,16 @@ static void fetch_zval_from_symbol_table(
 				goto cleanup;
 			}
 
+			/* Return special exception value if set and enabled */
+			if (
+				XG_DBG(context).virtual_exception_value &&
+				EG(exception) &&
+				(strncmp(name, XDEBUG_EXCEPTION_VALUE_VAR_NAME, name_length) == 0)
+			) {
+				ZVAL_OBJ_COPY(&tmp_retval, EG(exception));
+				goto cleanup;
+			}
+
 			/* Check for compiled vars */
 			element = prepare_search_key(name, &element_length, "", 0);
 			if (xdebug_lib_has_active_data() && xdebug_lib_has_active_function()) {

--- a/tests/debugger/dbgp-virtual-exception-value-001.inc
+++ b/tests/debugger/dbgp-virtual-exception-value-001.inc
@@ -1,0 +1,3 @@
+<?php
+throw new \Exception("TEST", 0, new \Exception("NESTED"));
+?>

--- a/tests/debugger/dbgp-virtual-exception-value-001.phpt
+++ b/tests/debugger/dbgp-virtual-exception-value-001.phpt
@@ -1,0 +1,45 @@
+--TEST--
+DBGP: virtual __EXCEPTION local property when feature virtual_exception_value is set
+--SKIPIF--
+<?php
+require __DIR__ . '/../utils.inc';
+check_reqs('dbgp');
+?>
+--FILE--
+<?php
+require 'dbgp/dbgpclient.php';
+$filename = dirname(__FILE__) . '/dbgp-virtual-exception-value-001.inc';
+
+$commands = array(
+	'feature_set -n virtual_exception_value -v 1',
+	'breakpoint_set -t exception -x Exception',
+	'run',
+	'context_get',
+	'detach',
+);
+
+dbgpRunFile( $filename, $commands );
+?>
+--EXPECTF--
+<?xml version="1.0" encoding="iso-8859-1"?>
+<init xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" fileuri="file://dbgp-virtual-exception-value-001.inc" language="PHP" xdebug:language_version="" protocol_version="1.0" appid=""><engine version=""><![CDATA[Xdebug]]></engine><author><![CDATA[Derick Rethans]]></author><url><![CDATA[https://xdebug.org]]></url><copyright><![CDATA[Copyright (c) 2002-2099 by Derick Rethans]]></copyright></init>
+
+-> feature_set -i 1 -n virtual_exception_value -v 1
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="feature_set" transaction_id="1" feature="virtual_exception_value" success="1"></response>
+
+-> breakpoint_set -i 2 -t exception -x Exception
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="breakpoint_set" transaction_id="2" id="{{PID}}0001"></response>
+
+-> run -i 3
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="3" status="break" reason="ok"><xdebug:message filename="file://dbgp-virtual-exception-value-001.inc" lineno="2" exception="Exception"><![CDATA[TEST]]></xdebug:message></response>
+
+-> context_get -i 4
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="context_get" transaction_id="4" context="0"><property name="$__EXCEPTION" fullname="$__EXCEPTION" type="object" classname="Exception" children="1" numchildren="7" page="0" pagesize="32" facet="readonly virtual"><property name="message" fullname="$__EXCEPTION-&gt;message" facet="protected" type="string" size="4" encoding="base64"><![CDATA[VEVTVA==]]></property><property name="string" fullname="$__EXCEPTION-&gt;string" facet="private" type="string" size="0" encoding="base64"><![CDATA[]]></property><property name="code" fullname="$__EXCEPTION-&gt;code" facet="protected" type="int"><![CDATA[0]]></property><property name="file" fullname="$__EXCEPTION-&gt;file" facet="protected" type="string" size="%d" encoding="base64"><![CDATA[%s]]></property><property name="line" fullname="$__EXCEPTION-&gt;line" facet="protected" type="int"><![CDATA[2]]></property><property name="trace" fullname="$__EXCEPTION-&gt;trace" facet="private" type="array" children="0" numchildren="0"></property><property name="previous" fullname="$__EXCEPTION-&gt;previous" facet="private" type="object" classname="Exception" children="1" numchildren="7"></property></property></response>
+
+-> detach -i 5
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="detach" transaction_id="5" status="stopping" reason="ok"></response>

--- a/tests/debugger/dbgp-virtual-exception-value-002.inc
+++ b/tests/debugger/dbgp-virtual-exception-value-002.inc
@@ -1,0 +1,4 @@
+<?php
+$__EXCEPTION = "fake";
+throw new \Exception("TEST", 0, new \Exception("NESTED"));
+?>

--- a/tests/debugger/dbgp-virtual-exception-value-002.phpt
+++ b/tests/debugger/dbgp-virtual-exception-value-002.phpt
@@ -1,0 +1,45 @@
+--TEST--
+DBGP: no virtual __EXCEPTION local property when feature virtual_exception_value is not set
+--SKIPIF--
+<?php
+require __DIR__ . '/../utils.inc';
+check_reqs('dbgp');
+?>
+--FILE--
+<?php
+require 'dbgp/dbgpclient.php';
+$filename = dirname(__FILE__) . '/dbgp-virtual-exception-value-002.inc';
+
+$commands = array(
+	'feature_set -n virtual_exception_value -v 0',
+	'breakpoint_set -t exception -x Exception',
+	'run',
+	'context_get',
+	'detach',
+);
+
+dbgpRunFile( $filename, $commands );
+?>
+--EXPECT--
+<?xml version="1.0" encoding="iso-8859-1"?>
+<init xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" fileuri="file://dbgp-virtual-exception-value-002.inc" language="PHP" xdebug:language_version="" protocol_version="1.0" appid=""><engine version=""><![CDATA[Xdebug]]></engine><author><![CDATA[Derick Rethans]]></author><url><![CDATA[https://xdebug.org]]></url><copyright><![CDATA[Copyright (c) 2002-2099 by Derick Rethans]]></copyright></init>
+
+-> feature_set -i 1 -n virtual_exception_value -v 0
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="feature_set" transaction_id="1" feature="virtual_exception_value" success="1"></response>
+
+-> breakpoint_set -i 2 -t exception -x Exception
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="breakpoint_set" transaction_id="2" id="{{PID}}0001"></response>
+
+-> run -i 3
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="run" transaction_id="3" status="break" reason="ok"><xdebug:message filename="file://dbgp-virtual-exception-value-002.inc" lineno="3" exception="Exception"><![CDATA[TEST]]></xdebug:message></response>
+
+-> context_get -i 4
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="context_get" transaction_id="4" context="0"><property name="$__EXCEPTION" fullname="$__EXCEPTION" type="string" size="4" encoding="base64"><![CDATA[ZmFrZQ==]]></property></response>
+
+-> detach -i 5
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="detach" transaction_id="5" status="stopping" reason="ok"></response>


### PR DESCRIPTION
This could be a way to expose the current Exception that is in EG(exception). I have tested this with VSC and it does indeed work.

![image](https://github.com/xdebug/xdebug/assets/2456026/28b547b1-6cc1-48e4-a82b-76dbd87266a2)

However, I think a better way would be to provide a _dynamic_ context name when an exception is available.. Same with return value. Maybe....

I have not written any tests for this yet.