### PR TITLE
Add missing pcntl requirement to bug02036-php84.phpt

### DIFF
--- a/tests/base/bug02036-php84.phpt
+++ b/tests/base/bug02036-php84.phpt
@@ -3,7 +3,7 @@ Test for bug #2036: Segfault on fiber switch in finally block in garbage collect
 --SKIPIF--
 <?php
 require __DIR__ . '/../utils.inc';
-check_reqs('PHP >= 8.2; ext posix');
+check_reqs('PHP >= 8.2; ext posix; ext pcntl');
 ?>
 --INI--
 xdebug.mode=develop


### PR DESCRIPTION
This test uses pcntl_signal(), but the requirements don't check for this extension to be available.