### PR TITLE
Optimizing Xdebug Performance When Debugging is Inactive

### DIFF
--- a/src/base/base.c
+++ b/src/base/base.c
@@ -77,6 +77,9 @@ void xdebug_base_use_original_error_cb(void);
 void xdebug_base_use_xdebug_error_cb(void);
 void xdebug_base_use_xdebug_throw_exception_hook(void);
 
+static statement_handler_func_t existing_statement_handler;
+static zend_extension *xdebug_extension = NULL;
+
 /* Forward declarations for function overides */
 PHP_FUNCTION(xdebug_set_time_limit);
 PHP_FUNCTION(xdebug_error_reporting);
@@ -608,23 +611,30 @@ static void collect_params(function_stack_entry *fse, zend_execute_data *zdata, 
 #endif
 }
 
-function_stack_entry *xdebug_add_stack_frame(zend_execute_data *zdata, zend_op_array *op_array, int type)
+function_stack_entry *xdebug_add_stack_frame(zend_execute_data *zdata, zend_op_array *op_array, int type, int use_current_execute_data)
 {
 	zend_execute_data    *edata;
 	zend_op             **opline_ptr = NULL;
 	function_stack_entry *tmp;
 	zend_op              *cur_opcode;
 
+	if (use_current_execute_data) {
+		edata = EG(current_execute_data);
+	} else {
+		edata = zdata;
+	}
 	if (type == XDEBUG_USER_DEFINED) {
-		edata = EG(current_execute_data)->prev_execute_data;
+		edata = edata->prev_execute_data;
 		if (edata) {
 			opline_ptr = (zend_op**) &edata->opline;
 		}
 	} else {
-		edata = EG(current_execute_data);
-		opline_ptr = (zend_op**) &EG(current_execute_data)->opline;
+		opline_ptr = (zend_op**) &edata->opline;
 	}
-	zdata = EG(current_execute_data);
+
+	if (use_current_execute_data) {
+		zdata = EG(current_execute_data);
+	}
 
 	tmp = (function_stack_entry*) xdebug_vector_push(XG_BASE(stack));
 	tmp->level         = XDEBUG_VECTOR_COUNT(XG_BASE(stack));
@@ -756,7 +766,7 @@ static void xdebug_execute_user_code_begin(zend_execute_data *execute_data)
 		zend_throw_exception_ex(zend_ce_error, 0, "Xdebug has detected a possible infinite loop, and aborted your script with a stack depth of '" ZEND_LONG_FMT "' frames", XINI_BASE(max_nesting_level));
 	}
 
-	fse = xdebug_add_stack_frame(edata, op_array, XDEBUG_USER_DEFINED);
+	fse = xdebug_add_stack_frame(edata, op_array, XDEBUG_USER_DEFINED, 1);
 	fse->function.internal = 0;
 
 	/* A hack to make __call work with profiles. The function *is* user defined after all. */
@@ -874,18 +884,36 @@ static bool should_run_user_handler_wrapper(zend_execute_data *execute_data)
 #endif
 }
 
