### PR TITLE
Make sure that environment variables are not set when running the test for bug 00815

### DIFF
--- a/tests/debugger/bug00815.phpt
+++ b/tests/debugger/bug00815.phpt
@@ -5,6 +5,9 @@ Test for bug #815: Xdebug crashes when 'exit' operator used in the script
 require __DIR__ . '/../utils.inc';
 check_reqs('dbgp');
 ?>
+--ENV--
+PHP_IDE_CONFIG=
+SERVER_NAME=
 --FILE--
 <?php
 require 'dbgp/dbgpclient.php';


### PR DESCRIPTION
The test for bug 00815 expects that the `PHP_IDE_CONFIG` and `SERVER_NAME` environment variables are not set as it is doing some evals on them and checking the result. If you are working on an environment where these variables have some values, for example if you are working with PHPStorm on other projects, then this test will fail.

This PR fixes the problem by defining these variables in the `--ENV--` section of the test definition to make sure that they are not set

Note: I am not 100% sure why these evals are needed. If it turns out that they are not actually needed, perhaps a better solution is to just remove them. If that is the case, let me know and I will modify the PR.
