### PR TITLE
Add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
While looking to currently open PRs, I saw that Actions used in Github workflow are updated manually (see #900).

Adding the proposed dependabot config would help to keep them up-to-date.