### PR TITLE
Fixed issue #2405: Handle minimum path in .xdebug directory discovery

### DIFF
--- a/src/lib/maps/maps.c
+++ b/src/lib/maps/maps.c
@@ -179,9 +179,9 @@ void xdebug_path_maps_scan(const char *script_source)
 	parts = xdebug_arg_ctor();
 	xdebug_explode(slash, script_source, parts, -1);
 
-	current_dir = parts->c > 2 ? xdebug_join(slash, parts, 0, parts->c - 2) : NULL;
-	parent_dir = parts->c > 3 ? xdebug_join(slash, parts, 0, parts->c - 3) : NULL;
-	grand_dir = parts->c > 4 ? xdebug_join(slash, parts, 0, parts->c - 4) : NULL;
+	current_dir = parts->c >= 2 ? xdebug_join(slash, parts, 0, parts->c - 2) : NULL;
+	parent_dir = parts->c >= 3 ? xdebug_join(slash, parts, 0, parts->c - 3) : NULL;
+	grand_dir = parts->c >= 4 ? xdebug_join(slash, parts, 0, parts->c - 4) : NULL;
 
 	if (grand_dir) {
 		scan_directory(grand_dir->d);

--- a/tests/debugger/maps/map-minimum-path/.xdebug/minimum.map
+++ b/tests/debugger/maps/map-minimum-path/.xdebug/minimum.map
@@ -1,0 +1,1 @@
+./foo/bar/file.inc = /var/www/minimum-path/fake-file.php

--- a/tests/debugger/maps/map-minimum-path/foo/bar/file.inc
+++ b/tests/debugger/maps/map-minimum-path/foo/bar/file.inc
@@ -1,0 +1,4 @@
+<?php
+define("YES", M_PI); $NO = 42;
+echo "hi\n";
+?>

--- a/tests/debugger/maps/map-minimum-path/minimum-path.phpt
+++ b/tests/debugger/maps/map-minimum-path/minimum-path.phpt
@@ -1,0 +1,75 @@
+--TEST--
+DBGP: minimum path discovery of .xdebug map files
+--SKIPIF--
+<?php
+require __DIR__ . '/../../../utils.inc';
+check_reqs('dbgp');
+?>
+--FILE--
+<?php
+require __DIR__ . '/../../dbgp/dbgpclient.php';
+
+$tmpBase = sys_get_temp_dir() . '/' . getenv('UNIQ_RUN_ID') . getenv('TEST_PHP_WORKER') . 'minimum-path';
+
+@mkdir( $tmpBase . '/foo/bar', 0755, true );
+@mkdir( $tmpBase . '/.xdebug', 0755, true );
+
+copy( __DIR__ . '/foo/bar/file.inc', $tmpBase . '/file.inc' );
+copy( __DIR__ . '/.xdebug/minimum.map', $tmpBase . '/.xdebug/minimum.map' );
+
+$filename = $tmpBase . '/file.inc';
+
+$xdebugLogFileName = sys_get_temp_dir() . '/' . getenv('UNIQ_RUN_ID') . getenv('TEST_PHP_WORKER') . 'minimum-path.txt';
+@unlink( $xdebugLogFileName );
+
+$commands = array(
+	'feature_set -n breakpoint_details -v 1',
+	'step_into',
+	"breakpoint_set -t line -f /var/www/minimum-path/fake-file.php -n 3",
+	'breakpoint_list',
+	'run',
+	'detach',
+);
+
+dbgpRunFile(
+	$filename, $commands,
+	[
+		'xdebug.mode' => 'debug', 'xdebug.start_with_request' => 'yes',
+		'xdebug.log' => $xdebugLogFileName, 'xdebug.log_level' => 10,
+		'xdebug.path_mapping' => 'yes',
+	]
+);
+
+echo file_get_contents( $xdebugLogFileName );
+@unlink( $xdebugLogFileName );
+?>
+--CLEAN--
+<?php
+$tmpBase = sys_get_temp_dir() . '/' . getenv('UNIQ_RUN_ID') . getenv('TEST_PHP_WORKER') . 'minimum-path';
+
+@unlink( $tmpBase . '/foo/bar/file.inc' );
+@unlink( $tmpBase . '/.xdebug/minimum.map' );
+@rmdir( $tmpBase . '/foo/bar' );
+@rmdir( $tmpBase . '/foo' );
+@rmdir( $tmpBase . '/.xdebug' );
+@rmdir( $tmpBase );
+?>
+--EXPECTF--
+%A
+[%d] [Path Mapping] INFO: Scanning for map files with pattern '%S%e.xdebug%e*.map'
+[%d] [Path Mapping] DEBUG: No map files found with pattern '%S%e.xdebug%e*.map'
+[%d] [Path Mapping] INFO: Scanning for map files with pattern '%S%e%s%e.xdebug%e*.map'
+[%d] [Path Mapping] DEBUG: No map files found with pattern '%S%e%s%e.xdebug%e*.map'
+[%d] [Path Mapping] INFO: Scanning for map files with pattern '%S%e%s%e%sminimum-path%e.xdebug%e*.map'
+[%d] [Path Mapping] INFO: Reading mapping file '%S%e%s%e%sminimum-path%e.xdebug%eminimum.map'
+[%d] [Path Mapping] DEBUG: Found 1 path mapping rules
+%A
+[%d] [Step Debug] <- breakpoint_set -i 3 -t line -f /var/www/minimum-path/fake-file.php -n 3
+[%d] [Path Mapping] INFO: Mapping (to replace) local location /var/www/minimum-path/fake-file.php:3
+[%d] [Path Mapping] INFO: Mapped location /var/www/minimum-path/fake-file.php:3 to %sfile.inc:3
+%A
+[%d] [Step Debug] <- breakpoint_list -i 4
+[%d] [Path Mapping] INFO: Mapping brkinfo local location %sfile.inc:3
+[%d] [Path Mapping] INFO: Mapped location %sfile.inc:3 to /var/www/minimum-path/fake-file.php:3
+[%d] [Step Debug] -> <response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="breakpoint_list" transaction_id="4"><breakpoint type="line" filename="file:///var/www/minimum-path/fake-file.php" lineno="3" state="enabled" hit_count="0" hit_value="0" id="%s0001"></breakpoint></response>
+%A


### PR DESCRIPTION
This is #1062, but then with the test case fixed, and targetted for the `xdebug_3_5` branch.