### PR TITLE
avoid Deprecated warning

### DIFF
--- a/run-xdebug-tests.php
+++ b/run-xdebug-tests.php
@@ -2991,7 +2991,7 @@ function error(string $message): void
 function settings2array(array $settings, array &$ini_settings): void
 {
     foreach ($settings as $setting) {
-        if (strpos($setting, '=') !== false) {
+        if ($setting && strpos($setting, '=') !== false) {
             $setting = explode("=", $setting, 2);
             $name = trim($setting[0]);
             $value = trim($setting[1]);


### PR DESCRIPTION
```
Running selected tests.
TEST 1/4 [tests/debugger/bug02424-01.phpt]
Deprecated: strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in /work/GIT/pecl-and-ext/xdebug/run-xdebug-tests.php on line 2994
PASS Test for bug #2424: Ctrl Socket: Aliveness after empty command [tests/debugger/bug02424-01.phpt] 
...
```