+void xdebug_save_statement_handler(zend_extension *extension, statement_handler_func_t statement_handler)
+{
+	xdebug_extension = extension;
+	existing_statement_handler = statement_handler;
+}
+
+
+static void xdebug_disable_statement_extension_handler()
+{
+	existing_statement_handler = xdebug_extension->statement_handler;
+	xdebug_extension->statement_handler = NULL;
+}
+
+static void xdebug_enable_statement_extension_handler()
+{
+	xdebug_extension->statement_handler = existing_statement_handler;
+}
+
 /* We still need this to do "include", "require", and "eval" */
 static void xdebug_execute_ex(zend_execute_data *execute_data)
 {
 	bool run_user_handler = should_run_user_handler_wrapper(execute_data);
 
-	if (run_user_handler) {
+	if (run_user_handler && (XG_DBG(debugger_disabled) == 0 || execute_data->func->type == ZEND_EVAL_CODE)) {
 		xdebug_execute_user_code_begin(execute_data);
 	}
 
 	xdebug_old_execute_ex(execute_data);
 
-	if (run_user_handler) {
+	if (run_user_handler && XG_DBG(debugger_disabled) == 0) {
 		xdebug_execute_user_code_end(execute_data, execute_data->return_value);
 	}
 }
@@ -941,7 +969,7 @@ static void xdebug_execute_internal_begin(zend_execute_data *current_execute_dat
 		zend_throw_exception_ex(zend_ce_error, 0, "Xdebug has detected a possible infinite loop, and aborted your script with a stack depth of '" ZEND_LONG_FMT "' frames", XINI_BASE(max_nesting_level));
 	}
 
-	fse = xdebug_add_stack_frame(edata, &edata->func->op_array, XDEBUG_BUILT_IN);
+	fse = xdebug_add_stack_frame(edata, &edata->func->op_array, XDEBUG_BUILT_IN, 1);
 	fse->function.internal = 1;
 
 	if (XDEBUG_MODE_IS(XDEBUG_MODE_DEVELOP)) {
@@ -1011,7 +1039,7 @@ static void xdebug_execute_internal(zend_execute_data *current_execute_data, zva
 {
 	bool run_internal_handler = should_run_internal_handler(current_execute_data);
 
-	if (run_internal_handler) {
+	if (run_internal_handler && XG_DBG(debugger_disabled) == 0) {
 		xdebug_execute_internal_begin(current_execute_data);
 	}
 
@@ -1021,7 +1049,7 @@ static void xdebug_execute_internal(zend_execute_data *current_execute_data, zva
 		execute_internal(current_execute_data, return_value);
 	}
 
-	if (run_internal_handler) {
+	if (run_internal_handler && XG_DBG(debugger_disabled) == 0) {
 		xdebug_execute_internal_end(current_execute_data, return_value);
 	}
 }
@@ -1030,6 +1058,9 @@ static void xdebug_execute_internal(zend_execute_data *current_execute_data, zva
 #if PHP_VERSION_ID >= 80100
 static void xdebug_execute_begin(zend_execute_data *execute_data)
 {
+	if (XG_DBG(debugger_disabled) == 1 && execute_data->func->type != ZEND_EVAL_CODE) {
+		return;
+	}	
 	/* If the stack vector hasn't been initialised yet, we should abort immediately */
 	if (!XG_BASE(stack)) {
 		return;
@@ -1047,6 +1078,9 @@ static void xdebug_execute_begin(zend_execute_data *execute_data)
 
 static void xdebug_execute_end(zend_execute_data *execute_data, zval *retval)
 {
+	if (XG_DBG(debugger_disabled) == 1) {
+		return;
+	}	
 	/* If the stack vector hasn't been initialised yet, we should abort immediately */
 	if (!XG_BASE(stack)) {
 		return;
@@ -1067,6 +1101,83 @@ static zend_observer_fcall_handlers xdebug_observer_init(zend_execute_data *exec
 	return (zend_observer_fcall_handlers){xdebug_execute_begin, xdebug_execute_end};
 }
 #endif
+
+static void xdebug_enable_debugger_handlers()
+{
+#if PHP_VERSION_ID >= 80100
+	zend_execute_ex = xdebug_execute_ex;
+#endif
+	
+	xdebug_enable_statement_extension_handler();
+}
+
+static void xdebug_disable_debugger_handlers()
+{
+#if PHP_VERSION_ID >= 80100
+	zend_execute_ex = xdebug_old_execute_ex;
+#endif
+	
+	xdebug_disable_statement_extension_handler();
+}
+
+static void add_stack_frame_recursively(zend_execute_data *execute_data)
+{
+	zend_op_array *op_array;
+	int type;
+	function_stack_entry *fse;
+
+	if (execute_data->prev_execute_data) {
+		add_stack_frame_recursively(execute_data->prev_execute_data);
+	}
+	if (execute_data->func) {
+		op_array = &(execute_data->func->op_array);
+		type = ZEND_USER_CODE(execute_data->func->type) ? XDEBUG_USER_DEFINED : XDEBUG_BUILT_IN;
+		fse = xdebug_add_stack_frame(execute_data, op_array, type, 0);
+		fse->execute_data = execute_data->prev_execute_data;
+		if (ZEND_CALL_INFO(execute_data) & ZEND_CALL_HAS_SYMBOL_TABLE) {
+			fse->symbol_table = execute_data->symbol_table;
+		}
+	}
+}
+
+static void xdebug_rebuild_stack()
+{
+	xdebug_vector_empty(XG_BASE(stack));
+
+	add_stack_frame_recursively(EG(current_execute_data));
+}
+
+void xdebug_enable_debugger_if_disabled()
+{
+	if (XG_DBG(debugger_disabled) == 1) {
+		XG_DBG(debugger_disabled) = 0;
+		xdebug_enable_debugger_handlers();
+	}	
+}
+
+void xdebug_disable_debugger_if_enabled()
+{
+	if (XG_DBG(debugger_disabled) == 0) {
+		XG_DBG(debugger_disabled) = 1;
+		xdebug_disable_debugger_handlers();
+	}
+}
+
+void xdebug_enable_debugger_and_rebuild_stack_if_disabled()
+{
+	if (XG_DBG(debugger_disabled) == 1) {
+		xdebug_enable_debugger_if_disabled();
+		xdebug_rebuild_stack();
+	}
+}
+
+void xdebug_rebuild_stack_if_disabled()
+{
+	if (XG_DBG(debugger_disabled) == 1) {
+		xdebug_rebuild_stack();
+	}
+}
+
 /***************************************************************************/
 
 static void xdebug_base_overloaded_functions_setup(void)

--- a/src/base/base.h
+++ b/src/base/base.h
@@ -17,6 +17,8 @@
 #ifndef __XDEBUG_BASE_H__
 #define __XDEBUG_BASE_H__
 
+#include "zend_extensions.h"
+
 void xdebug_base_minit(INIT_FUNC_ARGS);
 void xdebug_base_mshutdown();
 
@@ -32,4 +34,11 @@ void xdebug_func_dtor(xdebug_func *elem);
 void xdebug_build_fname(xdebug_func *tmp, zend_execute_data *edata);
 
 void xdebug_print_info(void);
+
+void xdebug_enable_debugger_if_disabled();
+void xdebug_disable_debugger_if_enabled();
+void xdebug_enable_debugger_and_rebuild_stack_if_disabled();
+void xdebug_rebuild_stack_if_disabled();
+void xdebug_save_statement_handler(zend_extension *extension, statement_handler_func_t statement_handler);
+
 #endif // __XDEBUG_BASE_H__

--- a/src/base/ctrl_socket.c
+++ b/src/base/ctrl_socket.c
@@ -28,6 +28,7 @@
 
 #if HAVE_XDEBUG_CONTROL_SOCKET_SUPPORT
 
+#include "base/base.h"
 #include "ctrl_socket.h"
 #include "lib/cmd_parser.h"
 #include "lib/log.h"
@@ -220,6 +221,8 @@ CTRL_FUNC(pause)
 		xdebug_xml_add_text(action, xdstrdup("IDE Connection Signalled"));
 
 		XG_DBG(context).do_connect_to_client = 1;
+
+		xdebug_enable_debugger_and_rebuild_stack_if_disabled();
 	} else {
 		action = xdebug_xml_node_init("action");
 		xdebug_xml_add_text(action, xdstrdup("Breakpoint Signalled"));

--- a/src/debugger/debugger.h
+++ b/src/debugger/debugger.h
@@ -29,6 +29,7 @@ typedef struct _xdebug_debugger_globals_t {
 	zend_bool     remote_connection_enabled;
 	zend_ulong    remote_connection_pid;
 	zend_bool     breakpoints_allowed;
+	zend_bool     debugger_disabled;
 	zend_bool     suppress_return_value_step;
 	zend_bool     detached;
 	xdebug_con    context;

--- a/src/debugger/handler_dbgp.c
+++ b/src/debugger/handler_dbgp.c
@@ -38,6 +38,7 @@
 #include "handler_dbgp.h"
 #include "debugger_private.h"
 
+#include "base/base.h"
 #include "coverage/code_coverage.h"
 #include "develop/stack.h"
 #include "lib/compat.h"
@@ -2321,6 +2322,19 @@ static int xdebug_dbgp_cmdloop(xdebug_con *context, int bail)
 
 		free(option);
 	} while (0 == ret);
+
+	if (!XG_DBG(context).do_connect_to_client &&
+		!XG_DBG(context).do_break &&
+		!XG_DBG(context).do_finish &&
+		!XG_DBG(context).do_next &&
+		!XG_DBG(context).do_step &&
+		(!XG_DBG(context).line_breakpoints || XG_DBG(context).line_breakpoints->size == 0) &&
+		(!XG_DBG(context).function_breakpoints || XG_DBG(context).function_breakpoints->size == 0)
+	) {
+		xdebug_disable_debugger_if_enabled();
+	} else {
+		xdebug_enable_debugger_if_disabled();
+	}
 
 	if (bail && XG_DBG(status) == DBGP_STATUS_STOPPED) {
 		_zend_bailout((char*)__FILE__, __LINE__);

--- a/src/lib/lib.c
+++ b/src/lib/lib.c
@@ -680,12 +680,15 @@ void xdebug_set_opcode_handler(int opcode, user_opcode_handler_t handler)
 static int xdebug_opcode_multi_handler(zend_execute_data *execute_data)
 {
 	const zend_op *cur_opcode = execute_data->opline;
+	xdebug_multi_opcode_handler_t *handler_ptr;
 
-	xdebug_multi_opcode_handler_t *handler_ptr = XG_LIB(opcode_multi_handlers[cur_opcode->opcode]);
+	if (XG_DBG(debugger_disabled) == 0) {
+		handler_ptr = XG_LIB(opcode_multi_handlers[cur_opcode->opcode]);
 
-	while (handler_ptr) {
-		handler_ptr->handler(execute_data);
-		handler_ptr = handler_ptr->next;
+		while (handler_ptr) {
+			handler_ptr->handler(execute_data);
+			handler_ptr = handler_ptr->next;
+		}
 	}
 
 	return xdebug_call_original_opcode_handler_if_set(cur_opcode->opcode, XDEBUG_OPCODE_HANDLER_ARGS_PASSTHRU);

--- a/src/lib/lib.h
+++ b/src/lib/lib.h
@@ -260,6 +260,7 @@ void xdebug_disable_opcache_optimizer(void);
 int xdebug_lib_set_mode(const char *mode);
 
 #define XDEBUG_MODE_IS_OFF() ((xdebug_global_mode == XDEBUG_MODE_OFF))
+#define XDEBUG_MODE_IS_ONLY_DEBUG() ((xdebug_global_mode == XDEBUG_MODE_STEP_DEBUG))
 #define XDEBUG_MODE_IS(v) ((xdebug_global_mode & (v)) ? 1 : 0)
 #define RETURN_IF_MODE_IS_NOT(m) if (!XDEBUG_MODE_IS((m))) { return; }
 #define RETURN_FALSE_IF_MODE_IS_NOT(m) if (!XDEBUG_MODE_IS((m))) { RETURN_FALSE; }

--- a/src/lib/vector.h
+++ b/src/lib/vector.h
@@ -112,4 +112,11 @@ static inline void xdebug_vector_destroy(xdebug_vector *v)
 	xdfree(v);
 }
 
+static inline void xdebug_vector_empty(xdebug_vector *v)
+{
+	while (XDEBUG_VECTOR_COUNT(v)) {
+		xdebug_vector_pop(v);
+	}
+}
+
 #endif /* __XDEBUG_VECTOR_H__ */

--- a/tests/debugger/bug01656.phpt
+++ b/tests/debugger/bug01656.phpt
@@ -8,12 +8,14 @@ xdebug.start_with_request=yes
 xdebug.client_discovery_header=I_LIKE_COOKIES
 xdebug.discover_client_host=1
 xdebug.client_port=9999
-xdebug.log=
+xdebug.log={TMP}/{RUNID}{TEST_PHP_WORKER}bug01656.txt
 xdebug.log_level=10
 --FILE--
 <?php
+echo file_get_contents(sys_get_temp_dir() . '/' . getenv('UNIQ_RUN_ID') . getenv('TEST_PHP_WORKER') . 'bug01656.txt' );
+@unlink (sys_get_temp_dir() . '/' . getenv('UNIQ_RUN_ID') . getenv('TEST_PHP_WORKER') . 'bug01656.txt' );
 var_dump( $_SERVER['I_LIKE_COOKIES'] );
 ?>
 --EXPECTF--
-Xdebug: [Step Debug] %sTried: 127.0.0.1:9999 (from I_LIKE_COOKIES HTTP header), localhost:9999 (fallback through xdebug.client_host/xdebug.client_port).
+%A[Step Debug] %sTried: 127.0.0.1:9999 (from I_LIKE_COOKIES HTTP header), localhost:9999 (fallback through xdebug.client_host/xdebug.client_port).
 string(20) "127.0.0.1, 127.0.0.2"

--- a/tests/debugger/bug01782.phpt
+++ b/tests/debugger/bug01782.phpt
@@ -12,16 +12,18 @@ xdebug.mode=debug,develop
 default_charset=utf-8
 xdebug.filename_format=
 xdebug.client_port=9172
-xdebug.log=
+xdebug.log={TMP}/{RUNID}{TEST_PHP_WORKER}bug01782.txt
 xdebug.log_level=10
 --FILE--
 <?php
 var_dump( xdebug_get_headers( ) );
+echo file_get_contents(sys_get_temp_dir() . '/' . getenv('UNIQ_RUN_ID') . getenv('TEST_PHP_WORKER') . 'bug01782.txt' );
+@unlink (sys_get_temp_dir() . '/' . getenv('UNIQ_RUN_ID') . getenv('TEST_PHP_WORKER') . 'bug01782.txt' );
 ?>
 --EXPECTF--
-Xdebug: [Step Debug] %sTried: localhost:9172 (through xdebug.client_host/xdebug.client_port).
 %sbug01782.php:2:
 array(1) {
   [0] =>
   string(%d) "Set-Cookie: XDEBUG_SESSION=testing; path=/; SameSite=Lax"
 }
+%A[Step Debug] %sTried: localhost:9172 (through xdebug.client_host/xdebug.client_port).

--- a/tests/debugger/remote_log-unix-2.phpt
+++ b/tests/debugger/remote_log-unix-2.phpt
@@ -30,4 +30,4 @@ unlink (sys_get_temp_dir() . '/' . getenv('UNIQ_RUN_ID') . getenv('TEST_PHP_WORK
 [%d] [Step Debug] WARN: Invalid remote address provided containing URI spec 'unix:///tmp/haxx0r.sock'.
 [%d] [Step Debug] WARN: Could not discover client host through HTTP headers, connecting to configured address/port: unix:///tmp/xdbg.sock:0.
 [%d] [Step Debug] WARN: Creating socket for 'unix:///tmp/xdbg.sock', connect: No such file or directory.
-[%d] [Step Debug] ERR: Could not connect to debugging client. Tried: unix:///tmp/xdbg.sock:0 (fallback through xdebug.client_host/xdebug.client_port).
+[%d] [Step Debug] WARN: Could not connect to debugging client. Tried: unix:///tmp/xdbg.sock:0 (fallback through xdebug.client_host/xdebug.client_port).

--- a/tests/debugger/remote_log-unix.phpt
+++ b/tests/debugger/remote_log-unix.phpt
@@ -25,4 +25,4 @@ unlink (sys_get_temp_dir() . '/' . getenv('UNIQ_RUN_ID') . getenv('TEST_PHP_WORK
 [%d] Log opened at %d-%d-%d %d:%d:%d.%d
 [%d] [Step Debug] INFO: Connecting to configured address/port: unix:///tmp/xdbg.sock:0.
 [%d] [Step Debug] WARN: Creating socket for 'unix:///tmp/xdbg.sock', connect: No such file or directory.
-[%d] [Step Debug] ERR: Could not connect to debugging client. Tried: unix:///tmp/xdbg.sock:0 (through xdebug.client_host/xdebug.client_port).
+[%d] [Step Debug] WARN: Could not connect to debugging client. Tried: unix:///tmp/xdbg.sock:0 (through xdebug.client_host/xdebug.client_port).

--- a/tests/debugger/remote_log-win.phpt
+++ b/tests/debugger/remote_log-win.phpt
@@ -31,4 +31,4 @@ echo file_get_contents("C:\\Windows\\Temp\\remote-log4.txt");
 [%d] [Step Debug] WARN: Creating socket for 'doesnotexist3:9003', getaddrinfo: %d.
 [%d] [Step Debug] WARN: Could not connect to client host discovered through HTTP headers, connecting to configured address/port: doesnotexist2:9003.
 [%d] [Step Debug] WARN: Creating socket for 'doesnotexist2:9003', getaddrinfo: 11001.
-[%d] [Step Debug] ERR: Could not connect to debugging client. Tried: doesnotexist3:9003 (from I_LIKE_COOKIES HTTP header), doesnotexist2:9003 (fallback through xdebug.client_host/xdebug.client_port).
+[%d] [Step Debug] WARN: Could not connect to debugging client. Tried: doesnotexist3:9003 (from I_LIKE_COOKIES HTTP header), doesnotexist2:9003 (fallback through xdebug.client_host/xdebug.client_port).

--- a/tests/debugger/remote_log1.phpt
+++ b/tests/debugger/remote_log1.phpt
@@ -25,4 +25,4 @@ unlink (sys_get_temp_dir() . '/' . getenv('UNIQ_RUN_ID') . getenv('TEST_PHP_WORK
 [%d] Log opened at %d-%d-%d %d:%d:%d.%d
 [%d] [Step Debug] INFO: Connecting to configured address/port: doesnotexist:9002.
 [%d] [Step Debug] WARN: Creating socket for 'doesnotexist:9002', getaddrinfo: %s.
-[%d] [Step Debug] ERR: Could not connect to debugging client. Tried: doesnotexist:9002 (through xdebug.client_host/xdebug.client_port).
+[%d] [Step Debug] WARN: Could not connect to debugging client. Tried: doesnotexist:9002 (through xdebug.client_host/xdebug.client_port).

--- a/tests/debugger/remote_log2.phpt
+++ b/tests/debugger/remote_log2.phpt
@@ -27,4 +27,4 @@ unlink (sys_get_temp_dir() . '/' . getenv('UNIQ_RUN_ID') . getenv('TEST_PHP_WORK
 [%d] [Step Debug] INFO: Checking header 'REMOTE_ADDR'.
 [%d] [Step Debug] WARN: Could not discover client host through HTTP headers, connecting to configured address/port: doesnotexist2:9003.
 [%d] [Step Debug] WARN: Creating socket for 'doesnotexist2:9003', getaddrinfo: %s.
-[%d] [Step Debug] ERR: Could not connect to debugging client. Tried: doesnotexist2:9003 (fallback through xdebug.client_host/xdebug.client_port).
+[%d] [Step Debug] WARN: Could not connect to debugging client. Tried: doesnotexist2:9003 (fallback through xdebug.client_host/xdebug.client_port).

--- a/tests/debugger/remote_log3.phpt
+++ b/tests/debugger/remote_log3.phpt
@@ -29,4 +29,4 @@ unlink (sys_get_temp_dir() . '/' . getenv('UNIQ_RUN_ID') . getenv('TEST_PHP_WORK
 [%d] [Step Debug] INFO: Checking header 'REMOTE_ADDR'.
 [%d] [Step Debug] WARN: Could not discover client host through HTTP headers, connecting to configured address/port: doesnotexist2:9003.
 [%d] [Step Debug] WARN: Creating socket for 'doesnotexist2:9003', getaddrinfo: %s.
-[%d] [Step Debug] ERR: Could not connect to debugging client. Tried: doesnotexist2:9003 (fallback through xdebug.client_host/xdebug.client_port).
+[%d] [Step Debug] WARN: Could not connect to debugging client. Tried: doesnotexist2:9003 (fallback through xdebug.client_host/xdebug.client_port).

--- a/tests/debugger/remote_log4.phpt
+++ b/tests/debugger/remote_log4.phpt
@@ -31,4 +31,4 @@ unlink (sys_get_temp_dir() . '/' . getenv('UNIQ_RUN_ID') . getenv('TEST_PHP_WORK
 [%d] [Step Debug] WARN: Creating socket for 'cookiehost:9003', getaddrinfo: %s.
 [%d] [Step Debug] WARN: Could not connect to client host discovered through HTTP headers, connecting to configured address/port: doesnotexist2:9003.
 [%d] [Step Debug] WARN: Creating socket for 'doesnotexist2:9003', getaddrinfo: %s.
-[%d] [Step Debug] ERR: Could not connect to debugging client. Tried: cookiehost:9003 (from I_LIKE_COOKIES HTTP header), doesnotexist2:9003 (fallback through xdebug.client_host/xdebug.client_port).
+[%d] [Step Debug] WARN: Could not connect to debugging client. Tried: cookiehost:9003 (from I_LIKE_COOKIES HTTP header), doesnotexist2:9003 (fallback through xdebug.client_host/xdebug.client_port).

--- a/tests/debugger/remote_log5.phpt
+++ b/tests/debugger/remote_log5.phpt
@@ -10,7 +10,8 @@ I_LIKE_COOKIES=cookiehost
 --INI--
 xdebug.mode=debug
 xdebug.start_with_request=yes
-xdebug.log=
+xdebug.log={TMP}/{RUNID}{TEST_PHP_WORKER}remote-log4.txt
+xdebug.log_level=3
 xdebug.discover_client_host=1
 xdebug.client_host=doesnotexist2
 xdebug.client_port=9003
@@ -18,7 +19,9 @@ xdebug.client_discovery_header=I_LIKE_COOKIES
 --FILE--
 <?php
 echo strlen("foo"), "\n";
+echo file_get_contents(sys_get_temp_dir() . '/' . getenv('UNIQ_RUN_ID') . getenv('TEST_PHP_WORKER') . 'remote-log4.txt' );
+unlink (sys_get_temp_dir() . '/' . getenv('UNIQ_RUN_ID') . getenv('TEST_PHP_WORKER') . 'remote-log4.txt' );
 ?>
 --EXPECTF--
-Xdebug: [Step Debug] Could not connect to debugging client. Tried: cookiehost:9003 (from I_LIKE_COOKIES HTTP header), doesnotexist2:9003 (fallback through xdebug.client_host/xdebug.client_port).
 3
+%A[Step Debug] WARN: Could not connect to debugging client. Tried: cookiehost:9003 (from I_LIKE_COOKIES HTTP header), doesnotexist2:9003 (fallback through xdebug.client_host/xdebug.client_port).

--- a/xdebug.c
+++ b/xdebug.c
@@ -569,7 +569,10 @@ PHP_MINIT_FUNCTION(xdebug)
 		return SUCCESS;
 	}
 
-	xdebug_library_minit();
+	if (XDEBUG_MODE_IS(XDEBUG_MODE_TRACING) || XDEBUG_MODE_IS(XDEBUG_MODE_COVERAGE)) {
+		xdebug_library_minit();
+	}
+
 	xdebug_base_minit(INIT_FUNC_ARGS_PASSTHRU);
 
 	if (XDEBUG_MODE_IS(XDEBUG_MODE_STEP_DEBUG)) {
@@ -590,6 +593,9 @@ PHP_MINIT_FUNCTION(xdebug)
 
 	/* Overload the "include_or_eval" opcode if the mode is 'debug' or 'trace' */
 	if (XDEBUG_MODE_IS(XDEBUG_MODE_STEP_DEBUG) || XDEBUG_MODE_IS(XDEBUG_MODE_TRACING)) {
+		if (XDEBUG_MODE_IS(XDEBUG_MODE_STEP_DEBUG)) {
+			xdebug_set_opcode_multi_handler(ZEND_INCLUDE_OR_EVAL);
+		}		
 		xdebug_register_with_opcode_multi_handler(ZEND_INCLUDE_OR_EVAL, xdebug_include_or_eval_handler);
 	}
 
@@ -787,6 +793,7 @@ ZEND_DLEXPORT void xdebug_statement_call(zend_execute_data *frame)
 
 ZEND_DLEXPORT int xdebug_zend_startup(zend_extension *extension)
 {
+	xdebug_save_statement_handler(extension, xdebug_statement_call);
 	xdebug_library_zend_startup();
 	xdebug_debugger_zend_startup();
 
@@ -823,7 +830,7 @@ ZEND_DLEXPORT void xdebug_zend_shutdown(zend_extension *extension)
 
 ZEND_DLEXPORT void xdebug_init_oparray(zend_op_array *op_array)
 {
-	if (XDEBUG_MODE_IS_OFF()) {
+	if (!XDEBUG_MODE_IS(XDEBUG_MODE_COVERAGE)) {
 		return;
 	}
 


### PR DESCRIPTION
When using Xdebug, enabling **debug mode** significantly impacts execution speed, often **doubling the run time** of code compared to when Xdebug is not loaded. This performance penalty occurs **even if the debugger is not actively used** —i.e., when no client connects or no breakpoints are set. As a result, developers often find themselves frequently enabling and disabling Xdebug to avoid noticeable slowdowns.

## Cause of the Slowdown
This slowdown happens because Xdebug injects additional processing at two critical points:

1. **On each function call** – It records stack traces, including function calls and variable values.
2. **On each statement execution** – It checks whether execution should pause at a breakpoint.

These operations are essential when debugging but become **unnecessary overhead** when the debugger is inactive.

## What This PR Changes
This PR introduces optimizations that **dynamically disable unnecessary debugging operations** when:

- Xdebug is running **only in debug mode** (i.e., without code coverage, profiling, tracing, etc...).
- The debugger is **not activated**, meaning:
  - The debugger is not started,
  - Or no client is connected,
  - Or no breakpoints are set.

By skipping function call logging and statement checks in these cases, we can **greatly reduce execution overhead** while maintaining full debugging capabilities when needed.

## Handling Just-In-Time (JIT) Debugging
One challenge is **JIT debugging**, where the debugger is automatically started when:

- An **exception or error** occurs.
- `xdebug_break()` is called.
- `xdebug_connect_to_client()` is used.

In these cases, some debugging functionality must remain available to ensure Xdebug can correctly **attach to the process and capture execution state**. As a result, the optimizations in this PR do **not** entirely eliminate Xdebug’s overhead but **significantly reduce it** compared to the current implementation.

## Challenges
A key challenge is that **JIT debugging sessions will not have a pre-recorded stack trace**. However, this is an issue thar can be overcome because:

- The stack trace can be reconstructed when a jit debugging session is started.
- While reconstructing the stack trace incurs some performance cost, it happens **only once during reconnection**, rather than continuously during execution.

This is a reasonable compromise to ensure that Xdebug remains performant when debugging is not actively in use.

## Performance Improvements
To illustrate the benefits of this approach, I measured execution times for two common real-world use cases: Running **RectorPHP** and **PHPStan** on a codebase.

| **Operation**            | **Without Xdebug (s)** | **With Current Xdebug (s)** | **Slowdown (%)** | **With Optimized Xdebug (s)** | **Slowdown (%)** |
|--------------------------|----------------------|----------------------|----------------|----------------------|----------------|
| Running **RectorPHP**    | 42                   | 92                   | **+119%**       | **52**                | **+23%**       |
| Running **PHPStan**      | 51                   | 108                  | **+112%**       | **62**                | **+22%**       |

These tests were conducted with **Xdebug enabled, a debugger client connected, and no breakpoints set**. As the results show, the optimized implementation **runs 3–4× faster** than the current version when debugging is not actively used.

## Goal of This Change
The ultimate goal of this improvement is to **make Xdebug’s performance impact minimal when debugging is inactive**. This means developers no longer need to constantly toggle Xdebug on and off. Instead, they can leave it enabled at all times with:

```ini
xdebug.mode=debug
xdebug.start_with_request=yes
```

This allows seamless debugging when needed, without causing unnecessary slowdowns during regular execution.

## Additional improvements

This PR also includes a few optimizations that enhance the execution speed of the debugger, regardless of whether it is actively used or not. These improvements further reduce the overall overhead of Xdebug, making debugging more efficient while maintaining full functionality.

## Support This Work

If you or your company use Xdebug, please consider supporting my open-source work by [sponsoring me](https://github.com/sponsors/carlos-granados) on GitHub. Your support helps fund further improvements, and I have several ideas for enhancing Xdebug even further.