### PR TITLE
drop inet_ntoa usage

### DIFF
--- a/src/debugger/ip_info.c
+++ b/src/debugger/ip_info.c
@@ -222,11 +222,12 @@ char *xdebug_get_gateway_ip(void)
 {
     in_addr_t addr = 0;
     char      iface[IF_NAMESIZE];
+    char      addrbuf[INET6_ADDRSTRLEN];
 
     memset(iface, 0, sizeof(iface));
 
     if (get_gateway_and_iface(&addr, iface)) {
-		return xdstrdup(inet_ntoa(*(struct in_addr *) &addr));
+		return xdstrdup(inet_ntop(AF_INET, &addr, addrbuf, sizeof(addrbuf)));
 	}
 
     return NULL;


### PR DESCRIPTION
this is deprecated and his usage discouraged

php-src already have drop it everywhere
using `HAVE_INET_NTOP`, but as `inet_ntop` already used in this project without conditional, I didn't use it