### PR TITLE
Optimise xdebug_init_oparray

### DIFF
--- a/xdebug.c
+++ b/xdebug.c
@@ -827,7 +827,9 @@ ZEND_DLEXPORT void xdebug_init_oparray(zend_op_array *op_array)
 		return;
 	}
 
-	xdebug_coverage_init_oparray(op_array);
+	if (XDEBUG_MODE_IS(XDEBUG_MODE_COVERAGE)) {
+		xdebug_coverage_init_oparray(op_array);
+	}
 }
 
 #ifndef ZEND_EXT_API


### PR DESCRIPTION
The functionality in the `xdebug_init_oparray` function is only needed when doing code coverage, in all other cases we don't need to run this code.

In my tests I measured an overall improvement of around 1% in Xdebug's execution time

Extracted from https://github.com/xdebug/xdebug/pull/996

Fixes https://bugs.xdebug.org/view.php?id=2336