### PR TITLE
Use `zend_smart_string.h` to replace old `php_smart_string.h`

### DIFF
--- a/src/develop/stack.c
+++ b/src/develop/stack.c
@@ -18,9 +18,9 @@
 #include "main/php_ini.h"
 
 #include "ext/standard/html.h"
-#include "ext/standard/php_smart_string.h"
 #include "zend_exceptions.h"
 #include "zend_generators.h"
+#include "zend_smart_string.h"
 
 #include "monitor.h"
 #include "stack.h"

--- a/src/lib/var.c
+++ b/src/lib/var.c
@@ -20,7 +20,7 @@
 #include "zend.h"
 #include "zend_exceptions.h"
 #include "zend_extensions.h"
-#include "ext/standard/php_smart_string.h"
+#include "zend_smart_string.h"
 #include "zend_smart_str.h"
 #include "zend_closures.h"
 


### PR DESCRIPTION
This is an untested and basic attempt to replace the usage of `php_smart_string.h`, following its removal in https://github.com/php/php-src/pull/19233.