### PR TITLE
Add `XDEBUG_CC_HIT_COUNT` to enable counting how often each line is executed

### DIFF
--- a/src/coverage/code_coverage.c
+++ b/src/coverage/code_coverage.c
@@ -226,8 +226,17 @@ static void xdebug_count_line(zend_string *filename, int lineno, int executable,
 		} else {
 			line->executable = 1;
 		}
-	} else {
+	} else if (!XG_COV(code_coverage_hit_count)) {
 		line->count++;
+	} else {
+		function_stack_entry *fse = XDEBUG_VECTOR_TAIL(XG_BASE(stack));
+
+		if (!fse) {
+			line->count++;
+		} else if (fse->code_coverage_last_lineno != lineno) {
+			line->count++;
+			fse->code_coverage_last_lineno = lineno;
+		}
 	}
 }
 
@@ -758,6 +767,17 @@ PHP_FUNCTION(xdebug_start_code_coverage)
 	XG_COV(code_coverage_unused) = (options & XDEBUG_CC_OPTION_UNUSED);
 	XG_COV(code_coverage_dead_code_analysis) = (options & XDEBUG_CC_OPTION_DEAD_CODE);
 	XG_COV(code_coverage_branch_check) = (options & XDEBUG_CC_OPTION_BRANCH_CHECK);
+	XG_COV(code_coverage_hit_count) = (options & XDEBUG_CC_OPTION_HIT_COUNT);
+
+	if (XG_COV(code_coverage_hit_count)) {
+		size_t i;
+
+		for (i = 0; i < XDEBUG_VECTOR_COUNT(XG_BASE(stack)); i++) {
+			function_stack_entry *fse = xdebug_vector_element_get(XG_BASE(stack), i);
+
+			fse->code_coverage_last_lineno = 0;
+		}
+	}
 
 	XG_COV(code_coverage_active) = 1;
 	RETURN_TRUE;
@@ -822,6 +842,8 @@ static void add_line(void *ret, xdebug_hash_element *e)
 
 	if (line->executable && (line->count == 0)) {
 		add_index_long(retval, line->lineno, -line->executable);
+	} else if (XG_COV(code_coverage_hit_count)) {
+		add_index_long(retval, line->lineno, line->count);
 	} else {
 		add_index_long(retval, line->lineno, 1);
 	}
@@ -1009,6 +1031,7 @@ void xdebug_init_coverage_globals(xdebug_coverage_globals_t *xg)
 	xg->branches.size        = 0;
 	xg->branches.last_branch_nr = NULL;
 	xg->code_coverage_active = 0;
+	xg->code_coverage_hit_count = 0;
 
 	/* Get reserved offset */
 	xg->dead_code_analysis_tracker_offset = zend_xdebug_cc_run_offset;
@@ -1319,6 +1342,7 @@ void xdebug_coverage_register_constants(INIT_FUNC_ARGS)
 	REGISTER_LONG_CONSTANT("XDEBUG_CC_UNUSED", XDEBUG_CC_OPTION_UNUSED, CONST_CS | CONST_PERSISTENT);
 	REGISTER_LONG_CONSTANT("XDEBUG_CC_DEAD_CODE", XDEBUG_CC_OPTION_DEAD_CODE, CONST_CS | CONST_PERSISTENT);
 	REGISTER_LONG_CONSTANT("XDEBUG_CC_BRANCH_CHECK", XDEBUG_CC_OPTION_BRANCH_CHECK, CONST_CS | CONST_PERSISTENT);
+	REGISTER_LONG_CONSTANT("XDEBUG_CC_HIT_COUNT", XDEBUG_CC_OPTION_HIT_COUNT, CONST_CS | CONST_PERSISTENT);
 }
 
 void xdebug_coverage_rinit(void)

