### PR TITLE
use unique file name instead of paths.dot

### DIFF
--- a/tests/coverage/dump-branch-coverage.inc
+++ b/tests/coverage/dump-branch-coverage.inc
@@ -3,7 +3,7 @@ require dirname(__FILE__) . '/../../contrib/branch-coverage-to-dot.php';
 
 function dump_branch_coverage($info)
 {
-	file_put_contents(sys_get_temp_dir() . "/paths.dot", branch_coverage_to_dot( $info ) );
+	file_put_contents(tempnam(sys_get_temp_dir(), "xdebug-paths-"), branch_coverage_to_dot( $info ) );
 	ksort($info);
 
 	foreach ( $info as $fname => $file )


### PR DESCRIPTION
Problem
- perm denied when running different builds under different user accounts

Other solutions
- don't create this file (which doesn't seem to be used)
- use CLEAN section on each test
