### PR TITLE
PHP 8.5: Fatal errors now have stack traces

### DIFF
--- a/tests/coverage/bug00318.phpt
+++ b/tests/coverage/bug00318.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test for bug #318: Segmentation Fault in code coverage analysis
 --INI--
-xdebug.mode=coverage
+xdebug.mode=develop,coverage
 --FILE--
 <?php
 // Run me from the PHP CLI
@@ -12,3 +12,5 @@ xdebug_stop_code_coverage();
 ?>
 --EXPECTF--
 Fatal error: %sbreak%s in %sbug00318.inc on line 3
+
+Call Stack:%A

--- a/tests/coverage/bug00670.phpt
+++ b/tests/coverage/bug00670.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test for bug #670: Xdebug crashes with broken "break x" code
 --INI--
-xdebug.mode=coverage
+xdebug.mode=develop,coverage
 --FILE--
 <?php
 xdebug_start_code_coverage( XDEBUG_CC_DEAD_CODE | XDEBUG_CC_UNUSED );
@@ -10,3 +10,5 @@ echo "OK\n";
 ?>
 --EXPECTF--
 Fatal error: Cannot 'break' 2 levels in %s670-ConsistentHashing.inc on line 146
+
+Call Stack:%A


### PR DESCRIPTION
Xdebug has always had these in develop mode, which wasn't turned on for these tests. We we enable them so that the test has the same out for all supported PHP versions.