### PR TITLE
Fixed issue #2315: xdebug_dump_superglobals() leaks memory

### DIFF
--- a/src/develop/superglobals.c
+++ b/src/develop/superglobals.c
@@ -198,7 +198,8 @@ PHP_FUNCTION(xdebug_dump_superglobals)
 
 	superglobal_info = xdebug_get_printable_superglobals(html);
 	if (superglobal_info) {
-		php_printf("%s", xdebug_get_printable_superglobals(html));
+		php_printf("%s", superglobal_info);
+		xdfree(superglobal_info);
 	} else {
 		php_printf("<tr><td><i>No information about superglobals is available or configured.</i></td></tr>\n");
 	}


### PR DESCRIPTION
xdebug_dump_superglobals() calls xdebug_get_printable_superglobals() twice and never frees the memory.
This patch calls the function once and frees its memory.

No test was added because the existing tests reproduce the issue.
Hope I didn't miss anything from the contribution docs.