### PR TITLE
Allow Xdebug to be built with PHP master

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -17,10 +17,10 @@ if test "$PHP_XDEBUG" != "no"; then
   PHP_XDEBUG_FOUND_VERSION=`${PHP_CONFIG} --version`
   PHP_XDEBUG_FOUND_VERNUM=`${PHP_CONFIG} --vernum`
   if test "$PHP_XDEBUG_FOUND_VERNUM" -lt "80000"; then
-    AC_MSG_ERROR([not supported. Need a PHP version >= 8.0.0 and < 8.5.0 (found $PHP_XDEBUG_FOUND_VERSION)])
+    AC_MSG_ERROR([not supported. Need a PHP version >= 8.0.0 and < 8.6.0 (found $PHP_XDEBUG_FOUND_VERSION)])
   else
-    if test "$PHP_XDEBUG_FOUND_VERNUM" -ge "80500"; then
-      AC_MSG_ERROR([not supported. Need a PHP version >= 8.0.0 and < 8.5.0 (found $PHP_XDEBUG_FOUND_VERSION)])
+    if test "$PHP_XDEBUG_FOUND_VERNUM" -ge "80600"; then
+      AC_MSG_ERROR([not supported. Need a PHP version >= 8.0.0 and < 8.6.0 (found $PHP_XDEBUG_FOUND_VERSION)])
     else
       AC_MSG_RESULT([supported ($PHP_XDEBUG_FOUND_VERSION)])
     fi


### PR DESCRIPTION
php-src has nightly builds for some popular PECL extensions, to be able to notice inadvertent BC breaks, but this build fails due to Xdebug for PHP's master branch.  It seems reasonable to allow such builds for Xdebug's master branch.