### PR TITLE
Remove ext- prefix on PHP Pie extension name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": ">=8.0,<8.5"
     },
     "php-ext": {
-        "extension-name": "ext-xdebug",
+        "extension-name": "xdebug",
         "priority": 90,
         "configure-options": []
     }


### PR DESCRIPTION
Hi @derickr,

According to the PIE [documentation](https://github.com/php/pie/blob/main/docs/extension-maintainers.md#extension-name), the `ext-` prefix is not necessary into the `composer.json` extension name.

