### PR TITLE
Fix XDEBUG_PHP_VERSION for `buildconf` builds

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -17,7 +17,7 @@ if (PHP_XDEBUG != 'no') {
 	
 	var files = "xdebug.c";
 
-	var XDEBUG_PHP_VERSION = 10000 * PHP_VERSION + 100 * PHP_MINOR_VERSION + PHP_RELEASE_VERSION;
+	var XDEBUG_PHP_VERSION = 10000 * PHP_VERSION + 100 * PHP_MINOR_VERSION + 1 * PHP_RELEASE_VERSION;
 	if (XDEBUG_PHP_VERSION < 80000) {
 		ERROR("not supported. Need a PHP version >= 8.0.0 and < 8.5.0 (found " + XDEBUG_PHP_VERSION + ")");
 	} else if (XDEBUG_PHP_VERSION >= 80500) {


### PR DESCRIPTION
For `phpize` builds, all three version variables are numbers, but for `buildconf` builds, all are strings.  We need to cater to this by implicitly converting to number.

Reported by @nono303, who also suggested the patch.

---

See also https://github.com/xdebug/xdebug/pull/977#issuecomment-2394037465.