### PR TITLE
Fixed issue #2221: Crash when other extensions run PHP code without the stack being initialised yet

### DIFF
--- a/src/base/base.c
+++ b/src/base/base.c
@@ -832,6 +832,11 @@ static bool should_run_user_handler(zend_execute_data *execute_data)
 	zend_op_array     *op_array = &(execute_data->func->op_array);
 	zend_execute_data *prev_edata = execute_data->prev_execute_data;
 
+	/* If the stack vector hasn't been initialised yet, we should abort immediately */
+	if (!XG_BASE(stack)) {
+		return false;
+	}
+
 	if (xdebug_debugger_bailout_if_no_exec_requested()) {
 		return false;
 	}
@@ -859,11 +864,6 @@ static bool should_run_user_handler(zend_execute_data *execute_data)
  * negation should be **added** to the usage below in xdebug_execute_ex. */
 static bool should_run_user_handler_wrapper(zend_execute_data *execute_data)
 {
-	/* If the stack vector hasn't been initialised yet, we should abort immediately */
-	if (!XG_BASE(stack)) {
-		return false;
-	}
-
 #if PHP_VERSION_ID >= 80100
 	return !should_run_user_handler(execute_data);
 #else


### PR DESCRIPTION
The fix in https://github.com/xdebug/xdebug/commit/5e13c7b7b1d2b2efc21098bc47d2047878d714a7 is not complete, Swoole still has a segfault