### PR TITLE
Set XG_LIB(diagnosis_buffer) to NULL after it has been freed

### DIFF
--- a/src/lib/lib.c
+++ b/src/lib/lib.c
@@ -107,6 +107,7 @@ void xdebug_library_post_deactivate(void)
 
 	xdebug_close_log();
 	xdebug_str_free(XG_LIB(diagnosis_buffer));
+	XG_LIB(diagnosis_buffer) = NULL;
 }
 
 


### PR DESCRIPTION
Should fix https://bugs.xdebug.org/view.php?id=2230 (and so https://github.com/blackfireio/php-sdk/issues/69)

When Blackfire RINIT is ran before Xdebug's one, it may trigger the use of `XG_LIB(diagnosis_buffer)` which is not NULL but points to the memory that has been freed
