### PR TITLE
maps: fix label-before-declaration in local_to_remote()

### DIFF
--- a/src/lib/maps/maps_private.c
+++ b/src/lib/maps/maps_private.c
@@ -275,7 +275,7 @@ int local_to_remote(xdebug_path_maps *maps, const char *local_path, size_t local
 			*remote_line = local_line;
 			break;
 
-		case XDEBUG_PATH_MAP_TYPE_LINES:
+		case XDEBUG_PATH_MAP_TYPE_LINES: {
 			xdebug_str *result_path;
 			size_t      result_line;
 
@@ -286,6 +286,7 @@ int local_to_remote(xdebug_path_maps *maps, const char *local_path, size_t local
 			*remote_path = xdebug_str_copy(result_path);
 			*remote_line = result_line;
 			break;
+		}
 	}
 
 	xdfree(url_path);


### PR DESCRIPTION
Older GCC/Clang reject a declaration immediately after a label: a label must be followed by a statement.