--- a/src/coverage/code_coverage.h
+++ b/src/coverage/code_coverage.h
@@ -32,6 +32,7 @@ typedef struct _xdebug_coverage_globals_t {
 	zend_bool     code_coverage_unused;
 	zend_bool     code_coverage_dead_code_analysis;
 	zend_bool     code_coverage_branch_check;
+	zend_bool     code_coverage_hit_count;
 	int           dead_code_analysis_tracker_offset;
 	long          dead_code_last_start_id;
 	long          code_coverage_filter_offset;

--- a/src/coverage/code_coverage_private.h
+++ b/src/coverage/code_coverage_private.h
@@ -28,7 +28,7 @@
 
 typedef struct xdebug_coverage_line {
 	int lineno;
-	int count;
+	zend_long count;
 	int executable;
 } xdebug_coverage_line;
 

--- a/src/lib/lib.h
+++ b/src/lib/lib.h
@@ -80,6 +80,7 @@ typedef struct xdebug_var_name {
 #define XDEBUG_CC_OPTION_UNUSED          1
 #define XDEBUG_CC_OPTION_DEAD_CODE       2
 #define XDEBUG_CC_OPTION_BRANCH_CHECK    4
+#define XDEBUG_CC_OPTION_HIT_COUNT       8
 
 #define STATUS_STARTING   0
 #define STATUS_STOPPING   1
@@ -145,6 +146,7 @@ typedef struct _function_stack_entry {
 	bool         code_coverage_init;
 	char        *code_coverage_function_name;
 	zend_string *code_coverage_filename;
+	int          code_coverage_last_lineno;
 
 	/* location properties */
 	int          lineno;

--- a/tests/coverage/bug02392-001.phpt
+++ b/tests/coverage/bug02392-001.phpt
@@ -1,0 +1,36 @@
+--TEST--
+Test for bug #2392: Count how often a line of code was executed [1]
+--INI--
+xdebug.mode=coverage
+--FILE--
+<?php
+xdebug_start_code_coverage(XDEBUG_CC_UNUSED | XDEBUG_CC_DEAD_CODE | XDEBUG_CC_HIT_COUNT);
+$file = dirname(__FILE__) . DIRECTORY_SEPARATOR . 'bug02392.inc';
+include $file;
+$cc = xdebug_get_code_coverage();
+xdebug_stop_code_coverage();
+var_dump($cc[$file]);
+?>
+--EXPECT--
+array(10) {
+  [4]=>
+  int(5)
+  [5]=>
+  int(-2)
+  [9]=>
+  int(2)
+  [10]=>
+  int(7)
+  [11]=>
+  int(5)
+  [13]=>
+  int(2)
+  [14]=>
+  int(-2)
+  [16]=>
+  int(1)
+  [17]=>
+  int(1)
+  [18]=>
+  int(1)
+}

--- a/tests/coverage/bug02392-002.inc
+++ b/tests/coverage/bug02392-002.inc
@@ -1,0 +1,9 @@
+<?php
+function loops($n)
+{
+    $s = 0;
+    while ($s < $n) {
+        $s++;
+    }
+    return $s;
+}

--- a/tests/coverage/bug02392-002.phpt
+++ b/tests/coverage/bug02392-002.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Test for bug #2392: Count how often a line of code was executed [2] (stop/start resets counts)
+--INI--
+xdebug.mode=coverage
+--FILE--
+<?php
+$file = dirname(__FILE__) . DIRECTORY_SEPARATOR . 'bug02392-002.inc';
+include $file;
+
+xdebug_start_code_coverage(XDEBUG_CC_HIT_COUNT);
+loops(4);
+xdebug_stop_code_coverage();
+
+xdebug_start_code_coverage(XDEBUG_CC_HIT_COUNT);
+loops(4);
+$cc = xdebug_get_code_coverage();
+xdebug_stop_code_coverage();
+var_dump($cc[$file]);
+?>
+--EXPECT--
+array(4) {
+  [4]=>
+  int(1)
+  [5]=>
+  int(5)
+  [6]=>
+  int(4)
+  [8]=>
+  int(1)
+}

--- a/tests/coverage/bug02392.inc
+++ b/tests/coverage/bug02392.inc
@@ -1,0 +1,17 @@
+<?php
+function add($a, $b)
+{
+    return $a + $b;
+}
+
+function f($n)
+{
+    $sum = 0;
+    for ($i = 0; $i < $n; $i++) {
+        $sum = add($sum, $i);
+    }
+    return $sum;
+}
+
+f(3);
+f(2);

--- a/tests/library/xdebug_constants.phpt
+++ b/tests/library/xdebug_constants.phpt
@@ -12,4 +12,4 @@ if (array_key_exists('xdebug', $constants)) {
 }
 ?>
 --EXPECT--
-Constants: available: 17
+Constants: available: 18


### PR DESCRIPTION
This implements the feature requested in [#2392](https://bugs.xdebug.org/view.php?id=2392): an opt-in code coverage mode in which `xdebug_get_code_coverage()` reports, per line, how often execution entered that line, instead of the binary `1`.

A new option flag, `XDEBUG_CC_HIT_COUNT`, is added to control this functionality:

```php
xdebug_start_code_coverage(XDEBUG_CC_HIT_COUNT);
```

With this flag set, executed lines report their entry count (always ≥ 1); `-1`/`-2` keep their meaning (those records have `count == 0`, so there is no overlap). Without the flag, the output is identical to the current behaviour. There is no BC impact for existing consumers that do not pass `XDEBUG_CC_HIT_COUNT`.

A line is counted when the current frame moves onto a line it was not already on. This is the "count when the line number differs from the previous execution" rule from [#2392](https://bugs.xdebug.org/view.php?id=2392), with one refinement: the previously-executed line is tracked per stack frame rather than globally. That distinction matters for call sites, see line 12 in the example below.

```php
<?php
function add(int $a, int $b): int
{
    return $a + $b;
}

xdebug_start_code_coverage(XDEBUG_CC_HIT_COUNT);

$sum = 0;

for ($i = 0; $i < 3; $i++) {
    $sum = add($sum, $i);
}

var_dump(xdebug_get_code_coverage()[__FILE__]);
```

```
array(5) {
  [4]=>
  int(3)
  [9]=>
  int(1)
  [11]=>
  int(4)
  [12]=>
  int(3)
  [15]=>
  int(1)
}
```

- Line 4 (`return` in `add()`): 3 (once per call)
- Line 11 (`for` header): 4 (the initial entry plus one re-entry per iteration for the `$i++`/condition opcodes. Execution genuinely returns to that line, so it counts)
- Line 12 (call site): 3 (After `add()` returns, the caller frame executes the trailing `ASSIGN` opcode on line 12; with global previous-line tracking that would count line 12 a second time per iteration. Because each `add()` call runs in its own frame and the caller's frame still remembers line 12, the post-call opcode does not re-count it.)

A fully single-line loop (`while ($s < $n) $s++;`) counts 1: execution never leaves the line, so it is entered once. Inherent to the line-transition semantics proposed in [#2392](https://bugs.xdebug.org/view.php?id=2392). `for` header lines count init + one per iteration (line 11 in the example above).

phpunit/php-code-coverage has already been prepared for this:

- [sebastianbergmann/php-code-coverage@6288933c](https://github.com/sebastianbergmann/php-code-coverage/commit/6288933c4572d3439c8fd1b56fa261bbe3a29ff8) restructures the processed coverage data to store hit counts per test (test ID → positive-int maps instead of test ID lists) for lines, branches, and paths.
- [sebastianbergmann/php-code-coverage@0fe67813](https://github.com/sebastianbergmann/php-code-coverage/commit/0fe67813f8790d9e4fa172368440ca1a1c59fbe5) threads a "driver collects hit counts" capability through to the reports, so the HTML report shows how often a line was executed when the driver provides counts.

If/when this PR is merged, the Xdebug driver in phpunit/php-code-coverage only needs to pass `XDEBUG_CC_HIT_COUNT` and report itself as collecting hit counts.