### PR TITLE
Fix DBGp multiple_sessions feature_get and feature_set

### DIFF
--- a/src/debugger/handler_dbgp.c
+++ b/src/debugger/handler_dbgp.c
@@ -1430,6 +1430,11 @@ DBGP_FUNC(feature_get)
 			xdebug_xml_add_attribute(*retval, "supported", "1");
 		XDEBUG_STR_CASE_END
 
+		XDEBUG_STR_CASE("multiple_sessions")
+			xdebug_xml_add_text(*retval, xdebug_sprintf("%ld", XG_DBG(context).multiple_sessions));
+			xdebug_xml_add_attribute(*retval, "supported", "1");
+		XDEBUG_STR_CASE_END
+
 		XDEBUG_STR_CASE_DEFAULT
 			xdebug_xml_add_text(*retval, xdstrdup(lookup_cmd(CMD_OPTION_CHAR('n')) ? "1" : "0"));
 			xdebug_xml_add_attribute(*retval, "supported", lookup_cmd(CMD_OPTION_CHAR('n')) ? "1" : "0");
@@ -1482,7 +1487,7 @@ DBGP_FUNC(feature_set)
 		XDEBUG_STR_CASE_END
 
 		XDEBUG_STR_CASE("multiple_sessions")
-			/* FIXME: Add new boolean option check / struct field for this */
+			XG_DBG(context).multiple_sessions = strtol(CMD_OPTION_CHAR('v'), NULL, 10);
 		XDEBUG_STR_CASE_END
 
 		XDEBUG_STR_CASE("extended_properties")
@@ -2439,6 +2444,7 @@ int xdebug_dbgp_init(xdebug_con *context, int mode)
 	context->resolved_breakpoints = 0;
 	context->breakpoint_details = 0;
 	context->breakpoint_include_return_value = 0;
+	context->multiple_sessions = 0;
 
 	xdebug_mark_debug_connection_active();
 	xdebug_dbgp_cmdloop(context, XDEBUG_CMDLOOP_BAIL);

--- a/src/debugger/handlers.h
+++ b/src/debugger/handlers.h
@@ -94,6 +94,7 @@ struct _xdebug_con {
 	int                    resolved_breakpoints;
 	int                    breakpoint_details;
 	int                    breakpoint_include_return_value;
+	int                    multiple_sessions;
 
 	/* Statistics and diagnostics */
 	char *connected_hostname;

--- a/tests/debugger/dbgp-feature-multiple-sessions.phpt
+++ b/tests/debugger/dbgp-feature-multiple-sessions.phpt
@@ -1,0 +1,40 @@
+--TEST--
+DBGP: feature get/set for multiple_sessions
+--SKIPIF--
+<?php
+require __DIR__ . '/../utils.inc';
+check_reqs('dbgp');
+?>
+--FILE--
+<?php
+require 'dbgp/dbgpclient.php';
+$filename = dirname(__FILE__) . '/dbgp-breakpoint-call-method.inc';
+
+$commands = array(
+	'feature_get -n multiple_sessions',
+	'feature_set -n multiple_sessions -v 1',
+	'feature_get -n multiple_sessions',
+	'detach',
+);
+
+dbgpRunFile( $filename, $commands );
+?>
+--EXPECT--
+<?xml version="1.0" encoding="iso-8859-1"?>
+<init xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" fileuri="file://dbgp-breakpoint-call-method.inc" language="PHP" xdebug:language_version="" protocol_version="1.0" appid=""><engine version=""><![CDATA[Xdebug]]></engine><author><![CDATA[Derick Rethans]]></author><url><![CDATA[https://xdebug.org]]></url><copyright><![CDATA[Copyright (c) 2002-2099 by Derick Rethans]]></copyright></init>
+
+-> feature_get -i 1 -n multiple_sessions
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="feature_get" transaction_id="1" feature_name="multiple_sessions" supported="1"><![CDATA[0]]></response>
+
+-> feature_set -i 2 -n multiple_sessions -v 1
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="feature_set" transaction_id="2" feature="multiple_sessions" success="1"></response>
+
+-> feature_get -i 3 -n multiple_sessions
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="feature_get" transaction_id="3" feature_name="multiple_sessions" supported="1"><![CDATA[1]]></response>
+
+-> detach -i 4
+<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" command="detach" transaction_id="4" status="stopping" reason="ok"></response>


### PR DESCRIPTION
When an IDE sends `feature_get -n multiple_sessions`, Xdebug fell through to the default case in `feature_get`. That called `lookup_cmd("multiple_sessions")`, which returned NULL, so the response had `supported="0"`.

The feature is defined in the DBGp spec as get|set with values 0 or 1. `supported` should indicate that the engine knows the feature name; the body carries the value.

`feature_set` had a FIXME and did not store anything.

This adds `multiple_sessions` to `xdebug_con`, handles it in `feature_get` and `feature_set` the same way as `breakpoint_details`, and adds `tests/debugger/dbgp-feature-multiple-sessions.phpt`.