### PR TITLE
Skip bug02020.phpt on Windows

### DIFF
--- a/tests/base/bug02020.phpt
+++ b/tests/base/bug02020.phpt
@@ -1,5 +1,11 @@
 --TEST--
 Test for bug #2020: segfault if xdebug.dump.GET=* and integer key without value in URL
+--SKIPIF--
+<?php
+if (PHP_OS_FAMILY === "Windows") {
+    die("skip unsupported on Windows due to the fix for CVE-2024-8926");
+}
+?>
 --INI--
 xdebug.dump.GET=*
 xdebug.mode=develop


### PR DESCRIPTION
This failure is caused by the fix for GHSA-p99j-rfp4-xqvq.  A query string not containing an `=` causes the argument parsing to be disabled, so the `--INI--` section does not have any effect on Windows. Since there is no way to workaround that, we skip the test on Windows unconditionally.