### PR TITLE
fix xdebug_develop_minit function prototype

### DIFF
--- a/src/develop/develop.h
+++ b/src/develop/develop.h
@@ -67,7 +67,7 @@ typedef struct _xdebug_develop_settings_t {
 void xdebug_init_develop_globals(xdebug_develop_globals_t *xg);
 void xdebug_deinit_develop_globals(xdebug_develop_globals_t *xg);
 
-void xdebug_develop_minit();
+void xdebug_develop_minit(INIT_FUNC_ARGS);
 void xdebug_develop_mshutdown();
 void xdebug_develop_rinit();
 void xdebug_develop_post_deactivate();


### PR DESCRIPTION
Don't know if you still care about old branches

3.1 is the last to support 7.4
Build is broken with new GCC 15

3.4 (for 8+) is OK

