### PR TITLE
Switch INI_STR macros to zend_ini_string_literal for PHP 8.6

### DIFF
--- a/src/develop/stack.c
+++ b/src/develop/stack.c
@@ -871,8 +871,13 @@ char *xdebug_get_printable_stack(int html, int error_type, const char *buffer, c
 	char       *error_type_str = xdebug_error_type(error_type);
 	char       *error_type_str_simple = xdebug_error_type_simple(error_type);
 	xdebug_str  str = XDEBUG_STR_INITIALIZER;
+# if PHP_VERSION_ID >= 80600
+	const char *prepend_string = zend_ini_string_literal("error_prepend_string");
+	const char *append_string = zend_ini_string_literal("error_append_string");
+# else
 	char       *prepend_string = INI_STR((char*) "error_prepend_string");
 	char       *append_string = INI_STR((char*) "error_append_string");
+# endif
 
 	if (prepend_string) {
 		xdebug_str_add(&str, prepend_string, 0);
@@ -939,8 +944,13 @@ static char *xdebug_handle_stack_trace(int type, char *error_type_str, const cha
 	/* We need to see if we have an uncaught exception fatal error now */
 	if (type == E_ERROR && ((tmp_buf = xdebug_strip_php_stack_trace(buffer)) != NULL)) {
 		xdebug_str  str = XDEBUG_STR_INITIALIZER;
+# if PHP_VERSION_ID >= 80600
+		const char *prepend_string = zend_ini_string_literal("error_prepend_string");
+		const char *append_string = zend_ini_string_literal("error_append_string");
+# else
 		char       *prepend_string = INI_STR((char*) "error_prepend_string");
 		char       *append_string = INI_STR((char*) "error_append_string");
+# endif
 
 		if (prepend_string) {
 			xdebug_str_add(&str, prepend_string, 0);
@@ -1268,8 +1278,13 @@ void xdebug_develop_throw_exception_hook(zend_object *exception, zval *file, zva
 		}
 		if (PG(display_errors)) {
 			xdebug_str displ_tmp_str = XDEBUG_STR_INITIALIZER;
+# if PHP_VERSION_ID >= 80600
+			const char *prepend_string = zend_ini_string_literal("error_prepend_string");
+			const char *append_string = zend_ini_string_literal("error_append_string");
+# else
 			char *prepend_string = INI_STR((char*) "error_prepend_string");
 			char *append_string = INI_STR((char*) "error_append_string");
+# endif
 
 			if (prepend_string) {
 				xdebug_str_add(&displ_tmp_str, prepend_string, 0);

--- a/src/lib/usefulstuff.c
+++ b/src/lib/usefulstuff.c
@@ -594,7 +594,7 @@ int xdebug_format_output_filename(char **filename, char *format, char *script_na
 				case 'S': { /* session id */
 					zval *data;
 					char *char_ptr, *strval;
-					char *sess_name;
+					const char *sess_name;
 
 					sess_name = zend_ini_string((char*) "session.name", sizeof("session.name"), 0);
 


### PR DESCRIPTION
Ref https://github.com/php/php-src/commit/cd753007ce15665620343dc9244b37526c805cb4