### PR TITLE
Run test suites on PHP 8.3.0

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -15,14 +15,12 @@ jobs:
   - template: .azure/macos/job.yml
     parameters:
       configurationName: 'OSX_PHP_83'
-      phpVersion: 'branch'
-      phpBranch: 'PHP-8.3'
+      phpVersion: '8.3.0'
       configurationParameters: '--enable-debug --disable-zts'
   - template: .azure/macos/job.yml
     parameters:
       configurationName: 'OSX_PHP_83_ZTS'
-      phpVersion: 'branch'
-      phpBranch: 'PHP-8.3'
+      phpVersion: '8.3.0'
       configurationParameters: '--enable-debug --enable-zts'
   - template: .azure/macos/job.yml
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,40 @@ commands:
           command: php run-xdebug-tests.php -j8 -q -x --show-diff
 
 jobs:
+  "PHP 8 3 without opcache":
+    docker:
+      - image: cimg/php:8.3.0
+        auth:
+          username: $DOCKERHUB_USER
+          password: $DOCKERHUB_PW
+    steps:
+      - checkout
+      - compile
+      - run:
+          name: Setup extra env vars
+          command: |
+            echo 'export TEST_PHP_ARGS="-n -d foo=yes -d zend_extension=${CWD}/modules/xdebug.so"' >> $BASH_ENV
+      - run-tests
+    environment:
+      REPORT_EXIT_STATUS: 1
+
+  "PHP 8 3 with opcache":
+    docker:
+      - image: cimg/php:8.3.0
+        auth:
+          username: $DOCKERHUB_USER
+          password: $DOCKERHUB_PW
+    steps:
+      - checkout
+      - compile
+      - run:
+          name: Setup extra env vars
+          command: |
+            echo 'export TEST_PHP_ARGS="-n -d foo=yes -d zend_extension=opcache.so -d opcache.enable=1 -d opcache.enable_cli=1 -d zend_extension=${CWD}/modules/xdebug.so"' >> $BASH_ENV
+      - run-tests
+    environment:
+      REPORT_EXIT_STATUS: 1
+
   "PHP 8 2 without opcache":
     docker:
       - image: cimg/php:8.2.10

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,6 +157,8 @@ workflows:
   version: 2
   testing:
     jobs:
+      - "PHP 8 3 without opcache":
+      - "PHP 8 3 with opcache":
       - "PHP 8 2 without opcache"
       - "PHP 8 2 with opcache"
       - "PHP 8 1 without opcache"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,8 +157,8 @@ workflows:
   version: 2
   testing:
     jobs:
-      - "PHP 8 3 without opcache":
-      - "PHP 8 3 with opcache":
+      - "PHP 8 3 without opcache"
+      - "PHP 8 3 with opcache"
       - "PHP 8 2 without opcache"
       - "PHP 8 2 with opcache"
       - "PHP 8 1 without opcache"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,17 +17,9 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [8.0, 8.1, 8.2]
+                php: [8.0, 8.1, 8.2, 8.3]
                 use-opcache: [true, false]
                 experimental: [false]
-                include:
-                 - php: 8.3
-                   use-opcache: true
-                   experimental: true
-                 - php: 8.3
-                   use-opcache: false
-                   experimental: true
-
         steps:
             -   uses: actions/checkout@v2
 
@@ -75,19 +67,10 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: ["8.0", "8.1", "8.2"]
+                php: ["8.0", "8.1", "8.2", "8.3"]
                 arch: [x64]
                 ts: [nts, ts]
                 experimental: [false]
-                include:
-                 - php: "8.3"
-                   arch: x64
-                   ts: nts
-                   experimental: true
-                 - php: "8.3"
-                   arch: x64
-                   ts: ts
-                   experimental: true
         steps:
                 - name: Checkout Xdebug
                   uses: actions/checkout@v2


### PR DESCRIPTION
As PHP 8.3.0 has now been released, it would be nice to have an official support of it in xdebug.